### PR TITLE
Fixed deadlocks, completion blocks async, race condition on cancel

### DIFF
--- a/SDWebImage/MKAnnotationView+WebCache.m
+++ b/SDWebImage/MKAnnotationView+WebCache.m
@@ -48,7 +48,7 @@ static char imageURLKey;
         __weak MKAnnotationView *wself = self;
         id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
-            dispatch_main_sync_safe(^{
+            dispatch_main_async_safe(^{
                 __strong MKAnnotationView *sself = wself;
                 if (!sself) return;
                 if (image) {

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -26,6 +26,8 @@ typedef NS_ENUM(NSInteger, SDImageCacheType) {
 
 typedef void(^SDWebImageQueryCompletedBlock)(UIImage *image, SDImageCacheType cacheType);
 
+typedef void(^SDWebImageCheckCacheCompletionBlock)(BOOL isInCache);
+
 /**
  * SDImageCache maintains a memory cache and an optional disk cache. Disk cache write operations are performed
  * asynchronous so it doesn’t add unnecessary latency to the UI.
@@ -198,7 +200,20 @@ typedef void(^SDWebImageQueryCompletedBlock)(UIImage *image, SDImageCacheType ca
 - (void)calculateSizeWithCompletionBlock:(void (^)(NSUInteger fileCount, NSUInteger totalSize))completionBlock;
 
 /**
- * Check if image exists in cache already
+ *  Async check if image exists in disk cache already (does not load the image)
+ *
+ *  @param key             the key describing the url
+ *  @param completionBlock the block to be executed when the check is done.
+ *  @note the completion block will be always executed on the main queue
+ */
+- (void)diskImageExistsWithKey:(NSString *)key completion:(SDWebImageCheckCacheCompletionBlock)completionBlock;
+
+/**
+ *  Check if image exists in disk cache already (does not load the image)
+ *
+ *  @param key the key describing the url
+ *
+ *  @return YES if an image exists for the given key
  */
 - (BOOL)diskImageExistsWithKey:(NSString *)key;
 

--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -53,13 +53,6 @@
 
 extern UIImage *SDScaledImageForKey(NSString *key, UIImage *image);
 
-#define dispatch_main_sync_safe(block)\
-    if ([NSThread isMainThread]) {\
-        block();\
-    } else {\
-        dispatch_sync(dispatch_get_main_queue(), block);\
-    }
-
 #define dispatch_main_async_safe(block)\
     if ([NSThread isMainThread]) {\
         block();\

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -291,7 +291,9 @@
                 UIImage *scaledImage = [self scaledImageForKey:key image:image];
                 image = [UIImage decodedImageWithImage:scaledImage];
                 CGImageRelease(partialImageRef);
-                dispatch_main_sync_safe(^{
+                
+                // this is only executed in case we have a valid partial image
+                dispatch_main_async_safe(^{
                     if (self.completedBlock) {
                         self.completedBlock(image, nil, nil, NO);
                     }

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -214,10 +214,45 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 - (BOOL)isRunning;
 
 /**
- * Check if image has already been cached
+ *  Check if image has already been cached
+ *
+ *  @param url image url
+ *
+ *  @return if the image was already cached
  */
 - (BOOL)cachedImageExistsForURL:(NSURL *)url;
+
+/**
+ *  Check if image has already been cached on disk only
+ *
+ *  @param url image url
+ *
+ *  @return if the image was already cached (disk only)
+ */
 - (BOOL)diskImageExistsForURL:(NSURL *)url;
+
+/**
+ *  Async check if image has already been cached
+ *
+ *  @param url              image url
+ *  @param completionBlock  the block to be executed when the check is finished
+ *  
+ *  @note the completion block is always executed on the main queue
+ */
+- (void)cachedImageExistsForURL:(NSURL *)url
+                     completion:(SDWebImageCheckCacheCompletionBlock)completionBlock;
+
+/**
+ *  Async check if image has already been cached on disk only
+ *
+ *  @param url              image url
+ *  @param completionBlock  the block to be executed when the check is finished
+ *
+ *  @note the completion block is always executed on the main queue
+ */
+- (void)diskImageExistsForURL:(NSURL *)url
+                   completion:(SDWebImageCheckCacheCompletionBlock)completionBlock;
+
 
 /**
  *Return the cache key for a given URL

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -134,11 +134,11 @@
     }
 
     if (!url || (!(options & SDWebImageRetryFailed) && isFailedUrl)) {
-        dispatch_main_sync_safe(^{
+        dispatch_main_async_safe(^{
             NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist userInfo:nil];
             completedBlock(nil, error, SDImageCacheTypeNone, YES, url);
         });
-        return operation;
+        return nil; // no need to return the operation here, as we have an error
     }
 
     @synchronized (self.runningOperations) {
@@ -157,7 +157,7 @@
 
         if ((!image || options & SDWebImageRefreshCached) && (![self.delegate respondsToSelector:@selector(imageManager:shouldDownloadImageForURL:)] || [self.delegate imageManager:self shouldDownloadImageForURL:url])) {
             if (image && options & SDWebImageRefreshCached) {
-                dispatch_main_sync_safe(^{
+                dispatch_main_async_safe(^{
                     // If image was found in the cache bug SDWebImageRefreshCached is provided, notify about the cached image
                     // AND try to re-download it in order to let a chance to NSURLCache to refresh it from server.
                     completedBlock(image, nil, cacheType, YES, url);
@@ -181,12 +181,12 @@
             }
             id <SDWebImageOperation> subOperation = [self.imageDownloader downloadImageWithURL:url options:downloaderOptions progress:progressBlock completed:^(UIImage *downloadedImage, NSData *data, NSError *error, BOOL finished) {
                 if (weakOperation.isCancelled) {
-                    dispatch_main_sync_safe(^{
+                    dispatch_main_async_safe(^{
                         completedBlock(nil, nil, SDImageCacheTypeNone, finished, url);
                     });
                 }
                 else if (error) {
-                    dispatch_main_sync_safe(^{
+                    dispatch_main_async_safe(^{
                         completedBlock(nil, error, SDImageCacheTypeNone, finished, url);
                     });
 
@@ -212,7 +212,7 @@
                                 [self.imageCache storeImage:transformedImage recalculateFromImage:imageWasTransformed imageData:data forKey:key toDisk:cacheOnDisk];
                             }
 
-                            dispatch_main_sync_safe(^{
+                            dispatch_main_async_safe(^{
                                 completedBlock(transformedImage, nil, SDImageCacheTypeNone, finished, url);
                             });
                         });
@@ -222,7 +222,7 @@
                             [self.imageCache storeImage:downloadedImage recalculateFromImage:NO imageData:data forKey:key toDisk:cacheOnDisk];
                         }
 
-                        dispatch_main_sync_safe(^{
+                        dispatch_main_async_safe(^{
                             completedBlock(downloadedImage, nil, SDImageCacheTypeNone, finished, url);
                         });
                     }
@@ -243,7 +243,7 @@
             };
         }
         else if (image) {
-            dispatch_main_sync_safe(^{
+            dispatch_main_async_safe(^{
                 completedBlock(image, nil, cacheType, YES, url);
             });
             @synchronized (self.runningOperations) {
@@ -252,7 +252,7 @@
         }
         else {
             // Image not in cache and download disallowed by delegate
-            dispatch_main_sync_safe(^{
+            dispatch_main_async_safe(^{
                 completedBlock(nil, nil, SDImageCacheTypeNone, YES, url);
             });
             @synchronized (self.runningOperations) {

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -181,13 +181,15 @@
             }
             id <SDWebImageOperation> subOperation = [self.imageDownloader downloadImageWithURL:url options:downloaderOptions progress:progressBlock completed:^(UIImage *downloadedImage, NSData *data, NSError *error, BOOL finished) {
                 if (weakOperation.isCancelled) {
-                    dispatch_main_async_safe(^{
-                        completedBlock(nil, nil, SDImageCacheTypeNone, finished, url);
-                    });
+                    // Do nothing if the operation was cancelled
+                    // See #699 for more details
+                    // if we would call the completedBlock, there could be a race condition between this block and another completedBlock for the same object, so if this one is called second, we will overwrite the new data
                 }
                 else if (error) {
                     dispatch_main_async_safe(^{
-                        completedBlock(nil, error, SDImageCacheTypeNone, finished, url);
+                        if (!weakOperation.isCancelled) {
+                            completedBlock(nil, error, SDImageCacheTypeNone, finished, url);
+                        }
                     });
 
                     if (error.code != NSURLErrorNotConnectedToInternet && error.code != NSURLErrorCancelled && error.code != NSURLErrorTimedOut) {
@@ -213,7 +215,9 @@
                             }
 
                             dispatch_main_async_safe(^{
-                                completedBlock(transformedImage, nil, SDImageCacheTypeNone, finished, url);
+                                if (!weakOperation.isCancelled) {
+                                    completedBlock(transformedImage, nil, SDImageCacheTypeNone, finished, url);
+                                }
                             });
                         });
                     }
@@ -223,7 +227,9 @@
                         }
 
                         dispatch_main_async_safe(^{
-                            completedBlock(downloadedImage, nil, SDImageCacheTypeNone, finished, url);
+                            if (!weakOperation.isCancelled) {
+                                completedBlock(downloadedImage, nil, SDImageCacheTypeNone, finished, url);
+                            }
                         });
                     }
                 }
@@ -244,7 +250,9 @@
         }
         else if (image) {
             dispatch_main_async_safe(^{
-                completedBlock(image, nil, cacheType, YES, url);
+                if (!weakOperation.isCancelled) {
+                    completedBlock(image, nil, cacheType, YES, url);
+                }
             });
             @synchronized (self.runningOperations) {
                 [self.runningOperations removeObject:operation];
@@ -253,7 +261,9 @@
         else {
             // Image not in cache and download disallowed by delegate
             dispatch_main_async_safe(^{
-                completedBlock(nil, nil, SDImageCacheTypeNone, YES, url);
+                if (!weakOperation.isCancelled) {
+                    completedBlock(nil, nil, SDImageCacheTypeNone, YES, url);
+                }
             });
             @synchronized (self.runningOperations) {
                 [self.runningOperations removeObject:operation];

--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -71,7 +71,7 @@ static char imageURLStorageKey;
     __weak UIButton *wself = self;
     id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
         if (!wself) return;
-        dispatch_main_sync_safe(^{
+        dispatch_main_async_safe(^{
             __strong UIButton *sself = wself;
             if (!sself) return;
             if (image) {
@@ -114,7 +114,7 @@ static char imageURLStorageKey;
         __weak UIButton *wself = self;
         id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
-            dispatch_main_sync_safe(^{
+            dispatch_main_async_safe(^{
                 __strong UIButton *sself = wself;
                 if (!sself) return;
                 if (image) {

--- a/SDWebImage/UIImageView+HighlightedWebCache.m
+++ b/SDWebImage/UIImageView+HighlightedWebCache.m
@@ -36,17 +36,16 @@
         __weak UIImageView      *wself    = self;
         id<SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
-            dispatch_main_sync_safe (^
-                                     {
-                                         if (!wself) return;
-                                         if (image) {
-                                             wself.highlightedImage = image;
-                                             [wself setNeedsLayout];
-                                         }
-                                         if (completedBlock && finished) {
-                                             completedBlock(image, error, cacheType, url);
-                                         }
-                                     });
+            dispatch_main_async_safe (^{
+                if (!wself) return;
+                if (image) {
+                    wself.highlightedImage = image;
+                    [wself setNeedsLayout];
+                }
+                if (completedBlock && finished) {
+                    completedBlock(image, error, cacheType, url);
+                }
+            });
         }];
         [self sd_setImageLoadOperation:operation forKey:UIImageViewHighlightedWebCacheOperationKey];
     } else {

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -50,7 +50,7 @@ static char imageURLKey;
         __weak UIImageView *wself = self;
         id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
-            dispatch_main_sync_safe(^{
+            dispatch_main_async_safe(^{
                 if (!wself) return;
                 if (image) {
                     wself.image = image;
@@ -97,7 +97,7 @@ static char imageURLKey;
     for (NSURL *logoImageURL in arrayOfURLs) {
         id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:logoImageURL options:0 progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
-            dispatch_main_sync_safe(^{
+            dispatch_main_async_safe(^{
                 __strong UIImageView *sself = wself;
                 [sself stopAnimating];
                 if (sself && image) {

--- a/SDWebImage/UIView+WebCacheOperation.m
+++ b/SDWebImage/UIView+WebCacheOperation.m
@@ -24,6 +24,9 @@ static char loadOperationKey;
 }
 
 - (void)sd_setImageLoadOperation:(id)operation forKey:(NSString *)key {
+    if (!operation || !key) {
+        return;
+    }
     [self sd_cancelImageLoadOperationWithKey:key];
     NSMutableDictionary *operationDictionary = [self operationDictionary];
     [operationDictionary setObject:operation forKey:key];

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -64,4 +64,23 @@ static int64_t kAsyncTestTimeout = 5;
     XCAsyncFailAfter(kAsyncTestTimeout, @"Download image timed out");
 }
 
+- (void)testThatDownloadWithCancelDoesNotInvokeTheCompletionBlockAsync {
+    NSURL *originalImageURL = [NSURL URLWithString:@"http://static2.dmcdn.net/static/video/629/228/44822926:jpeg_preview_small.jpg?20120509181018"];
+    
+    id <SDWebImageOperation> operation = [[SDWebImageManager sharedManager] downloadImageWithURL:originalImageURL options:SDWebImageRefreshCached progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+        
+        XCTFail(@"Should not call the completion block");
+    }];
+    
+    [operation cancel];
+    
+    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC);
+    dispatch_after(popTime, dispatch_get_main_queue(), ^{
+        XCAsyncSuccess();
+    });
+    
+    
+    XCAsyncFailAfter(kAsyncTestTimeout, @"Download image timed out");
+}
+
 @end


### PR DESCRIPTION
#### Fixed issues #625 #507 aka deadlocks (replaces #509)
- In order to fix the deadlock, reviewed the `[SDImageCache diskImageExistsWithKey:]` method. Based on the Apple doc for `NSFileManager`, using the `defaultManager` without the dispatch on the `ioQueue` to avoid the deadlocks. This instance is thread safe. Also created an async variant of this method `[SDImageCache diskImageExistsWithKey:completion:]`
For consistency, added async methods in `SDWebImageManager` `cachedImageExistsForURL:completion:` and `diskImageExistsForURL:completion:`
-  More fixes against deadlocks. `dispatch_sync` on a serial queue is an [anti pattern](http://www.raywenderlich.com/60749/grand-central-dispatch-in-depth-part-1), as it can lead to deadlocks. I replaced all the `dispatch_main_sync_safe` with `dispatch_main_async_safe`, based on the fact that the completion blocks are not returning anything, so we don't need to wait for them to finish.
- The biggest change (architectural) is that the completion block will no longer be executed inside the operation. But that is not an issue, as `NSOperation` does the same (completion block gets called after operation `isFinished`).

#### Fixed race condition In SDWebImageManager (replaces #699)
- In SDWebImageManager if one operation is cancelled, the completion block must not be called, otherwise it might race with a newer completion for the same object