### PR TITLE
allow override diskCachePath

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -65,6 +65,8 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  */
 - (id)initWithNamespace:(NSString *)ns;
 
+-(NSString *)makeDiskCachePath:(NSString*)fullNamespace;
+
 /**
  * Add a read-only cache path to search for images pre-cached by SDImageCache
  * Useful if you want to bundle pre-loaded images with your app

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -74,8 +74,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
         _memCache.name = fullNamespace;
 
         // Init the disk cache
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
-        _diskCachePath = [paths[0] stringByAppendingPathComponent:fullNamespace];
+        _diskCachePath = [self makeDiskCachePath:fullNamespace];
 
         dispatch_sync(_ioQueue, ^{
             _fileManager = [NSFileManager new];
@@ -143,6 +142,12 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 }
 
 #pragma mark ImageCache
+
+// Init the disk cache
+-(NSString *)makeDiskCachePath:(NSString*)fullNamespace{
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    return [paths[0] stringByAppendingPathComponent:fullNamespace];
+}
 
 - (void)storeImage:(UIImage *)image recalculateFromImage:(BOOL)recalculate imageData:(NSData *)imageData forKey:(NSString *)key toDisk:(BOOL)toDisk {
     if (!image || !key) {


### PR DESCRIPTION
i need custom diskCachePath; I am subclass SDImageCache and override SDWebImageManager.createCache

using:
```swift
class BMWebImageManager: SDWebImageManager {
    
    override init() {
        super.init();
    }
    
    func createCache()->SDImageCache {
        return BMImageCache.sharedImageCache();
    }
    
}

class BMImageCache:SDImageCache{
    
    override func makeDiskCachePath(fullNamespace: String!) -> String! {
        return path;
    }
    
}



