### PR TITLE
add SD_APP_EXTENSION macro for ios8 extensions

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -467,6 +467,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 }
 
 - (void)backgroundCleanDisk {
+#ifndef SD_APP_EXTENSION
     UIApplication *application = [UIApplication sharedApplication];
     __block UIBackgroundTaskIdentifier bgTask = [application beginBackgroundTaskWithExpirationHandler:^{
         // Clean up any unfinished task business by marking where you
@@ -480,6 +481,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
         [application endBackgroundTask:bgTask];
         bgTask = UIBackgroundTaskInvalid;
     }];
+#endif
 }
 
 - (NSUInteger)getSize {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -68,7 +68,7 @@
             return;
         }
 
-#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
+#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0 && !defined(SD_APP_EXTENSION)
         if ([self shouldContinueWhenAppEntersBackground]) {
             __weak __typeof__ (self) wself = self;
             self.backgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
@@ -83,7 +83,7 @@
             }];
         }
 #endif
-
+		
         self.executing = YES;
         self.connection = [[NSURLConnection alloc] initWithRequest:self.request delegate:self startImmediately:NO];
         self.thread = [NSThread currentThread];
@@ -118,12 +118,13 @@
         }
     }
 
-#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
+#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0 && !defined(SD_APP_EXTENSION)
     if (self.backgroundTaskId != UIBackgroundTaskInvalid) {
         [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTaskId];
         self.backgroundTaskId = UIBackgroundTaskInvalid;
     }
 #endif
+
 }
 
 - (void)cancel {


### PR DESCRIPTION
define the SD_APP_EXTENSION preprocessor macro when you are building an extension that includes SDWebImage. This avoids compile time errors about the user of [UIApplication sharedApplication]

Addresses: #859 