### PR TITLE
Fix multiple requests for same image and then canceling one

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -176,12 +176,19 @@ typedef NSDictionary *(^SDWebImageDownloaderHeadersFilterBlock)(NSURL *url, NSDi
  *                       before to be called a last time with the full image and finished argument
  *                       set to YES. In case of error, the finished argument is always YES.
  *
- * @return A cancellable SDWebImageOperation
+ * @return A token that can be passed to -cancel: to cancel this operation
  */
-- (id <SDWebImageOperation>)downloadImageWithURL:(NSURL *)url
-                                         options:(SDWebImageDownloaderOptions)options
-                                        progress:(SDWebImageDownloaderProgressBlock)progressBlock
-                                       completed:(SDWebImageDownloaderCompletedBlock)completedBlock;
+- (id)downloadImageWithURL:(NSURL *)url
+                   options:(SDWebImageDownloaderOptions)options
+                  progress:(SDWebImageDownloaderProgressBlock)progressBlock
+                 completed:(SDWebImageDownloaderCompletedBlock)completedBlock;
+
+/**
+ * Cancels a download that was previously queued using -downloadImageWithURL:options:progress:completed:
+ *
+ * @param token The token received from -downloadImageWithURL:options:progress:completed: that should be canceled.
+ */
+- (void)cancel:(id)token;
 
 /**
  * Sets the download queue suspension state

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -10,13 +10,10 @@
 #import "SDWebImageDownloaderOperation.h"
 #import <ImageIO/ImageIO.h>
 
-static NSString *const kProgressCallbackKey = @"progress";
-static NSString *const kCompletedCallbackKey = @"completed";
-
 @interface _SDWebImageDownloaderToken : NSObject
 
 @property (nonatomic, strong) NSURL *url;
-@property (nonatomic, strong) id callbacks;
+@property (nonatomic, strong) id downloadOperationCancelToken;
 
 @end
 
@@ -28,7 +25,6 @@ static NSString *const kCompletedCallbackKey = @"completed";
 @property (strong, nonatomic) NSOperationQueue *downloadQueue;
 @property (weak, nonatomic) NSOperation *lastAddedOperation;
 @property (assign, nonatomic) Class operationClass;
-@property (strong, nonatomic) NSMutableDictionary *URLCallbacks;
 @property (strong, nonatomic) NSMutableDictionary *URLOperations;
 @property (strong, nonatomic) NSMutableDictionary *HTTPHeaders;
 // This queue is used to serialize the handling of the network responses of all the download operation in a single queue
@@ -77,7 +73,6 @@ static NSString *const kCompletedCallbackKey = @"completed";
         _executionOrder = SDWebImageDownloaderFIFOExecutionOrder;
         _downloadQueue = [NSOperationQueue new];
         _downloadQueue.maxConcurrentOperationCount = 6;
-        _URLCallbacks = [NSMutableDictionary new];
         _URLOperations = [NSMutableDictionary new];
 #ifdef SD_WEBP
         _HTTPHeaders = [@{@"Accept": @"image/webp,image/*;q=0.8"} mutableCopy];
@@ -125,7 +120,6 @@ static NSString *const kCompletedCallbackKey = @"completed";
 }
 
 - (id)downloadImageWithURL:(NSURL *)url options:(SDWebImageDownloaderOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageDownloaderCompletedBlock)completedBlock {
-    __block SDWebImageDownloaderOperation *operation;
     __weak SDWebImageDownloader *wself = self;
 
     return [self addProgressCallback:progressBlock completedBlock:completedBlock forURL:url createCallback:^SDWebImageDownloaderOperation *{
@@ -144,44 +138,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
         else {
             request.allHTTPHeaderFields = wself.HTTPHeaders;
         }
-        operation = [[wself.operationClass alloc] initWithRequest:request
-                                                          options:options
-                                                         progress:^(NSInteger receivedSize, NSInteger expectedSize) {
-                                                             SDWebImageDownloader *sself = wself;
-                                                             if (!sself) return;
-                                                             __block NSArray *callbacksForURL;
-                                                             dispatch_sync(sself.barrierQueue, ^{
-                                                                 callbacksForURL = [sself.URLCallbacks[url] copy];
-                                                             });
-                                                             for (NSDictionary *callbacks in callbacksForURL) {
-                                                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                                                     SDWebImageDownloaderProgressBlock callback = callbacks[kProgressCallbackKey];
-                                                                     if (callback) callback(receivedSize, expectedSize);
-                                                                 });
-                                                             }
-                                                         }
-                                                        completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {
-                                                            SDWebImageDownloader *sself = wself;
-                                                            if (!sself) return;
-                                                            __block NSArray *callbacksForURL;
-                                                            dispatch_barrier_sync(sself.barrierQueue, ^{
-                                                                callbacksForURL = [sself.URLCallbacks[url] copy];
-                                                                if (finished) {
-                                                                    [sself.URLCallbacks removeObjectForKey:url];
-                                                                }
-                                                            });
-                                                            for (NSDictionary *callbacks in callbacksForURL) {
-                                                                SDWebImageDownloaderCompletedBlock callback = callbacks[kCompletedCallbackKey];
-                                                                if (callback) callback(image, data, error, finished);
-                                                            }
-                                                        }
-                                                        cancelled:^{
-                                                            SDWebImageDownloader *sself = wself;
-                                                            if (!sself) return;
-                                                            dispatch_barrier_async(sself.barrierQueue, ^{
-                                                                [sself.URLCallbacks removeObjectForKey:url];
-                                                            });
-                                                        }];
+        SDWebImageDownloaderOperation *operation = [[wself.operationClass alloc] initWithRequest:request options:options];
         operation.shouldDecompressImages = wself.shouldDecompressImages;
         
         if (wself.urlCredential) {
@@ -212,18 +169,12 @@ static NSString *const kCompletedCallbackKey = @"completed";
         return;
     }
 
-    dispatch_barrier_async(self.barrierQueue, ^{
-        _SDWebImageDownloaderToken *typedToken = (_SDWebImageDownloaderToken *)token;
-
-        NSMutableArray *callbacksForURL = self.URLCallbacks[typedToken.url];
-        [callbacksForURL removeObjectIdenticalTo:typedToken.callbacks];
-
-        // If this was the last set of callbacks, then cancel the operation
-        if (callbacksForURL.count == 0) {
-            SDWebImageDownloaderOperation *operation = self.URLOperations[typedToken.url];
-            [operation cancel];
-        }
-    });
+    _SDWebImageDownloaderToken *typedToken = (_SDWebImageDownloaderToken *)token;
+    SDWebImageDownloaderOperation *operation = self.URLOperations[typedToken.url];
+    BOOL canceled = [operation cancel:typedToken.downloadOperationCancelToken];
+    if (canceled) {
+        [self.URLOperations removeObjectForKey:typedToken.url];
+    }
 }
 
 - (id)addProgressCallback:(SDWebImageDownloaderProgressBlock)progressBlock completedBlock:(SDWebImageDownloaderCompletedBlock)completedBlock forURL:(NSURL *)url createCallback:(SDWebImageDownloaderOperation *(^)())createCallback {
@@ -235,31 +186,25 @@ static NSString *const kCompletedCallbackKey = @"completed";
         return nil;
     }
 
-    __block _SDWebImageDownloaderToken *token = nil;
+    SDWebImageDownloaderOperation *operation = self.URLOperations[url];
+    if (!operation) {
+        operation = createCallback();
+        self.URLOperations[url] = operation;
 
-    dispatch_barrier_sync(self.barrierQueue, ^{
-        if (!self.URLCallbacks[url]) {
-            self.URLCallbacks[url] = [NSMutableArray new];
-        }
+        __weak SDWebImageDownloaderOperation *woperation = operation;
+        operation.completionBlock = ^{
+          SDWebImageDownloaderOperation *soperation = woperation;
+          if (!soperation) return;
+          if (self.URLOperations[url] == soperation) {
+              [self.URLOperations removeObjectForKey:url];
+          };
+        };
+    }
+    id downloadOperationCancelToken = [operation addHandlersForProgress:progressBlock completed:completedBlock];
 
-        // Handle single download of simultaneous download request for the same URL
-        NSMutableArray *callbacksForURL = self.URLCallbacks[url];
-        NSMutableDictionary *callbacks = [NSMutableDictionary new];
-        if (progressBlock) callbacks[kProgressCallbackKey] = [progressBlock copy];
-        if (completedBlock) callbacks[kCompletedCallbackKey] = [completedBlock copy];
-        [callbacksForURL addObject:callbacks];
-        self.URLCallbacks[url] = callbacksForURL;
-
-        SDWebImageDownloaderOperation *operation = self.URLOperations[url];
-        if (!operation) {
-            operation = createCallback();
-            self.URLOperations[url] = operation;
-        }
-
-        token = [_SDWebImageDownloaderToken new];
-        token.url = url;
-        token.callbacks = callbacks;
-    });
+    _SDWebImageDownloaderToken *token = [_SDWebImageDownloaderToken new];
+    token.url = url;
+    token.downloadOperationCancelToken = downloadOperationCancelToken;
 
     return token;
 }

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -61,18 +61,33 @@ extern NSString *const SDWebImageDownloadFinishNotification;
  *
  *  @param request        the URL request
  *  @param options        downloader options
- *  @param progressBlock  the block executed when a new chunk of data arrives. 
- *                        @note the progress block is executed on a background queue
- *  @param completedBlock the block executed when the download is done. 
- *                        @note the completed block is executed on the main queue for success. If errors are found, there is a chance the block will be executed on a background queue
- *  @param cancelBlock    the block executed if the download (operation) is cancelled
  *
  *  @return the initialized instance
  */
 - (id)initWithRequest:(NSURLRequest *)request
-              options:(SDWebImageDownloaderOptions)options
-             progress:(SDWebImageDownloaderProgressBlock)progressBlock
-            completed:(SDWebImageDownloaderCompletedBlock)completedBlock
-            cancelled:(SDWebImageNoParamsBlock)cancelBlock;
+              options:(SDWebImageDownloaderOptions)options;
+
+/**
+ *  Adds handlers for progress and completion. Returns a tokent that can be passed to -cancel: to cancel this set of
+ *  callbacks.
+ *
+ *  @param progressBlock  the block executed when a new chunk of data arrives.
+ *                        @note the progress block is executed on a background queue
+ *  @param completedBlock the block executed when the download is done.
+ *                        @note the completed block is executed on the main queue for success. If errors are found, there is a chance the block will be executed on a background queue
+ *
+ *  @return the token to use to cancel this set of handlers
+ */
+- (id)addHandlersForProgress:(SDWebImageDownloaderProgressBlock)progressBlock
+                   completed:(SDWebImageDownloaderCompletedBlock)completedBlock;
+
+/**
+ *  Cancels a set of callbacks. Once all callbacks are canceled, the operation is cancelled.
+ *
+ *  @param token the token representing a set of callbacks to cancel
+ *
+ *  @return YES if the operation was stopped because this was the last token to be canceled. NO otherwise.
+ */
+- (BOOL)cancel:(id)token;
 
 @end

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -387,10 +387,12 @@ static NSString *const kCompletedCallbackKey = @"completed";
     if (![[NSURLCache sharedURLCache] cachedResponseForRequest:_request]) {
         responseFromCached = NO;
     }
-    
-    for (SDWebImageDownloaderCompletedBlock completionBlock in completionBlocks) {
+
+    if (completionBlocks.count > 0) {
         if (self.options & SDWebImageDownloaderIgnoreCachedResponse && responseFromCached) {
-            completionBlock(nil, nil, nil, YES);
+            for (SDWebImageDownloaderCompletedBlock completionBlock in completionBlocks) {
+                completionBlock(nil, nil, nil, YES);
+            }
         } else if (self.imageData) {
             UIImage *image = [UIImage sd_imageWithData:self.imageData];
             NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
@@ -402,14 +404,18 @@ static NSString *const kCompletedCallbackKey = @"completed";
                     image = [UIImage decodedImageWithImage:image];
                 }
             }
-            if (CGSizeEqualToSize(image.size, CGSizeZero)) {
-                completionBlock(nil, nil, [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Downloaded image has 0 pixels"}], YES);
-            }
-            else {
-                completionBlock(image, self.imageData, nil, YES);
+            for (SDWebImageDownloaderCompletedBlock completionBlock in completionBlocks) {
+                if (CGSizeEqualToSize(image.size, CGSizeZero)) {
+                    completionBlock(nil, nil, [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Downloaded image has 0 pixels"}], YES);
+                }
+                else {
+                    completionBlock(image, self.imageData, nil, YES);
+                }
             }
         } else {
-            completionBlock(nil, nil, [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Image data is nil"}], YES);
+          for (SDWebImageDownloaderCompletedBlock completionBlock in completionBlocks) {
+              completionBlock(nil, nil, [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Image data is nil"}], YES);
+          }
         }
     }
     [self done];

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -79,9 +79,11 @@ static NSString *const kCompletedCallbackKey = @"completed";
 }
 
 - (NSArray *)callbacksForKey:(NSString *)key {
-    __block NSArray *callbacks = nil;
+    __block NSMutableArray *callbacks = nil;
     dispatch_sync(self.barrierQueue, ^{
-        callbacks = [self.callbackBlocks valueForKey:key];
+        // We need to remove [NSNull null] because there might not always be a progress block for each callback
+        callbacks = [[self.callbackBlocks valueForKey:key] mutableCopy];
+        [callbacks removeObjectIdenticalTo:[NSNull null]];
     });
     return callbacks;
 }

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -179,7 +179,7 @@
                 // ignore image read from NSURLCache if image if cached but force refreshing
                 downloaderOptions |= SDWebImageDownloaderIgnoreCachedResponse;
             }
-            id <SDWebImageOperation> subOperation = [self.imageDownloader downloadImageWithURL:url options:downloaderOptions progress:progressBlock completed:^(UIImage *downloadedImage, NSData *data, NSError *error, BOOL finished) {
+            id subOperation = [self.imageDownloader downloadImageWithURL:url options:downloaderOptions progress:progressBlock completed:^(UIImage *downloadedImage, NSData *data, NSError *error, BOOL finished) {
                 __strong __typeof(weakOperation) strongOperation = weakOperation;
                 if (!strongOperation || strongOperation.isCancelled) {
                     // Do nothing if the operation was cancelled
@@ -255,8 +255,8 @@
                 }
             }];
             operation.cancelBlock = ^{
-                [subOperation cancel];
-                
+                [self.imageDownloader cancel:subOperation];
+
                 @synchronized (self.runningOperations) {
                     __strong __typeof(weakOperation) strongOperation = weakOperation;
                     if (strongOperation) {

--- a/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
+++ b/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5F7F38AD1AE2A77A00B0E330 /* TestImage.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5F7F38AC1AE2A77A00B0E330 /* TestImage.jpg */; };
+		1E3C51E919B46E370092B5E6 /* SDWebImageDownloaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3C51E819B46E370092B5E6 /* SDWebImageDownloaderTests.m */; };
 		ABC8501F672447AA91C788DA /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EB0D107E6B4C4094BA2FEE29 /* libPods-ios.a */; };
 		DA248D57195472AA00390AB0 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA248D56195472AA00390AB0 /* XCTest.framework */; };
 		DA248D59195472AA00390AB0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA248D58195472AA00390AB0 /* Foundation.framework */; };
@@ -22,6 +23,7 @@
 		1A6DF883515E8008203AB352 /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
 		5F7F38AC1AE2A77A00B0E330 /* TestImage.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = TestImage.jpg; sourceTree = "<group>"; };
 		CA88E6BDE3581B2BFE933C10 /* Pods-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.release.xcconfig"; sourceTree = "<group>"; };
+		1E3C51E819B46E370092B5E6 /* SDWebImageDownloaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDownloaderTests.m; sourceTree = "<group>"; };
 		DA248D53195472AA00390AB0 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA248D56195472AA00390AB0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		DA248D58195472AA00390AB0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -96,6 +98,7 @@
 				DA248D68195475D800390AB0 /* SDImageCacheTests.m */,
 				DA248D6A195476AC00390AB0 /* SDWebImageManagerTests.m */,
 				DA91BEBB19795BC9006F2536 /* UIImageMultiFormatTests.m */,
+				1E3C51E819B46E370092B5E6 /* SDWebImageDownloaderTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -207,6 +210,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1E3C51E919B46E370092B5E6 /* SDWebImageDownloaderTests.m in Sources */,
 				DA248D69195475D800390AB0 /* SDImageCacheTests.m in Sources */,
 				DA248D6B195476AC00390AB0 /* SDWebImageManagerTests.m in Sources */,
 				DA91BEBC19795BC9006F2536 /* UIImageMultiFormatTests.m in Sources */,

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -32,21 +32,9 @@
     [super tearDown];
 }
 
-- (BOOL)spinRunLoopWithTimeout:(NSTimeInterval)timeout untilBlockIsTrue:(BOOL(^)())block {
-  CFTimeInterval timeoutDate = CACurrentMediaTime() + 5.;
-  while (true) {
-      if (block()) {
-          return YES;
-      }
-      if (CACurrentMediaTime() > timeoutDate) {
-          return NO;
-      }
-      CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1., true);
-  }
-  return NO;
-}
-
 - (void)testThatDownloadingSameURLTwiceAndCancellingFirstWorks {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Correct image downloads"];
+
     NSURL *imageURL = [NSURL URLWithString:@"http://static2.dmcdn.net/static/video/656/177/44771656:jpeg_preview_small.jpg?20120509154705"];
 
     id token1 = [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL
@@ -57,27 +45,22 @@
                                                                     }];
     expect(token1).toNot.beNil();
 
-    __block BOOL success = NO;
     id token2 = [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL
                                                                       options:0
                                                                      progress:nil
                                                                     completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {
-                                                                        success = YES;
+                                                                        [expectation fulfill];
                                                                     }];
     expect(token2).toNot.beNil();
 
     [[SDWebImageDownloader sharedDownloader] cancel:token1];
 
-    success = [self spinRunLoopWithTimeout:5. untilBlockIsTrue:^BOOL{
-        return success;
-    }];
-
-    if (!success) {
-        XCTFail(@"Failed to download image");
-    }
+    [self waitForExpectationsWithTimeout:5. handler:nil];
 }
 
 - (void)testThatCancelingDownloadThenRequestingAgainWorks {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Correct image downloads"];
+
     NSURL *imageURL = [NSURL URLWithString:@"http://static2.dmcdn.net/static/video/656/177/44771656:jpeg_preview_small.jpg?20120509154705"];
 
     id token1 = [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL
@@ -90,22 +73,15 @@
 
     [[SDWebImageDownloader sharedDownloader] cancel:token1];
 
-    __block BOOL success = NO;
     id token2 = [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL
                                                                       options:0
                                                                      progress:nil
                                                                     completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {
-                                                                        success = YES;
+                                                                        [expectation fulfill];
                                                                     }];
     expect(token2).toNot.beNil();
 
-    success = [self spinRunLoopWithTimeout:5. untilBlockIsTrue:^BOOL{
-        return success;
-    }];
-
-    if (!success) {
-        XCTFail(@"Failed to download image");
-    }
+    [self waitForExpectationsWithTimeout:5. handler:nil];
 }
 
 @end

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -1,0 +1,70 @@
+//
+//  SDWebImageDownloaderTests.m
+//  SDWebImage Tests
+//
+//  Created by Matt Galloway on 01/09/2014.
+//
+//
+
+#define EXP_SHORTHAND   // required by Expecta
+
+
+#import <XCTest/XCTest.h>
+#import <Expecta.h>
+
+#import "SDWebImageDownloader.h"
+
+@interface SDWebImageDownloaderTests : XCTestCase
+
+@end
+
+@implementation SDWebImageDownloaderTests
+
+- (void)setUp
+{
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testThatDownloadingSameURLTwiceAndCancellingFirstWorks {
+    NSURL *imageURL = [NSURL URLWithString:@"http://static2.dmcdn.net/static/video/656/177/44771656:jpeg_preview_small.jpg?20120509154705"];
+
+    id token1 = [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL
+                                                                      options:0
+                                                                     progress:nil
+                                                                    completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {
+                                                                        XCTFail(@"Shouldn't have completed here.");
+                                                                    }];
+    expect(token1).toNot.beNil();
+
+    __block BOOL success = NO;
+    id token2 = [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL
+                                                                      options:0
+                                                                     progress:nil
+                                                                    completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {
+                                                                        success = YES;
+                                                                    }];
+    expect(token2).toNot.beNil();
+
+    [[SDWebImageDownloader sharedDownloader] cancel:token1];
+
+    CFTimeInterval timeoutDate = CACurrentMediaTime() + 5.;
+    while (true) {
+        if (CACurrentMediaTime() > timeoutDate || success) {
+            break;
+        }
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 1., true);
+    }
+
+    if (!success) {
+        XCTFail(@"Failed to download image");
+    }
+}
+
+@end


### PR DESCRIPTION
SDWebImage helpfully downloads only once if a request for the same image comes in more than once while the image is still being downloaded. However, it doesn't handle canceling correctly. Only the first operation gets a handle to the download operation, and therefore is the only one which can cancel it. Moreover, if it does cancel it, then the other operations waiting on that download never complete either.

This patch changes things slightly so that the downloader gives out a "token" that can be used to cancel the request to download. It then removes callbacks for that one token, leaving the actual download operation running.