### PR TITLE
Issue809

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -323,16 +323,18 @@
             _cacheOperation = nil;
         }
         if (_cancelBlock) {
-            // store _cancelBlock to temp variable, because inside _cancelBlock self can be deleted
-            cancelBlock = [_cancelBlock copy];
-            
             // TODO: this is a temporary fix to #809.
             // Until we can figure the exact cause of the crash, going with the ivar instead of the setter
-            //          self.cancelBlock = nil;
+//            self.cancelBlock();
+//            self.cancelBlock = nil;
+
+            // store _cancelBlock to temp variable, because inside _cancelBlock self can be deleted
+            cancelBlock = [_cancelBlock copy];
             _cancelBlock = nil;
         }
     }
-    cancelBlock();
+    if (cancelBlock)
+        cancelBlock();
     // no acces to self now, because it may be deleted
 }
 

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -146,6 +146,14 @@
     }
     NSString *key = [self cacheKeyForURL:url];
 
+    __block id<SDWebImageOperation> subOperation = nil;
+    operation.cancelBlock = ^{
+        [subOperation cancel];
+        
+        @synchronized (self.runningOperations) {
+            [self.runningOperations removeObject:weakOperation];
+        }
+    };
     operation.cacheOperation = [self.imageCache queryDiskCacheForKey:key done:^(UIImage *image, SDImageCacheType cacheType) {
         if (operation.isCancelled) {
             @synchronized (self.runningOperations) {
@@ -179,7 +187,7 @@
                 // ignore image read from NSURLCache if image if cached but force refreshing
                 downloaderOptions |= SDWebImageDownloaderIgnoreCachedResponse;
             }
-            id <SDWebImageOperation> subOperation = [self.imageDownloader downloadImageWithURL:url options:downloaderOptions progress:progressBlock completed:^(UIImage *downloadedImage, NSData *data, NSError *error, BOOL finished) {
+            subOperation = [self.imageDownloader downloadImageWithURL:url options:downloaderOptions progress:progressBlock completed:^(UIImage *downloadedImage, NSData *data, NSError *error, BOOL finished) {
                 if (weakOperation.isCancelled) {
                     // Do nothing if the operation was cancelled
                     // See #699 for more details
@@ -241,13 +249,6 @@
                     }
                 }
             }];
-            operation.cancelBlock = ^{
-                [subOperation cancel];
-                
-                @synchronized (self.runningOperations) {
-                    [self.runningOperations removeObject:weakOperation];
-                }
-            };
         }
         else if (image) {
             dispatch_main_sync_safe(^{
@@ -301,30 +302,38 @@
 
 - (void)setCancelBlock:(SDWebImageNoParamsBlock)cancelBlock {
     // check if the operation is already cancelled, then we just call the cancelBlock
-    if (self.isCancelled) {
-        if (cancelBlock) {
-            cancelBlock();
+    @synchronized(self){ // make it thread safety
+        if (self.isCancelled) {
+            if (cancelBlock) {
+                cancelBlock();
+            }
+            _cancelBlock = nil; // don't forget to nil the cancelBlock, otherwise we will get crashes
+        } else {
+            _cancelBlock = [cancelBlock copy];
         }
-        _cancelBlock = nil; // don't forget to nil the cancelBlock, otherwise we will get crashes
-    } else {
-        _cancelBlock = [cancelBlock copy];
     }
 }
 
 - (void)cancel {
-    self.cancelled = YES;
-    if (self.cacheOperation) {
-        [self.cacheOperation cancel];
-        self.cacheOperation = nil;
+    SDWebImageNoParamsBlock cancelBlock = nil;
+    @synchronized(self){
+        _cancelled = YES;
+        if (_cacheOperation) {
+            [_cacheOperation cancel];
+            _cacheOperation = nil;
+        }
+        if (_cancelBlock) {
+            // store _cancelBlock to temp variable, because inside _cancelBlock self can be deleted
+            cancelBlock = [_cancelBlock copy];
+            
+            // TODO: this is a temporary fix to #809.
+            // Until we can figure the exact cause of the crash, going with the ivar instead of the setter
+            //          self.cancelBlock = nil;
+            _cancelBlock = nil;
+        }
     }
-    if (self.cancelBlock) {
-        self.cancelBlock();
-        
-        // TODO: this is a temporary fix to #809.
-        // Until we can figure the exact cause of the crash, going with the ivar instead of the setter
-//        self.cancelBlock = nil;
-        _cancelBlock = nil;
-    }
+    cancelBlock();
+    // no acces to self now, because it may be deleted
 }
 
 @end


### PR DESCRIPTION
1.  Don't access 'self' pointer from SDWebImageCombinedOperation.cancel when cancelBlock has been called

2. Race condition fix:
     a) self.cancelBlock is nil;
     b) SDWebImageCombinedOperation.setCancelBlock called and isCancelled is NO
     c) another thread calls cancel before _cancelBlock = [cancelBlock copy]; 
     d) SDWebImageCombinedOperation.cancel called but cancelBlock is still nil => no cancelBlock is called
     e)  _cancelBlock = [cancelBlock copy]; set, but never called, operation has already been cancelled