### PR TITLE
add init method to include NSSearchPathDirectory parameter

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -66,6 +66,17 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 - (id)initWithNamespace:(NSString *)ns;
 
 /**
+ *  Init a new cache store with a specific namespace and a specific search path
+ *
+ *  @param ns                  The namespace to use for this cache
+ *  @param searchPathDirectory The search path to use for this cache
+ *
+ *  @return A initialized SDImageCache instance
+ */
+
+- (id)initWithNamespace:(NSString *)ns searchPathDirectory:(NSSearchPathDirectory)searchPathDirectory;
+
+/**
  * Add a read-only cache path to search for images pre-cached by SDImageCache
  * Useful if you want to bundle pre-loaded images with your app
  *

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -58,46 +58,50 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 }
 
 - (id)initWithNamespace:(NSString *)ns {
+    return [self initWithNamespace:ns searchPathDirectory:NSCachesDirectory];
+}
+
+- (id)initWithNamespace:(NSString *)ns searchPathDirectory:(NSSearchPathDirectory)searchPathDirectory {
     if ((self = [super init])) {
         NSString *fullNamespace = [@"com.hackemist.SDWebImageCache." stringByAppendingString:ns];
-
+        
         // Create IO serial queue
         _ioQueue = dispatch_queue_create("com.hackemist.SDWebImageCache", DISPATCH_QUEUE_SERIAL);
-
+        
         // Init default values
         _maxCacheAge = kDefaultCacheMaxCacheAge;
-
+        
         // Init the memory cache
         _memCache = [[NSCache alloc] init];
         _memCache.name = fullNamespace;
-
+        
         // Init the disk cache
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(searchPathDirectory, NSUserDomainMask, YES);
         _diskCachePath = [paths[0] stringByAppendingPathComponent:fullNamespace];
-
+        
         dispatch_sync(_ioQueue, ^{
             _fileManager = [NSFileManager new];
         });
-
+        
 #if TARGET_OS_IPHONE
         // Subscribe to app events
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(clearMemory)
                                                      name:UIApplicationDidReceiveMemoryWarningNotification
                                                    object:nil];
-
+        
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(cleanDisk)
                                                      name:UIApplicationWillTerminateNotification
                                                    object:nil];
-
+        
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(backgroundCleanDisk)
                                                      name:UIApplicationDidEnterBackgroundNotification
                                                    object:nil];
 #endif
     }
-
+    
     return self;
 }
 


### PR DESCRIPTION
The image cache defaults to `NSCachesDirectory` which makes a lot of sense for most use cases. However sometimes you want to make sure that your image cache does not get blown away by the OS due to upgrades or low disk space situations.