### PR TITLE
Prevent warnings from CGBitmapContextCreate

### DIFF
--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -30,27 +30,23 @@
             infoMask == kCGImageAlphaNoneSkipFirst ||
             infoMask == kCGImageAlphaNoneSkipLast);
 
-    // CGBitmapContextCreate doesn't support kCGImageAlphaNone with RGB.
-    // https://developer.apple.com/library/mac/#qa/qa1037/_index.html
     if (infoMask == kCGImageAlphaNone && CGColorSpaceGetNumberOfComponents(colorSpace) > 1) {
-        // Unset the old alpha info.
-        bitmapInfo &= ~kCGBitmapAlphaInfoMask;
-
+        // CGBitmapContextCreate doesn't support kCGImageAlphaNone with RGB.
+        // https://developer.apple.com/library/mac/#qa/qa1037/_index.html
+        
         // Set noneSkipFirst.
-        bitmapInfo |= kCGImageAlphaNoneSkipFirst;
-    }
-            // Some PNGs tell us they have alpha but only 3 components. Odd.
-    else if (!anyNonAlpha && CGColorSpaceGetNumberOfComponents(colorSpace) == 3) {
-        // Unset the old alpha info.
-        bitmapInfo &= ~kCGBitmapAlphaInfoMask;
-        bitmapInfo |= kCGImageAlphaPremultipliedFirst;
+        bitmapInfo = kCGBitmapByteOrderDefault | kCGImageAlphaNoneSkipFirst;
+    } else if (anyNonAlpha) {
+        bitmapInfo = kCGBitmapByteOrderDefault | kCGImageAlphaNoneSkipLast;
+    } else {
+        bitmapInfo = kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst;
     }
 
     // It calculates the bytes-per-row based on the bitsPerComponent and width arguments.
     CGContextRef context = CGBitmapContextCreate(NULL,
             imageSize.width,
             imageSize.height,
-            CGImageGetBitsPerComponent(imageRef),
+            8,
             0,
             colorSpace,
             bitmapInfo);


### PR DESCRIPTION
Sometimes if the parameter combination is not supported by `CGBitmapContextCreate`, it will generate some warnings like the following one:

`<Error>: CGBitmapContextCreate: unsupported parameter combination: 16 integer bits/component; 64 bits/pixel; 3-component color space; kCGImageAlphaPremultipliedFirst; 2400 bytes/row.`

The warnings will be eliminated by using fixed parameter combinations which are already supported by `CGBitmapContextCreate`.