### PR TITLE
Easier Image Scaling

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -108,7 +108,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  *
  * @param key The unique key used to store the wanted image
  */
-- (NSOperation *)queryDiskCacheForKey:(NSString *)key done:(SDWebImageQueryCompletedBlock)doneBlock;
+- (NSOperation *)queryDiskCacheForKey:(NSString *)key scaledToScreen:(BOOL)scaledToScreen done:(SDWebImageQueryCompletedBlock)doneBlock;
 
 /**
  * Query the memory cache synchronously.
@@ -122,7 +122,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  *
  * @param key The unique key used to store the wanted image
  */
-- (UIImage *)imageFromDiskCacheForKey:(NSString *)key;
+- (UIImage *)imageFromDiskCacheForKey:(NSString *)key scaledToScreen:(BOOL)scaledToScreen;
 
 /**
  * Remove the image from memory and disk cache synchronously

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -224,7 +224,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
     return [self.memCache objectForKey:key];
 }
 
-- (UIImage *)imageFromDiskCacheForKey:(NSString *)key {
+- (UIImage *)imageFromDiskCacheForKey:(NSString *)key scaledToScreen:(BOOL)scaledToScreen {
     // First check the in-memory cache...
     UIImage *image = [self imageFromMemoryCacheForKey:key];
     if (image) {
@@ -232,7 +232,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
     }
 
     // Second check the disk cache...
-    UIImage *diskImage = [self diskImageForKey:key];
+    UIImage *diskImage = [self diskImageForKey:key scaledToScreen:scaledToScreen];
     if (diskImage) {
         CGFloat cost = diskImage.size.height * diskImage.size.width * diskImage.scale;
         [self.memCache setObject:diskImage forKey:key cost:cost];
@@ -259,11 +259,11 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
     return nil;
 }
 
-- (UIImage *)diskImageForKey:(NSString *)key {
+- (UIImage *)diskImageForKey:(NSString *)key scaledToScreen:(BOOL)scaledToScreen {
     NSData *data = [self diskImageDataBySearchingAllPathsForKey:key];
     if (data) {
         UIImage *image = [UIImage sd_imageWithData:data];
-        image = [self scaledImageForKey:key image:image];
+        image = [self scaledImageForKey:key image:image scaleToScreen:scaledToScreen];
         image = [UIImage decodedImageWithImage:image];
         return image;
     }
@@ -272,11 +272,11 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
     }
 }
 
-- (UIImage *)scaledImageForKey:(NSString *)key image:(UIImage *)image {
-    return SDScaledImageForKey(key, image);
+- (UIImage *)scaledImageForKey:(NSString *)key image:(UIImage *)image scaleToScreen:(BOOL)scaleToScreen {
+    return SDScaledImageForKey(key, image, scaleToScreen);
 }
 
-- (NSOperation *)queryDiskCacheForKey:(NSString *)key done:(SDWebImageQueryCompletedBlock)doneBlock {
+- (NSOperation *)queryDiskCacheForKey:(NSString *)key scaledToScreen:(BOOL)scaledToScreen done:(SDWebImageQueryCompletedBlock)doneBlock {
     if (!doneBlock) {
         return nil;
     }
@@ -300,7 +300,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
         }
 
         @autoreleasepool {
-            UIImage *diskImage = [self diskImageForKey:key];
+            UIImage *diskImage = [self diskImageForKey:key scaledToScreen:scaledToScreen];
             if (diskImage) {
                 CGFloat cost = diskImage.size.height * diskImage.size.width * diskImage.scale;
                 [self.memCache setObject:diskImage forKey:key cost:cost];

--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -51,7 +51,7 @@
 #define SDDispatchQueueSetterSementics assign
 #endif
 
-extern UIImage *SDScaledImageForKey(NSString *key, UIImage *image);
+extern UIImage *SDScaledImageForKey(NSString *key, UIImage *image, BOOL scaleToScreen);
 
 typedef void(^SDWebImageNoParamsBlock)();
 

--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -12,7 +12,7 @@
 #error SDWebImage is ARC only. Either turn on ARC for the project or use -fobjc-arc flag
 #endif
 
-inline UIImage *SDScaledImageForKey(NSString *key, UIImage *image) {
+inline UIImage *SDScaledImageForKey(NSString *key, UIImage *image, BOOL scaleToScreen) {
     if (!image) {
         return nil;
     }
@@ -21,21 +21,14 @@ inline UIImage *SDScaledImageForKey(NSString *key, UIImage *image) {
         NSMutableArray *scaledImages = [NSMutableArray array];
 
         for (UIImage *tempImage in image.images) {
-            [scaledImages addObject:SDScaledImageForKey(key, tempImage)];
+            [scaledImages addObject:SDScaledImageForKey(key, tempImage, scaleToScreen)];
         }
 
         return [UIImage animatedImageWithImages:scaledImages duration:image.duration];
     }
     else {
         if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
-            CGFloat scale = 1.0;
-            if (key.length >= 8) {
-                // Search @2x. at the end of the string, before a 3 to 4 extension length (only if key len is 8 or more @2x. + 4 len ext)
-                NSRange range = [key rangeOfString:@"@2x." options:0 range:NSMakeRange(key.length - 8, 5)];
-                if (range.location != NSNotFound) {
-                    scale = 2.0;
-                }
-            }
+            CGFloat scale = scaleToScreen ? [[UIScreen mainScreen] scale] : 1.0;
 
             UIImage *scaledImage = [[UIImage alloc] initWithCGImage:image.CGImage scale:scale orientation:image.imageOrientation];
             image = scaledImage;

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -279,7 +279,7 @@
             if (partialImageRef) {
                 UIImage *image = [UIImage imageWithCGImage:partialImageRef scale:1 orientation:orientation];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-                UIImage *scaledImage = [self scaledImageForKey:key image:image];
+                UIImage *scaledImage = [self scaledImageForKey:key image:image scaledToScreen:self.options & SDWebImageScaleToScreen];
                 image = [UIImage decodedImageWithImage:scaledImage];
                 CGImageRelease(partialImageRef);
                 dispatch_main_sync_safe(^{
@@ -321,8 +321,8 @@
     }
 }
 
-- (UIImage *)scaledImageForKey:(NSString *)key image:(UIImage *)image {
-    return SDScaledImageForKey(key, image);
+- (UIImage *)scaledImageForKey:(NSString *)key image:(UIImage *)image scaledToScreen:(BOOL)scaledToScreen {
+    return SDScaledImageForKey(key, image, scaledToScreen);
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)aConnection {
@@ -346,7 +346,7 @@
         else {
             UIImage *image = [UIImage sd_imageWithData:self.imageData];
             NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-            image = [self scaledImageForKey:key image:image];
+            image = [self scaledImageForKey:key image:image scaledToScreen:self.options & SDWebImageScaleToScreen];
             
             // Do not force decoding animated GIFs
             if (!image.images) {

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -76,10 +76,12 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      */
     SDWebImageDelayPlaceholder = 1 << 9,
     
+    SDWebImageTransformAnimatedImage = 1 << 10,
+    
     /**
      * Returned images are scaled to [[UIScreen mainScreen] scale]
      */
-    SDWebImageScaleToScreen = 1 << 10
+    SDWebImageScaleToScreen = 1 << 11
 };
 
 typedef void(^SDWebImageCompletionBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL);

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -75,13 +75,11 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * of the placeholder image until after the image has finished loading.
      */
     SDWebImageDelayPlaceholder = 1 << 9,
-
+    
     /**
-     * We usually don't call transformDownloadedImage delegate method on animated images,
-     * as most transformation code would mangle it.
-     * Use this flag to transform them anyway.
+     * Returned images are scaled to [[UIScreen mainScreen] scale]
      */
-    SDWebImageTransformAnimatedImage = 1 << 10,
+    SDWebImageScaleToScreen = 1 << 10
 };
 
 typedef void(^SDWebImageCompletionBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL);

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -146,7 +146,8 @@
     }
     NSString *key = [self cacheKeyForURL:url];
 
-    operation.cacheOperation = [self.imageCache queryDiskCacheForKey:key done:^(UIImage *image, SDImageCacheType cacheType) {
+    BOOL scalesToScreen = options & SDWebImageScaleToScreen;
+    operation.cacheOperation = [self.imageCache queryDiskCacheForKey:key scaledToScreen:scalesToScreen done:^(UIImage *image, SDImageCacheType cacheType) {
         if (operation.isCancelled) {
             @synchronized (self.runningOperations) {
                 [self.runningOperations removeObject:operation];
@@ -173,6 +174,7 @@
             if (options & SDWebImageHandleCookies) downloaderOptions |= SDWebImageDownloaderHandleCookies;
             if (options & SDWebImageAllowInvalidSSLCertificates) downloaderOptions |= SDWebImageDownloaderAllowInvalidSSLCertificates;
             if (options & SDWebImageHighPriority) downloaderOptions |= SDWebImageDownloaderHighPriority;
+            if (options & SDWebImageScaleToScreen) downloaderOptions |= SDWebImageScaleToScreen;
             if (image && options & SDWebImageRefreshCached) {
                 // force progressive off if image already cached but forced refreshing
                 downloaderOptions &= ~SDWebImageDownloaderProgressiveDownload;

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -79,7 +79,7 @@ static char imageURLKey;
 
 - (void)sd_setImageWithPreviousCachedImageWithURL:(NSURL *)url andPlaceholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock {
     NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
-    UIImage *lastPreviousCachedImage = [[SDImageCache sharedImageCache] imageFromDiskCacheForKey:key];
+    UIImage *lastPreviousCachedImage = [[SDImageCache sharedImageCache] imageFromDiskCacheForKey:key scaledToScreen:options & SDWebImageScaleToScreen];
     
     [self sd_setImageWithURL:url placeholderImage:lastPreviousCachedImage ?: placeholder options:options progress:progressBlock completed:completedBlock];    
 }


### PR DESCRIPTION
This fork allows a user to opt in to having images scaled to the screens scale using the SDWebImageOptions bit mask, instead of using an "@2x." suffix in the image key. Images should also be scaled to @3x on the iPhone 6 plus using this method

Oh, and I also had to add SDWebImageTransformAnimatedImage to the SDWebImageOptions to get the project to compile