### PR TITLE
UIImage+GIF.m updated for 3x resolution

### DIFF
--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -84,38 +84,42 @@
 }
 
 + (UIImage *)sd_animatedGIFNamed:(NSString *)name {
+    
     CGFloat scale = [UIScreen mainScreen].scale;
-
-    if (scale > 1.0f) {
-        NSString *retinaPath = [[NSBundle mainBundle] pathForResource:[name stringByAppendingString:@"@2x"] ofType:@"gif"];
-
-        NSData *data = [NSData dataWithContentsOfFile:retinaPath];
-
-        if (data) {
-            return [UIImage sd_animatedGIFWithData:data];
-        }
-
-        NSString *path = [[NSBundle mainBundle] pathForResource:name ofType:@"gif"];
-
+    
+    //set up possible paths
+    NSString *threeTimesResName = [name stringByAppendingString:@"@3x"];
+    NSString *twoTimesResName = [name stringByAppendingString:@"@2x"];
+    NSString *normalResName = name;
+    
+    NSData *data;
+    NSString *path;
+    
+    //get gif for 3x display
+    if (scale > 2.0f) {
+        path = [[NSBundle mainBundle] pathForResource:threeTimesResName ofType:@"gif"];
         data = [NSData dataWithContentsOfFile:path];
-
-        if (data) {
-            return [UIImage sd_animatedGIFWithData:data];
-        }
-
-        return [UIImage imageNamed:name];
     }
-    else {
-        NSString *path = [[NSBundle mainBundle] pathForResource:name ofType:@"gif"];
-
-        NSData *data = [NSData dataWithContentsOfFile:path];
-
-        if (data) {
-            return [UIImage sd_animatedGIFWithData:data];
-        }
-
-        return [UIImage imageNamed:name];
+    
+    //get gif for 2x display or if there is no 3x resource
+    if (scale > 1.0f && !data) {
+        path = [[NSBundle mainBundle] pathForResource:twoTimesResName ofType:@"gif"];
+        data = [NSData dataWithContentsOfFile:path];
     }
+    
+    //get gif for non-retina display or if there is no 2x or 3x resource
+    if (!data) {
+        path = [[NSBundle mainBundle] pathForResource:normalResName ofType:@"gif"];
+        data = [NSData dataWithContentsOfFile:path];
+    }
+    
+    if (data) {
+        return [UIImage sd_animatedGIFWithData:data];
+    }
+    
+    //still no resource found --> try to return non-gif image
+    return [UIImage imageNamed:name];
+    
 }
 
 - (UIImage *)sd_animatedImageByScalingAndCroppingToSize:(CGSize)size {

--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -95,21 +95,33 @@
     NSData *data;
     NSString *path;
     
-    //get gif for 3x display
+    //get gif for @3x display
     if (scale > 2.0f) {
         path = [[NSBundle mainBundle] pathForResource:threeTimesResName ofType:@"gif"];
         data = [NSData dataWithContentsOfFile:path];
     }
     
-    //get gif for 2x display or if there is no 3x resource
+    //get gif for 2x display or if there is no @3x resource
     if (scale > 1.0f && !data) {
         path = [[NSBundle mainBundle] pathForResource:twoTimesResName ofType:@"gif"];
         data = [NSData dataWithContentsOfFile:path];
     }
     
-    //get gif for non-retina display or if there is no 2x or 3x resource
+    //get gif for non-retina display or if there is no @2x or 3x resource
     if (!data) {
         path = [[NSBundle mainBundle] pathForResource:normalResName ofType:@"gif"];
+        data = [NSData dataWithContentsOfFile:path];
+    }
+    
+    //no data yet? maybe there is only a @2x image
+    if (!data) {
+        path = [[NSBundle mainBundle] pathForResource:twoTimesResName ofType:@"gif"];
+        data = [NSData dataWithContentsOfFile:path];
+    }
+    
+    //still no data? could be only a @3x image is provided
+    if (!data) {
+        path = [[NSBundle mainBundle] pathForResource:threeTimesResName ofType:@"gif"];
         data = [NSData dataWithContentsOfFile:path];
     }
     
@@ -120,43 +132,6 @@
     //still no resource found --> try to return non-gif image
     return [UIImage imageNamed:name];
     
-}
-
-- (UIImage *)sd_animatedImageByScalingAndCroppingToSize:(CGSize)size {
-    if (CGSizeEqualToSize(self.size, size) || CGSizeEqualToSize(size, CGSizeZero)) {
-        return self;
-    }
-
-    CGSize scaledSize = size;
-    CGPoint thumbnailPoint = CGPointZero;
-
-    CGFloat widthFactor = size.width / self.size.width;
-    CGFloat heightFactor = size.height / self.size.height;
-    CGFloat scaleFactor = (widthFactor > heightFactor) ? widthFactor : heightFactor;
-    scaledSize.width = self.size.width * scaleFactor;
-    scaledSize.height = self.size.height * scaleFactor;
-
-    if (widthFactor > heightFactor) {
-        thumbnailPoint.y = (size.height - scaledSize.height) * 0.5;
-    }
-    else if (widthFactor < heightFactor) {
-        thumbnailPoint.x = (size.width - scaledSize.width) * 0.5;
-    }
-
-    NSMutableArray *scaledImages = [NSMutableArray array];
-
-    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
-
-    for (UIImage *image in self.images) {
-        [image drawInRect:CGRectMake(thumbnailPoint.x, thumbnailPoint.y, scaledSize.width, scaledSize.height)];
-        UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
-
-        [scaledImages addObject:newImage];
-    }
-
-    UIGraphicsEndImageContext();
-
-    return [UIImage animatedImageWithImages:scaledImages duration:self.duration];
 }
 
 @end

--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -134,4 +134,41 @@
     
 }
 
+- (UIImage *)sd_animatedImageByScalingAndCroppingToSize:(CGSize)size {
+    if (CGSizeEqualToSize(self.size, size) || CGSizeEqualToSize(size, CGSizeZero)) {
+        return self;
+    }
+
+    CGSize scaledSize = size;
+    CGPoint thumbnailPoint = CGPointZero;
+
+    CGFloat widthFactor = size.width / self.size.width;
+    CGFloat heightFactor = size.height / self.size.height;
+    CGFloat scaleFactor = (widthFactor > heightFactor) ? widthFactor : heightFactor;
+    scaledSize.width = self.size.width * scaleFactor;
+    scaledSize.height = self.size.height * scaleFactor;
+
+    if (widthFactor > heightFactor) {
+        thumbnailPoint.y = (size.height - scaledSize.height) * 0.5;
+    }
+    else if (widthFactor < heightFactor) {
+        thumbnailPoint.x = (size.width - scaledSize.width) * 0.5;
+    }
+
+    NSMutableArray *scaledImages = [NSMutableArray array];
+
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
+
+    for (UIImage *image in self.images) {
+        [image drawInRect:CGRectMake(thumbnailPoint.x, thumbnailPoint.y, scaledSize.width, scaledSize.height)];
+        UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+
+        [scaledImages addObject:newImage];
+    }
+
+    UIGraphicsEndImageContext();
+
+    return [UIImage animatedImageWithImages:scaledImages duration:self.duration];
+}
+
 @end


### PR DESCRIPTION
So far, the iPhone 6+ is not taken into account in UIImage+GIF.m
After this change, the method +sd_animatedGIFNamed: looks for an @3x image now, if the scale is more than 2.0