### PR TITLE
[Memory Issue] Clear SDWebImagePrefetcher progressBlock when it has completed

### DIFF
--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -94,6 +94,7 @@
                 self.completionBlock(self.finishedCount, self.skippedCount);
                 self.completionBlock = nil;
             }
+            self.progressBlock = nil;
         }
     }];
 }


### PR DESCRIPTION
If self.progressblock captures objects, captured objects remain until next time SDWebImagePrefetcher works. So clear self.progressBlock with nil value as well as completionBlock.