### PR TITLE
Transparent GIF not clearing context between frames

### DIFF
--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -144,7 +144,11 @@
     UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
 
     for (UIImage *image in self.images) {
-        [image drawInRect:CGRectMake(thumbnailPoint.x, thumbnailPoint.y, scaledSize.width, scaledSize.height)];
+        CGRect imageRect = CGRectMake(thumbnailPoint.x, thumbnailPoint.y, scaledSize.width, scaledSize.height);
+        
+        CGContextClearRect(UIGraphicsGetCurrentContext(), imageRect);
+        
+        [image drawInRect:imageRect];
         UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
 
         [scaledImages addObject:newImage];


### PR DESCRIPTION
resolved an issue where transparent gifs would render their each previous frame in the next frame.  this lead to a ghosting effect that would draw the new frame over the previous frame instead of clearing the context before drawing the new frame