### PR TITLE
If we're going to store an image, first transform it to be upright.

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -107,6 +107,10 @@
 		5D5B9145188EE8DD006D06BD /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
 		5D5B9146188EE8DD006D06BD /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
 		5D5B9147188EE8DD006D06BD /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
+		874976481A663E110062CB2C /* UIImage+FixOrient.h in Headers */ = {isa = PBXBuildFile; fileRef = 874976461A663E110062CB2C /* UIImage+FixOrient.h */; };
+		874976491A663E110062CB2C /* UIImage+FixOrient.m in Sources */ = {isa = PBXBuildFile; fileRef = 874976471A663E110062CB2C /* UIImage+FixOrient.m */; };
+		8749764A1A663E310062CB2C /* UIImage+FixOrient.m in Sources */ = {isa = PBXBuildFile; fileRef = 874976471A663E110062CB2C /* UIImage+FixOrient.m */; };
+		8749764B1A663E460062CB2C /* UIImage+FixOrient.m in Sources */ = {isa = PBXBuildFile; fileRef = 874976471A663E110062CB2C /* UIImage+FixOrient.m */; };
 		A18A6CC7172DC28500419892 /* UIImage+GIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A18A6CC5172DC28500419892 /* UIImage+GIF.h */; };
 		A18A6CC8172DC28500419892 /* UIImage+GIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A18A6CC5172DC28500419892 /* UIImage+GIF.h */; };
 		A18A6CC9172DC28500419892 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
@@ -246,6 +250,8 @@
 		53FB894814D35E9E0020B787 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		5D5B9140188EE8DD006D06BD /* NSData+ImageContentType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+ImageContentType.h"; sourceTree = "<group>"; };
 		5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+ImageContentType.m"; sourceTree = "<group>"; };
+		874976461A663E110062CB2C /* UIImage+FixOrient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+FixOrient.h"; sourceTree = "<group>"; };
+		874976471A663E110062CB2C /* UIImage+FixOrient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+FixOrient.m"; sourceTree = "<group>"; };
 		A18A6CC5172DC28500419892 /* UIImage+GIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+GIF.h"; sourceTree = "<group>"; };
 		A18A6CC6172DC28500419892 /* UIImage+GIF.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+GIF.m"; sourceTree = "<group>"; };
 		AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+WebCacheOperation.h"; sourceTree = "<group>"; };
@@ -424,6 +430,8 @@
 				53EDFB8917623F7C00698166 /* UIImage+MultiFormat.m */,
 				53EDFB911762547C00698166 /* UIImage+WebP.h */,
 				53EDFB921762547C00698166 /* UIImage+WebP.m */,
+				874976461A663E110062CB2C /* UIImage+FixOrient.h */,
+				874976471A663E110062CB2C /* UIImage+FixOrient.m */,
 				ABBE71A518C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h */,
 				ABBE71A618C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m */,
 				53922D95148C56230056699D /* UIImageView+WebCache.h */,
@@ -635,6 +643,7 @@
 				530E49EA16464C7C002868E7 /* SDWebImageDownloaderOperation.h in Headers */,
 				ABBE71A718C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h in Headers */,
 				AB615303192DA24600A2D8E9 /* UIView+WebCacheOperation.h in Headers */,
+				874976481A663E110062CB2C /* UIImage+FixOrient.h in Headers */,
 				A18A6CC7172DC28500419892 /* UIImage+GIF.h in Headers */,
 				53EDFB8A17623F7C00698166 /* UIImage+MultiFormat.h in Headers */,
 			);
@@ -829,6 +838,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8749764A1A663E310062CB2C /* UIImage+FixOrient.m in Sources */,
 				531041C4157EAFA400BBABC3 /* SDImageCache.m in Sources */,
 				531041C5157EAFA400BBABC3 /* SDWebImageDecoder.m in Sources */,
 				531041C6157EAFA400BBABC3 /* SDWebImageDownloader.m in Sources */,
@@ -854,6 +864,7 @@
 			files = (
 				53761309155AD0D5005750A4 /* SDImageCache.m in Sources */,
 				5376130A155AD0D5005750A4 /* SDWebImageDecoder.m in Sources */,
+				874976491A663E110062CB2C /* UIImage+FixOrient.m in Sources */,
 				5376130B155AD0D5005750A4 /* SDWebImageDownloader.m in Sources */,
 				5376130C155AD0D5005750A4 /* SDWebImageManager.m in Sources */,
 				5376130D155AD0D5005750A4 /* SDWebImagePrefetcher.m in Sources */,
@@ -873,6 +884,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8749764B1A663E460062CB2C /* UIImage+FixOrient.m in Sources */,
 				DA577D101998E60B007367ED /* upsampling_neon.c in Sources */,
 				DA577D151998E60B007367ED /* yuv_sse2.c in Sources */,
 				DA577D111998E60B007367ED /* upsampling_sse2.c in Sources */,

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -9,6 +9,7 @@
 #import "SDImageCache.h"
 #import "SDWebImageDecoder.h"
 #import "UIImage+MultiFormat.h"
+#import "UIImage+FixOrient.h"
 #import <CommonCrypto/CommonDigest.h>
 
 static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
@@ -157,6 +158,8 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 
             if (image && (recalculate || !data)) {
 #if TARGET_OS_IPHONE
+                UIImage *orientedImage = [image fixOrientation];
+              
                 // We need to determine if the image is a PNG or a JPEG
                 // PNGs are easier to detect because they have a unique signature (http://www.w3.org/TR/PNG-Structure.html)
                 // The first eight bytes of a PNG file always contain the following (decimal) values:
@@ -172,10 +175,10 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
                 }
 
                 if (imageIsPng) {
-                    data = UIImagePNGRepresentation(image);
+                    data = UIImagePNGRepresentation(orientedImage);
                 }
                 else {
-                    data = UIImageJPEGRepresentation(image, (CGFloat)1.0);
+                    data = UIImageJPEGRepresentation(orientedImage, (CGFloat)1.0);
                 }
 #else
                 data = [NSBitmapImageRep representationOfImageRepsInArray:image.representations usingType: NSJPEGFileType properties:nil];

--- a/SDWebImage/UIImage+FixOrient.h
+++ b/SDWebImage/UIImage+FixOrient.h
@@ -1,0 +1,20 @@
+//
+//  UIImage+FixOrient.h
+//  RecordBoard
+//
+//  Created by Sam Kass on 1/14/15.
+//  Copyright (c) 2015 Aardustry LLC. All rights reserved.
+//
+
+#ifndef RecordBoard_UIImage_FixOrient_h
+#define RecordBoard_UIImage_FixOrient_h
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (FixOrient)
+
+- (UIImage *)fixOrientation;
+
+@end
+
+#endif

--- a/SDWebImage/UIImage+FixOrient.m
+++ b/SDWebImage/UIImage+FixOrient.m
@@ -1,0 +1,91 @@
+//
+//  UIImage+FixOrient.m
+//
+
+#include "UIImage+FixOrient.h"
+
+@implementation UIImage (FixOrient)
+
+- (UIImage *)fixOrientation {
+  
+  // No-op if the orientation is already correct
+  if (self.imageOrientation == UIImageOrientationUp) return self;
+  
+  // We need to calculate the proper transformation to make the image upright.
+  // We do it in 2 steps: Rotate if Left/Right/Down, and then flip if Mirrored.
+  CGAffineTransform transform = CGAffineTransformIdentity;
+  
+  switch (self.imageOrientation) {
+    case UIImageOrientationDown:
+    case UIImageOrientationDownMirrored:
+      transform = CGAffineTransformTranslate(transform, self.size.width, self.size.height);
+      transform = CGAffineTransformRotate(transform, M_PI);
+      break;
+      
+    case UIImageOrientationLeft:
+    case UIImageOrientationLeftMirrored:
+      transform = CGAffineTransformTranslate(transform, self.size.width, 0);
+      transform = CGAffineTransformRotate(transform, M_PI_2);
+      break;
+      
+    case UIImageOrientationRight:
+    case UIImageOrientationRightMirrored:
+      transform = CGAffineTransformTranslate(transform, 0, self.size.height);
+      transform = CGAffineTransformRotate(transform, -M_PI_2);
+      break;
+    
+    case UIImageOrientationUp:
+    case UIImageOrientationUpMirrored:
+      break;
+  }
+  
+  switch (self.imageOrientation) {
+    case UIImageOrientationUpMirrored:
+    case UIImageOrientationDownMirrored:
+      transform = CGAffineTransformTranslate(transform, self.size.width, 0);
+      transform = CGAffineTransformScale(transform, -1, 1);
+      break;
+      
+    case UIImageOrientationLeftMirrored:
+    case UIImageOrientationRightMirrored:
+      transform = CGAffineTransformTranslate(transform, self.size.height, 0);
+      transform = CGAffineTransformScale(transform, -1, 1);
+      break;
+
+    case UIImageOrientationUp:
+    case UIImageOrientationDown:
+    case UIImageOrientationLeft:
+    case UIImageOrientationRight:
+      break;
+  }
+  
+  // Now we draw the underlying CGImage into a new context, applying the transform
+  // calculated above.
+  CGContextRef ctx = CGBitmapContextCreate(NULL, self.size.width, self.size.height,
+                                           CGImageGetBitsPerComponent(self.CGImage), 0,
+                                           CGImageGetColorSpace(self.CGImage),
+                                           CGImageGetBitmapInfo(self.CGImage));
+  CGContextConcatCTM(ctx, transform);
+  switch (self.imageOrientation) {
+    case UIImageOrientationLeft:
+    case UIImageOrientationLeftMirrored:
+    case UIImageOrientationRight:
+    case UIImageOrientationRightMirrored:
+      // Grr...
+      CGContextDrawImage(ctx, CGRectMake(0,0,self.size.height,self.size.width), self.CGImage);
+      break;
+      
+    default:
+      CGContextDrawImage(ctx, CGRectMake(0,0,self.size.width,self.size.height), self.CGImage);
+      break;
+  }
+  
+  // And now we just create a new UIImage from the drawing context
+  CGImageRef cgimg = CGBitmapContextCreateImage(ctx);
+  UIImage *img = [UIImage imageWithCGImage:cgimg];
+  CGContextRelease(ctx);
+  CGImageRelease(cgimg);
+  return img;
+}
+@end
+


### PR DESCRIPTION
This is a fix for JPEG images being stored in the cache sideways or upside-down if the rotation is in the EXIF data: https://github.com/rs/SDWebImage/issues/75
