### PR TITLE
Fix transparency being lost from transformed images

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -210,7 +210,7 @@
 
                             if (transformedImage && finished) {
                                 BOOL imageWasTransformed = ![transformedImage isEqual:downloadedImage];
-                                [self.imageCache storeImage:transformedImage recalculateFromImage:imageWasTransformed imageData:data forKey:key toDisk:cacheOnDisk];
+                                [self.imageCache storeImage:transformedImage recalculateFromImage:imageWasTransformed imageData:imageWasTransformed ? nil : data forKey:key toDisk:cacheOnDisk];
                             }
 
                             dispatch_main_sync_safe(^{


### PR DESCRIPTION
When caching an image, the original data is checked for a PNG header to determine whether to cache the image as PNG. If the image has been transformed, the new image may have transparency information even if the original image wasn't a PNG (in my case, I was masking the image before saving)

This change stops the original data being passed to the caching method if the image has been transformed. The caching method then defaults to saving the image as a PNG, maintaining any transparency information that may have been added