### PR TITLE
Add an option to scale down large images on iOS

### DIFF
--- a/SDWebImage/SDWebImageDecoder.h
+++ b/SDWebImage/SDWebImageDecoder.h
@@ -15,4 +15,6 @@
 
 + (UIImage *)decodedImageWithImage:(UIImage *)image;
 
++ (UIImage *)decodedAndScaledDownImageWithImage:(UIImage *)image;
+
 @end

--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -10,9 +10,30 @@
 
 #import "SDWebImageDecoder.h"
 
+/*
+ Size in MB, compatible with all iOS devices.
+ */
+#define kSDWebImageDecoderMaxImageSizeMB 4.f
+
+#define SDWebImageDecoderMaxTotalPixels(bitsPerComponent) ((kSDWebImageDecoderMaxImageSizeMB*1024.*1024.*8.)/bitsPerComponent)
+
+inline static CGSize SDWebImageDecoderConstrainedSize(UIImage *image) {
+    CGImageRef imageRef = image.CGImage;
+    CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
+    size_t imageBitsPerComponent = CGImageGetBitsPerComponent(imageRef);
+    CGFloat imageTotalPixels = imageSize.width * imageSize.height;
+    if (imageTotalPixels < SDWebImageDecoderMaxTotalPixels(imageBitsPerComponent)) {
+        return CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
+    }
+    CGFloat ratio = SDWebImageDecoderMaxTotalPixels(imageBitsPerComponent) / imageTotalPixels;
+    CGFloat maxWidth = imageSize.width * ratio;
+    CGFloat maxHeight = imageSize.height *ratio;
+    return CGSizeMake(floorf(maxWidth), floorf(maxHeight));
+}
+
 @implementation UIImage (ForceDecode)
 
-+ (UIImage *)decodedImageWithImage:(UIImage *)image {
++ (UIImage *)decodedAndScaledDownImageToSize:(CGSize)size withImage:(UIImage *)image {
     if (image.images) {
         // Do not decode animated images
         return image;
@@ -20,15 +41,20 @@
 
     CGImageRef imageRef = image.CGImage;
     CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
-    CGRect imageRect = (CGRect){.origin = CGPointZero, .size = imageSize};
+    
+    if ((size.width < imageSize.width) && (size.height < imageSize.height)) {
+        imageSize = size;
+    }
 
+    CGRect imageRect = (CGRect){.origin = CGPointZero, .size = imageSize};
+    
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
 
     int infoMask = (bitmapInfo & kCGBitmapAlphaInfoMask);
     BOOL anyNonAlpha = (infoMask == kCGImageAlphaNone ||
-            infoMask == kCGImageAlphaNoneSkipFirst ||
-            infoMask == kCGImageAlphaNoneSkipLast);
+                        infoMask == kCGImageAlphaNoneSkipFirst ||
+                        infoMask == kCGImageAlphaNoneSkipLast);
 
     // CGBitmapContextCreate doesn't support kCGImageAlphaNone with RGB.
     // https://developer.apple.com/library/mac/#qa/qa1037/_index.html
@@ -39,7 +65,7 @@
         // Set noneSkipFirst.
         bitmapInfo |= kCGImageAlphaNoneSkipFirst;
     }
-            // Some PNGs tell us they have alpha but only 3 components. Odd.
+    // Some PNGs tell us they have alpha but only 3 components. Odd.
     else if (!anyNonAlpha && CGColorSpaceGetNumberOfComponents(colorSpace) == 3) {
         // Unset the old alpha info.
         bitmapInfo &= ~kCGBitmapAlphaInfoMask;
@@ -48,17 +74,18 @@
 
     // It calculates the bytes-per-row based on the bitsPerComponent and width arguments.
     CGContextRef context = CGBitmapContextCreate(NULL,
-            imageSize.width,
-            imageSize.height,
-            CGImageGetBitsPerComponent(imageRef),
-            0,
-            colorSpace,
-            bitmapInfo);
+                                                 imageSize.width,
+                                                 imageSize.height,
+                                                 CGImageGetBitsPerComponent(imageRef),
+                                                 0,
+                                                 colorSpace,
+                                                 bitmapInfo);
     CGColorSpaceRelease(colorSpace);
 
     // If failed, return undecompressed image
     if (!context) return image;
 
+    CGContextSetInterpolationQuality(context, kCGInterpolationHigh);
     CGContextDrawImage(context, imageRect, imageRef);
     CGImageRef decompressedImageRef = CGBitmapContextCreateImage(context);
 
@@ -67,6 +94,14 @@
     UIImage *decompressedImage = [UIImage imageWithCGImage:decompressedImageRef scale:image.scale orientation:image.imageOrientation];
     CGImageRelease(decompressedImageRef);
     return decompressedImage;
+}
+
++ (UIImage *)decodedImageWithImage:(UIImage *)image {
+    return [UIImage decodedAndScaledDownImageToSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX) withImage:image];
+}
+
++ (UIImage *)decodedAndScaledDownImageWithImage:(UIImage *)image {
+    return [UIImage decodedAndScaledDownImageToSize:SDWebImageDecoderConstrainedSize(image) withImage:image];
 }
 
 @end

--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -10,58 +10,32 @@
 
 #import "SDWebImageDecoder.h"
 
-/*
- Size in MB, compatible with all iOS devices.
- */
-#define kSDWebImageDecoderMaxImageSizeMB 4.f
-
-#define SDWebImageDecoderMaxTotalPixels(bitsPerComponent) ((kSDWebImageDecoderMaxImageSizeMB*1024.*1024.*8.)/bitsPerComponent)
-
-inline static CGSize SDWebImageDecoderConstrainedSize(UIImage *image) {
-    CGImageRef imageRef = image.CGImage;
-    CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
-    size_t imageBitsPerComponent = CGImageGetBitsPerComponent(imageRef);
-    CGFloat imageTotalPixels = imageSize.width * imageSize.height;
-    if (imageTotalPixels < SDWebImageDecoderMaxTotalPixels(imageBitsPerComponent)) {
-        return CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX);
-    }
-    CGFloat ratio = SDWebImageDecoderMaxTotalPixels(imageBitsPerComponent) / imageTotalPixels;
-    CGFloat maxWidth = imageSize.width * ratio;
-    CGFloat maxHeight = imageSize.height *ratio;
-    return CGSizeMake(floorf(maxWidth), floorf(maxHeight));
-}
-
 @implementation UIImage (ForceDecode)
 
-+ (UIImage *)decodedAndScaledDownImageToSize:(CGSize)size withImage:(UIImage *)image {
++ (UIImage *)decodedImageWithImage:(UIImage *)image {
     if (image.images) {
         // Do not decode animated images
         return image;
     }
-
+    
     CGImageRef imageRef = image.CGImage;
     CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
-    
-    if ((size.width < imageSize.width) && (size.height < imageSize.height)) {
-        imageSize = size;
-    }
-
     CGRect imageRect = (CGRect){.origin = CGPointZero, .size = imageSize};
     
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
     CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
-
+    
     int infoMask = (bitmapInfo & kCGBitmapAlphaInfoMask);
     BOOL anyNonAlpha = (infoMask == kCGImageAlphaNone ||
                         infoMask == kCGImageAlphaNoneSkipFirst ||
                         infoMask == kCGImageAlphaNoneSkipLast);
-
+    
     // CGBitmapContextCreate doesn't support kCGImageAlphaNone with RGB.
     // https://developer.apple.com/library/mac/#qa/qa1037/_index.html
     if (infoMask == kCGImageAlphaNone && CGColorSpaceGetNumberOfComponents(colorSpace) > 1) {
         // Unset the old alpha info.
         bitmapInfo &= ~kCGBitmapAlphaInfoMask;
-
+        
         // Set noneSkipFirst.
         bitmapInfo |= kCGImageAlphaNoneSkipFirst;
     }
@@ -71,7 +45,7 @@ inline static CGSize SDWebImageDecoderConstrainedSize(UIImage *image) {
         bitmapInfo &= ~kCGBitmapAlphaInfoMask;
         bitmapInfo |= kCGImageAlphaPremultipliedFirst;
     }
-
+    
     // It calculates the bytes-per-row based on the bitsPerComponent and width arguments.
     CGContextRef context = CGBitmapContextCreate(NULL,
                                                  imageSize.width,
@@ -81,27 +55,193 @@ inline static CGSize SDWebImageDecoderConstrainedSize(UIImage *image) {
                                                  colorSpace,
                                                  bitmapInfo);
     CGColorSpaceRelease(colorSpace);
-
+    
     // If failed, return undecompressed image
     if (!context) return image;
-
-    CGContextSetInterpolationQuality(context, kCGInterpolationHigh);
+    
     CGContextDrawImage(context, imageRect, imageRef);
     CGImageRef decompressedImageRef = CGBitmapContextCreateImage(context);
-
+    
     CGContextRelease(context);
-
+    
     UIImage *decompressedImage = [UIImage imageWithCGImage:decompressedImageRef scale:image.scale orientation:image.imageOrientation];
     CGImageRelease(decompressedImageRef);
     return decompressedImage;
 }
 
-+ (UIImage *)decodedImageWithImage:(UIImage *)image {
-    return [UIImage decodedAndScaledDownImageToSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX) withImage:image];
-}
+/*
+ * Defines the maximum size in MB of the decoded image when the flag `SDWebImageScaleDownLargeImage` is set
+ * Suggested value for iPad1 and iPhone 3GS: 60.
+ * Suggested value for iPad2 and iPhone 4: 120.
+ * Suggested value for iPhone 3G and iPod 2 and earlier devices: 30.
+ */
+#define kDestImageSizeMB 60.0f
+
+/*
+ * Defines the maximum size in MB of a tile used to decode image when the flag `SDWebImageScaleDownLargeImage` is set
+ * Suggested value for iPad1 and iPhone 3GS: 20.
+ * Suggested value for iPad2 and iPhone 4: 40.
+ * Suggested value for iPhone 3G and iPod 2 and earlier devices: 10.
+ */
+#define kSourceImageTileSizeMB 20.0f
+
+#define bytesPerMB 1048576.0f
+#define bytesPerPixel 4.0f
+#define pixelsPerMB ( bytesPerMB / bytesPerPixel )
+#define destTotalPixels kDestImageSizeMB * pixelsPerMB
+#define tileTotalPixels kSourceImageTileSizeMB * pixelsPerMB
+#define destSeemOverlap 2.0f // the numbers of pixels to overlap the seems where tiles meet.
 
 + (UIImage *)decodedAndScaledDownImageWithImage:(UIImage *)image {
-    return [UIImage decodedAndScaledDownImageToSize:SDWebImageDecoderConstrainedSize(image) withImage:image];
+    
+    BOOL shouldDownSize = ({
+        BOOL shouldDoIt = YES;
+        
+        CGImageRef sourceImageRef = image.CGImage;
+        CGSize sourceResolution = CGSizeZero;
+        sourceResolution.width = CGImageGetWidth(sourceImageRef);
+        sourceResolution.height = CGImageGetHeight(sourceImageRef);
+        float sourceTotalPixels = sourceResolution.width * sourceResolution.height;
+        float imageScale = destTotalPixels / sourceTotalPixels;
+        if (imageScale < 1) {
+            shouldDoIt = YES;
+        } else {
+            shouldDoIt = NO;
+        }
+        shouldDoIt;
+    });
+    
+    if (NO == shouldDownSize) {
+        return [UIImage decodedImageWithImage:image];
+    }
+    
+    CGContextRef destContext;
+    
+    @autoreleasepool {
+        CGImageRef sourceImageRef = image.CGImage;
+        
+        CGSize sourceResolution = CGSizeZero;
+        sourceResolution.width = CGImageGetWidth(sourceImageRef);
+        sourceResolution.height = CGImageGetHeight(sourceImageRef);
+        float sourceTotalPixels = sourceResolution.width * sourceResolution.height;
+        // Determine the scale ratio to apply to the input image
+        // that results in an output image of the defined size.
+        // see kDestImageSizeMB, and how it relates to destTotalPixels.
+        float imageScale = destTotalPixels / sourceTotalPixels;
+        CGSize destResolution = CGSizeZero;
+        destResolution.width = (int)(sourceResolution.width*imageScale);
+        destResolution.height = (int)(sourceResolution.height*imageScale);
+        CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+        int bytesPerRow = bytesPerPixel * destResolution.width;
+        // Allocate enough pixel data to hold the output image.
+        void* destBitmapData = malloc( bytesPerRow * destResolution.height );
+        if (destBitmapData == NULL) {
+            return image;
+        }
+        CGBitmapInfo bitmapInfo = ({
+            CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(sourceImageRef);
+            int infoMask = (bitmapInfo & kCGBitmapAlphaInfoMask);
+            BOOL anyNonAlpha = (infoMask == kCGImageAlphaNone ||
+                                infoMask == kCGImageAlphaNoneSkipFirst ||
+                                infoMask == kCGImageAlphaNoneSkipLast);
+            
+            // CGBitmapContextCreate doesn't support kCGImageAlphaNone with RGB.
+            // https://developer.apple.com/library/mac/#qa/qa1037/_index.html
+            if (infoMask == kCGImageAlphaNone && CGColorSpaceGetNumberOfComponents(colorSpace) > 1) {
+                // Unset the old alpha info.
+                bitmapInfo &= ~kCGBitmapAlphaInfoMask;
+                
+                // Set noneSkipFirst.
+                bitmapInfo |= kCGImageAlphaNoneSkipFirst;
+            }
+            // Some PNGs tell us they have alpha but only 3 components. Odd.
+            else if (!anyNonAlpha && CGColorSpaceGetNumberOfComponents(colorSpace) == 3) {
+                // Unset the old alpha info.
+                bitmapInfo &= ~kCGBitmapAlphaInfoMask;
+                bitmapInfo |= kCGImageAlphaPremultipliedFirst;
+            }
+            bitmapInfo;
+        });
+        destContext = CGBitmapContextCreate(destBitmapData,
+                                            destResolution.width,
+                                            destResolution.height,
+                                            8,
+                                            bytesPerRow,
+                                            colorSpace,
+                                            bitmapInfo);
+        if (destContext == NULL) {
+            free( destBitmapData );
+            return image;
+        }
+        CGContextSetInterpolationQuality(destContext, kCGInterpolationHigh);
+        CGColorSpaceRelease(colorSpace);
+        // Now define the size of the rectangle to be used for the
+        // incremental blits from the input image to the output image.
+        // we use a source tile width equal to the width of the source
+        // image due to the way that iOS retrieves image data from disk.
+        // iOS must decode an image from disk in full width 'bands', even
+        // if current graphics context is clipped to a subrect within that
+        // band. Therefore we fully utilize all of the pixel data that results
+        // from a decoding opertion by achnoring our tile size to the full
+        // width of the input image.
+        CGRect sourceTile = CGRectZero;
+        sourceTile.size.width = sourceResolution.width;
+        // The source tile height is dynamic. Since we specified the size
+        // of the source tile in MB, see how many rows of pixels high it
+        // can be given the input image width.
+        sourceTile.size.height = (int)( tileTotalPixels / sourceTile.size.width );
+        sourceTile.origin.x = 0.0f;
+        // The output tile is the same proportions as the input tile, but
+        // scaled to image scale.
+        CGRect destTile;
+        destTile.size.width = destResolution.width;
+        destTile.size.height = sourceTile.size.height * imageScale;
+        destTile.origin.x = 0.0f;
+        // The source seem overlap is proportionate to the destination seem overlap.
+        // this is the amount of pixels to overlap each tile as we assemble the ouput image.
+        float sourceSeemOverlap = (int)((destSeemOverlap/destResolution.height)*sourceResolution.height);
+        CGImageRef sourceTileImageRef;
+        // calculate the number of read/write operations required to assemble the
+        // output image.
+        int iterations = (int)( sourceResolution.height / sourceTile.size.height );
+        // If tile height doesn't divide the image height evenly, add another iteration
+        // to account for the remaining pixels.
+        int remainder = (int)sourceResolution.height % (int)sourceTile.size.height;
+        if(remainder) {
+            iterations++;
+        }
+        // Add seem overlaps to the tiles, but save the original tile height for y coordinate calculations.
+        float sourceTileHeightMinusOverlap = sourceTile.size.height;
+        sourceTile.size.height += sourceSeemOverlap;
+        destTile.size.height += destSeemOverlap;
+        for( int y = 0; y < iterations; ++y ) {
+            @autoreleasepool {
+                sourceTile.origin.y = y * sourceTileHeightMinusOverlap + sourceSeemOverlap;
+                destTile.origin.y = destResolution.height - (( y + 1 ) * sourceTileHeightMinusOverlap * imageScale + destSeemOverlap);
+                sourceTileImageRef = CGImageCreateWithImageInRect( sourceImageRef, sourceTile );
+                if( y == iterations - 1 && remainder ) {
+                    float dify = destTile.size.height;
+                    destTile.size.height = CGImageGetHeight( sourceTileImageRef ) * imageScale;
+                    dify -= destTile.size.height;
+                    destTile.origin.y += dify;
+                }
+                CGContextDrawImage( destContext, destTile, sourceTileImageRef );
+                CGImageRelease( sourceTileImageRef );
+            }
+        }
+    }
+    CGImageRef destImageRef = CGBitmapContextCreateImage(destContext);
+    CGContextRelease(destContext);
+    if (destImageRef == NULL) {
+        return image;
+    }
+    UIImage *destImage = [UIImage imageWithCGImage:destImageRef scale:image.scale orientation:image.imageOrientation];
+    CGImageRelease(destImageRef);
+    if (destImage == nil) {
+        return image;
+    }
+    return destImage;
 }
+
 
 @end

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -50,7 +50,11 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
      */
     SDWebImageDownloaderHighPriority = 1 << 7,
     
-
+    /**
+     * Scale down the image
+     */
+    SDWebImageDownloaderScaleDownLargeImage = 1 << 8,
+    
 };
 
 typedef NS_ENUM(NSInteger, SDWebImageDownloaderExecutionOrder) {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -360,6 +360,7 @@
 #ifdef TARGET_OS_IPHONE
                 if (self.options & SDWebImageDownloaderScaleDownLargeImage) {
                     image = [UIImage decodedAndScaledDownImageWithImage:image];
+                    [self.imageData setData:UIImagePNGRepresentation(image)];
                 } else {
                     image = [UIImage decodedImageWithImage:image];
                 }

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -357,7 +357,15 @@
 
             if (!image.images) // Do not force decod animated GIFs
             {
+#ifdef TARGET_OS_IPHONE
+                if (self.options & SDWebImageDownloaderScaleDownLargeImage) {
+                    image = [UIImage decodedAndScaledDownImageWithImage:image];
+                } else {
+                    image = [UIImage decodedImageWithImage:image];
+                }
+#else
                 image = [UIImage decodedImageWithImage:image];
+#endif
             }
 
             if (CGSizeEqualToSize(image.size, CGSizeZero)) {

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -74,7 +74,15 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * By default, placeholder images are loaded while the image is loading. This flag will delay the loading
      * of the placeholder image until after the image has finished loading.
      */
-    SDWebImageDelayPlaceholder = 1 << 9
+    SDWebImageDelayPlaceholder = 1 << 9,
+    
+    /**
+     * By default, images are decoded respecting their original size. On iOS, this flag will scale down the
+     * images to a size compatible with the constrained memory of devices.
+     * If `SDWebImageProgressiveDownload` flag is set the scale down is deactivated.
+     */
+    SDWebImageScaleDownLargeImage = 1 << 10
+
 };
 
 typedef void(^SDWebImageCompletedBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType);

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -134,11 +134,16 @@
             if (options & SDWebImageHandleCookies) downloaderOptions |= SDWebImageDownloaderHandleCookies;
             if (options & SDWebImageAllowInvalidSSLCertificates) downloaderOptions |= SDWebImageDownloaderAllowInvalidSSLCertificates;
             if (options & SDWebImageHighPriority) downloaderOptions |= SDWebImageDownloaderHighPriority;
+            if (options & SDWebImageScaleDownLargeImage) downloaderOptions |= SDWebImageDownloaderScaleDownLargeImage;
             if (image && options & SDWebImageRefreshCached) {
                 // force progressive off if image already cached but forced refreshing
                 downloaderOptions &= ~SDWebImageDownloaderProgressiveDownload;
                 // ignore image read from NSURLCache if image if cached but force refreshing
                 downloaderOptions |= SDWebImageDownloaderIgnoreCachedResponse;
+            }
+            if (options & SDWebImageProgressiveDownload) {
+                // Progressive download deactivate scale down
+                downloaderOptions &= ~SDWebImageDownloaderScaleDownLargeImage;
             }
             id <SDWebImageOperation> subOperation = [self.imageDownloader downloadImageWithURL:url options:downloaderOptions progress:progressBlock completed:^(UIImage *downloadedImage, NSData *data, NSError *error, BOOL finished) {
                 if (weakOperation.isCancelled) {


### PR DESCRIPTION
Difference with the previous PR  #769:

- I have updated the scale down code, following the sample code of Apple "Large Image Downsizing". It is now perfectly safe to download large images with SDWebImage. Note: if the image is very large it can take time several seconds to get the image

Comment from the previous PR:
- I added an option to scale down large images as it is a common problem with SDWebImage.
- I chose to not add another method to SDWebImageManagerDelegate because I think we could choose the right maximum size for the library users.
Let me know what you think?



PS: I create a new pull request because I think my previous one closed can't be updated