### PR TITLE
add option to specify a custom SDWebImageDownloader

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -40,7 +40,7 @@
 - (id)init {
     if ((self = [super init])) {
         _imageCache = [self createCache];
-        _imageDownloader = [SDWebImageDownloader sharedDownloader];
+        _imageDownloader = [[SDWebImageDownloader alloc] init];
         _failedURLs = [NSMutableArray new];
         _runningOperations = [NSMutableArray new];
     }

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -159,8 +159,46 @@
  *                       is nil and the second parameter may contain an NSError. The third parameter is a Boolean
  *                       indicating if the image was retrived from the local cache or from the network.
  *                       The forth parameter is the original image url.
+ * @param manager        The custom SDWebImageManager used to download the image. If use any of the convenient
+ *                       methods, it will be the shared SDWebImageManager
+ */
+- (void)sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock manager: (SDWebImageManager *) manager;
+
+/**
+ * Set the imageView `image` with an `url` and a optionaly placeholder image.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url            The url for the image.
+ * @param placeholder    The image to be set initially, until the image request finishes.
+ * @param options        The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param progressBlock  A block called while image is downloading
+ * @param completedBlock A block called when operation has been completed. This block has no return value
+ *                       and takes the requested UIImage as first parameter. In case of error the image parameter
+ *                       is nil and the second parameter may contain an NSError. The third parameter is a Boolean
+ *                       indicating if the image was retrived from the local cache or from the network.
+ *                       The forth parameter is the original image url.
  */
 - (void)sd_setImageWithPreviousCachedImageWithURL:(NSURL *)url andPlaceholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock;
+
+/**
+ * Set the imageView `image` with an `url` and a optionaly placeholder image.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url            The url for the image.
+ * @param placeholder    The image to be set initially, until the image request finishes.
+ * @param options        The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param progressBlock  A block called while image is downloading
+ * @param completedBlock A block called when operation has been completed. This block has no return value
+ *                       and takes the requested UIImage as first parameter. In case of error the image parameter
+ *                       is nil and the second parameter may contain an NSError. The third parameter is a Boolean
+ *                       indicating if the image was retrived from the local cache or from the network.
+ *                       The forth parameter is the original image url.
+ * @param manager        The custom SDWebImageManager used to download the image. If use any of the convenient
+ *                       methods, it will be the shared SDWebImageManager
+ */
+- (void)sd_setImageWithPreviousCachedImageWithURL:(NSURL *)url andPlaceholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock manager: (SDWebImageManager *) manager;
 
 /**
  * Download an array of images and starts them in an animation loop

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -39,16 +39,20 @@ static char imageURLKey;
 }
 
 - (void)sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock {
+    [self sd_setImageWithURL: url placeholderImage: placeholder options: options progress: progressBlock completed: completedBlock manager: SDWebImageManager.sharedManager];
+}
+
+- (void)sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock manager: (SDWebImageManager *) manager{
     [self sd_cancelCurrentImageLoad];
     objc_setAssociatedObject(self, &imageURLKey, url, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-
+    
     if (!(options & SDWebImageDelayPlaceholder)) {
         self.image = placeholder;
     }
     
     if (url) {
         __weak UIImageView *wself = self;
-        id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+        id <SDWebImageOperation> operation = [manager downloadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             if (!wself) return;
             dispatch_main_sync_safe(^{
                 if (!wself) return;
@@ -78,10 +82,13 @@ static char imageURLKey;
 }
 
 - (void)sd_setImageWithPreviousCachedImageWithURL:(NSURL *)url andPlaceholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock {
+    [self sd_setImageWithPreviousCachedImageWithURL: url andPlaceholderImage: placeholder options: IOPOL_APPLICATION progress: progressBlock completed: completedBlock manager: SDWebImageManager.sharedManager];
+}
+- (void)sd_setImageWithPreviousCachedImageWithURL:(NSURL *)url andPlaceholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock manager: (SDWebImageManager *) manager {
     NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
     UIImage *lastPreviousCachedImage = [[SDImageCache sharedImageCache] imageFromDiskCacheForKey:key];
     
-    [self sd_setImageWithURL:url placeholderImage:lastPreviousCachedImage ?: placeholder options:options progress:progressBlock completed:completedBlock];    
+    [self sd_setImageWithURL:url placeholderImage:lastPreviousCachedImage ?: placeholder options:options progress:progressBlock completed:completedBlock manager: manager];
 }
 
 - (NSURL *)sd_imageURL {


### PR DESCRIPTION
This commit adds the option to specify a custom `SDWebImageDownloader`. Currently the whole thing use a single `SDWebImageDownloader` instance, it's not possible (or very hacky) to set custom delegate to process certain images. By default the convenient methods still use the shared `SDWebImageDownloader` instance so nothing really changes.

1 change I'm not 100% sure is in `SDWebImageManager.m`. I prefer to have a separate downloader for my manager to avoid the case of 1 queue blocking all the others - so I create a new `SDWebImageDownloader` instance for every `SDWebImageDownloader` instance. Again, for normal use that does not need custom `SDWebImageDownloader`, nothing really changes.