### PR TITLE
Adds ability to disable gif support

### DIFF
--- a/SDWebImage/UIImage+MultiFormat.m
+++ b/SDWebImage/UIImage+MultiFormat.m
@@ -20,25 +20,27 @@
 + (UIImage *)sd_imageWithData:(NSData *)data {
     UIImage *image;
     NSString *imageContentType = [NSData sd_contentTypeForImageData:data];
+#ifndef SD_DISABLE_GIF
     if ([imageContentType isEqualToString:@"image/gif"]) {
         image = [UIImage sd_animatedGIFWithData:data];
-    }
-#ifdef SD_WEBP
-    else if ([imageContentType isEqualToString:@"image/webp"])
-    {
-        image = [UIImage sd_imageWithWebPData:data];
+        return image;
     }
 #endif
-    else {
-        image = [[UIImage alloc] initWithData:data];
-        UIImageOrientation orientation = [self sd_imageOrientationFromImageData:data];
-        if (orientation != UIImageOrientationUp) {
-            image = [UIImage imageWithCGImage:image.CGImage
-                                        scale:image.scale
-                                  orientation:orientation];
-        }
+#ifdef SD_WEBP
+    if ([imageContentType isEqualToString:@"image/webp"])
+    {
+        image = [UIImage sd_imageWithWebPData:data];
+        return image;
     }
-
+#endif
+    
+    image = [[UIImage alloc] initWithData:data];
+    UIImageOrientation orientation = [self sd_imageOrientationFromImageData:data];
+    if (orientation != UIImageOrientationUp) {
+        image = [UIImage imageWithCGImage:image.CGImage
+                                    scale:image.scale
+                              orientation:orientation];
+    }
 
     return image;
 }


### PR DESCRIPTION
I noticed a significant amount of dropped frames when scrolling through a collection view that contained animated GIFs. In my mind the animated gifs are not worth the performance hit. This adds a simple compiler flag to disable GIF support. 

Based off of the recommendations here: https://github.com/rs/SDWebImage/issues/501