### PR TITLE
Compare requested url with returned

### DIFF
--- a/SDWebImage/MKAnnotationView+WebCache.m
+++ b/SDWebImage/MKAnnotationView+WebCache.m
@@ -48,6 +48,18 @@ static char imageURLKey;
         __weak MKAnnotationView *wself = self;
         id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
+            
+            NSURL *lastURL = [wself sd_imageURL];
+            if (![lastURL isEqual:imageURL]) {
+                dispatch_main_async_safe(^{
+                    NSError *urlError = [NSError errorWithDomain:@"SDWebImageErrorDomain" code:-1 userInfo:@{NSLocalizedDescriptionKey : @"URL request/response mismatch"}];
+                    if (completedBlock) {
+                        completedBlock(nil, urlError, SDImageCacheTypeNone, imageURL);
+                    }
+                });
+                return;
+            }
+            
             dispatch_main_sync_safe(^{
                 __strong MKAnnotationView *sself = wself;
                 if (!sself) return;

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -61,72 +61,69 @@
 }
 
 - (void)start {
-    dispatch_main_sync_safe(^{
-
-        @synchronized (self) {
-            if (self.isCancelled) {
-                self.finished = YES;
-                [self reset];
-                return;
-            }
-
-#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
-            if ([self shouldContinueWhenAppEntersBackground]) {
-                __weak __typeof__(self) wself = self;
-                self.backgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-                    __strong __typeof(wself) sself = wself;
-
-                    if (sself) {
-                        [sself cancel];
-
-                        [[UIApplication sharedApplication] endBackgroundTask:sself.backgroundTaskId];
-                        sself.backgroundTaskId = UIBackgroundTaskInvalid;
-                    }
-                }];
-            }
-#endif
-
-            self.executing = YES;
-            self.connection = [[NSURLConnection alloc] initWithRequest:self.request delegate:self startImmediately:NO];
-            self.thread = [NSThread currentThread];
+    @synchronized (self) {
+        if (self.isCancelled) {
+            self.finished = YES;
+            [self reset];
+            return;
         }
 
-        [self.connection start];
+#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
+        if ([self shouldContinueWhenAppEntersBackground]) {
+            __weak __typeof__ (self) wself = self;
+            self.backgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+                __strong __typeof (wself) sself = wself;
 
-        if (self.connection) {
-            if (self.progressBlock) {
-                self.progressBlock(0, NSURLResponseUnknownLength);
-            }
-            [[NSNotificationCenter defaultCenter] postNotificationName:SDWebImageDownloadStartNotification object:self];
+                if (sself) {
+                    [sself cancel];
 
-            if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_5_1) {
-                // Make sure to run the runloop in our background thread so it can process downloaded data
-                // Note: we use a timeout to work around an issue with NSURLConnection cancel under iOS 5
-                //       not waking up the runloop, leading to dead threads (see https://github.com/rs/SDWebImage/issues/466)
-                CFRunLoopRunInMode(kCFRunLoopDefaultMode, 10, false);
-            }
-            else {
-                CFRunLoopRun();
-            }
+                    [[UIApplication sharedApplication] endBackgroundTask:sself.backgroundTaskId];
+                    sself.backgroundTaskId = UIBackgroundTaskInvalid;
+                }
+            }];
+        }
+#endif
 
-            if (!self.isFinished) {
-                [self.connection cancel];
-                [self connection:self.connection didFailWithError:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:@{NSURLErrorFailingURLErrorKey : self.request.URL}]];
-            }
+        self.executing = YES;
+        self.connection = [[NSURLConnection alloc] initWithRequest:self.request delegate:self startImmediately:NO];
+        self.thread = [NSThread currentThread];
+    }
+
+    [self.connection start];
+
+    if (self.connection) {
+        if (self.progressBlock) {
+            self.progressBlock(0, NSURLResponseUnknownLength);
+        }
+        [[NSNotificationCenter defaultCenter] postNotificationName:SDWebImageDownloadStartNotification object:self];
+
+        if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_5_1) {
+            // Make sure to run the runloop in our background thread so it can process downloaded data
+            // Note: we use a timeout to work around an issue with NSURLConnection cancel under iOS 5
+            //       not waking up the runloop, leading to dead threads (see https://github.com/rs/SDWebImage/issues/466)
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 10, false);
         }
         else {
-            if (self.completedBlock) {
-                self.completedBlock(nil, nil, [NSError errorWithDomain:NSURLErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Connection can't be initialized"}], YES);
-            }
+            CFRunLoopRun();
         }
 
-#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
-        if (self.backgroundTaskId != UIBackgroundTaskInvalid) {
-            [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTaskId];
-            self.backgroundTaskId = UIBackgroundTaskInvalid;
+        if (!self.isFinished) {
+            [self.connection cancel];
+            [self connection:self.connection didFailWithError:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:@{NSURLErrorFailingURLErrorKey : self.request.URL}]];
         }
+    }
+    else {
+        if (self.completedBlock) {
+            self.completedBlock(nil, nil, [NSError errorWithDomain:NSURLErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Connection can't be initialized"}], YES);
+        }
+    }
+
+#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
+    if (self.backgroundTaskId != UIBackgroundTaskInvalid) {
+        [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTaskId];
+        self.backgroundTaskId = UIBackgroundTaskInvalid;
+    }
 #endif
-    });
 }
 
 - (void)cancel {

--- a/SDWebImage/UIImageView+HighlightedWebCache.m
+++ b/SDWebImage/UIImageView+HighlightedWebCache.m
@@ -8,10 +8,17 @@
 
 #import "UIImageView+HighlightedWebCache.h"
 #import "UIView+WebCacheOperation.h"
+#import "objc/runtime.h"
 
 #define UIImageViewHighlightedWebCacheOperationKey @"highlightedImage"
 
+static char imageURLKey;
+
 @implementation UIImageView (HighlightedWebCache)
+
+- (NSURL *)sd_imageURL {
+    return objc_getAssociatedObject(self, &imageURLKey);
+}
 
 - (void)sd_setHighlightedImageWithURL:(NSURL *)url {
     [self sd_setHighlightedImageWithURL:url options:0 progress:nil completed:nil];
@@ -31,11 +38,24 @@
 
 - (void)sd_setHighlightedImageWithURL:(NSURL *)url options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock {
     [self sd_cancelCurrentHighlightedImageLoad];
+    objc_setAssociatedObject(self, &imageURLKey, url, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
     if (url) {
         __weak UIImageView      *wself    = self;
         id<SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
+            
+            NSURL *lastURL = [wself sd_imageURL];
+            if (![lastURL isEqual:imageURL]) {
+                dispatch_main_async_safe(^{
+                    NSError *urlError = [NSError errorWithDomain:@"SDWebImageErrorDomain" code:-1 userInfo:@{NSLocalizedDescriptionKey : @"URL request/response mismatch"}];
+                    if (completedBlock) {
+                        completedBlock(nil, urlError, SDImageCacheTypeNone, imageURL);
+                    }
+                });
+                return;
+            }
+            
             dispatch_main_sync_safe (^
                                      {
                                          if (!wself) return;

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -50,6 +50,18 @@ static char imageURLKey;
         __weak UIImageView *wself = self;
         id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
+            
+            NSURL *lastURL = [wself sd_imageURL];
+            if (![lastURL isEqual:imageURL]) {
+                dispatch_main_async_safe(^{
+                    NSError *urlError = [NSError errorWithDomain:@"SDWebImageErrorDomain" code:-1 userInfo:@{NSLocalizedDescriptionKey : @"URL request/response mismatch"}];
+                    if (completedBlock) {
+                        completedBlock(nil, urlError, SDImageCacheTypeNone, imageURL);
+                    }
+                });
+                return;
+            }
+            
             dispatch_main_sync_safe(^{
                 if (!wself) return;
                 if (image) {


### PR DESCRIPTION
To avoid the issue of loading the wrong image into UI controls, as seen on fast table scrolling and similar scenarios, we match the requested URL with the returned URL. In case of mismatch, we back out.

The benefit of this change is to put the responsibility of loading the correct image URL on the library and not the user - the details of URL matching should not be the user's responsibility. The library should only load the last requested URL's content into the UI object.