### PR TITLE
Bug fix:Collection <__NSArrayM: > was mutated while being enumerated

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -248,7 +248,8 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
         return data;
     }
 
-    for (NSString *path in self.customPaths) {
+    NSArray *customPaths = [self.customPaths copy];
+    for (NSString *path in customPaths) {
         NSString *filePath = [self cachePathForKey:key inPath:path];
         NSData *imageData = [NSData dataWithContentsOfFile:filePath];
         if (imageData) {


### PR DESCRIPTION
Method `@selector(diskImageDataBySearchingAllPathsForKey:)` sometimes called in the background thread. While method `@selector(addReadOnlyCachePath:)` called in some other threads such as main thread usually, there is an existing risk crash: `Collection <__NSArrayM: > was mutated while being enumerated`