### PR TITLE
Decode images only up to a maximum size

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -52,6 +52,12 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 @property (assign, nonatomic) NSUInteger maxCacheSize;
 
 /**
+ * The maximum size of decoded images. CGSizeZero indicates no maximum and is the default value.
+ */
+@property (assign, nonatomic) CGSize maxImageSize;
+
+
+/**
  * Returns global shared cache instance
  *
  * @return SDImageCache global instance

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -66,6 +66,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 
         // Init default values
         _maxCacheAge = kDefaultCacheMaxCacheAge;
+        _maxImageSize = CGSizeZero;
 
         // Init the memory cache
         _memCache = [[NSCache alloc] init];
@@ -264,7 +265,8 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
     if (data) {
         UIImage *image = [UIImage sd_imageWithData:data];
         image = [self scaledImageForKey:key image:image];
-        image = [UIImage decodedImageWithImage:image];
+        image = [UIImage decodedImageWithImage:image
+                                       maxSize:self.maxImageSize];
         return image;
     }
     else {

--- a/SDWebImage/SDWebImageDecoder.h
+++ b/SDWebImage/SDWebImageDecoder.h
@@ -15,4 +15,7 @@
 
 + (UIImage *)decodedImageWithImage:(UIImage *)image;
 
++ (UIImage *)decodedImageWithImage:(UIImage *)image
+                           maxSize:(CGSize)maxSize;
+
 @end

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -280,7 +280,9 @@
                 UIImage *image = [UIImage imageWithCGImage:partialImageRef scale:1 orientation:orientation];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                 UIImage *scaledImage = [self scaledImageForKey:key image:image];
-                image = [UIImage decodedImageWithImage:scaledImage];
+                CGSize maxSize = [SDWebImageManager sharedManager].imageCache.maxImageSize;
+                image = [UIImage decodedImageWithImage:scaledImage
+                                               maxSize:maxSize];
                 CGImageRelease(partialImageRef);
                 dispatch_main_sync_safe(^{
                     if (self.completedBlock) {
@@ -350,7 +352,9 @@
             
             // Do not force decoding animated GIFs
             if (!image.images) {
-                image = [UIImage decodedImageWithImage:image];
+                CGSize maxSize = [SDWebImageManager sharedManager].imageCache.maxImageSize;
+                image = [UIImage decodedImageWithImage:image
+                                               maxSize:maxSize];
             }
             if (CGSizeEqualToSize(image.size, CGSizeZero)) {
                 completionBlock(nil, nil, [NSError errorWithDomain:@"SDWebImageErrorDomain" code:0 userInfo:@{NSLocalizedDescriptionKey : @"Downloaded image has 0 pixels"}], YES);


### PR DESCRIPTION
Decoding very large images may lead to memory warnings or even crashes. This pull request introduces a new property `maxImageSize` on `SDImageCache` that is used for all image decoding operations. 

`[UImage +decodedImageWithImage:maxSize:]` will detect if the undecoded image's size exceeds the maximum  size, and scale it down, respecting the aspect ratio. Only if the image is downscaled, the context's interpolation quality is adjusted `CGContextSetInterpolationQuality(context, kCGInterpolationHigh)` to prevent staggering (see http://vocaro.com/trevor/blog/2009/10/12/resize-a-uiimage-the-right-way/)