### PR TITLE
new image decoding method (do not merge this as-is, but please comment)

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -281,7 +281,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         UIImage *image = [UIImage sd_imageWithData:data];
         image = [self scaledImageForKey:key image:image];
         if (self.shouldDecompressImages) {
-            image = [UIImage decodedImageWithImage:image];
+            image = [UIImage decodedImageWithImage:image data:data];
         }
         return image;
     }

--- a/SDWebImage/SDWebImageDecoder.h
+++ b/SDWebImage/SDWebImageDecoder.h
@@ -14,5 +14,6 @@
 @interface UIImage (ForceDecode)
 
 + (UIImage *)decodedImageWithImage:(UIImage *)image;
++ (UIImage *)decodedImageWithImage:(UIImage *)image data:(NSData *)data;
 
 @end

--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -9,6 +9,7 @@
  */
 
 #import "SDWebImageDecoder.h"
+#import <ImageIO/ImageIO.h>
 
 @implementation UIImage (ForceDecode)
 
@@ -17,55 +18,25 @@
         // Do not decode animated images
         return image;
     }
+    
+    // new decompression method
+    NSData *data = UIImagePNGRepresentation(image);
+    return [self decodedImageWithImage:image data:data];
+}
 
-    CGImageRef imageRef = image.CGImage;
-    CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
-    CGRect imageRect = (CGRect){.origin = CGPointZero, .size = imageSize};
-
-    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    CGBitmapInfo bitmapInfo = CGImageGetBitmapInfo(imageRef);
-
-    int infoMask = (bitmapInfo & kCGBitmapAlphaInfoMask);
-    BOOL anyNonAlpha = (infoMask == kCGImageAlphaNone ||
-            infoMask == kCGImageAlphaNoneSkipFirst ||
-            infoMask == kCGImageAlphaNoneSkipLast);
-
-    // CGBitmapContextCreate doesn't support kCGImageAlphaNone with RGB.
-    // https://developer.apple.com/library/mac/#qa/qa1037/_index.html
-    if (infoMask == kCGImageAlphaNone && CGColorSpaceGetNumberOfComponents(colorSpace) > 1) {
-        // Unset the old alpha info.
-        bitmapInfo &= ~kCGBitmapAlphaInfoMask;
-
-        // Set noneSkipFirst.
-        bitmapInfo |= kCGImageAlphaNoneSkipFirst;
++ (UIImage *)decodedImageWithImage:(UIImage *)image data:(NSData *)data {
+    if (image.images) {
+        // Do not decode animated images
+        return image;
     }
-            // Some PNGs tell us they have alpha but only 3 components. Odd.
-    else if (!anyNonAlpha && CGColorSpaceGetNumberOfComponents(colorSpace) == 3) {
-        // Unset the old alpha info.
-        bitmapInfo &= ~kCGBitmapAlphaInfoMask;
-        bitmapInfo |= kCGImageAlphaPremultipliedFirst;
-    }
-
-    // It calculates the bytes-per-row based on the bitsPerComponent and width arguments.
-    CGContextRef context = CGBitmapContextCreate(NULL,
-            imageSize.width,
-            imageSize.height,
-            CGImageGetBitsPerComponent(imageRef),
-            0,
-            colorSpace,
-            bitmapInfo);
-    CGColorSpaceRelease(colorSpace);
-
-    // If failed, return undecompressed image
-    if (!context) return image;
-
-    CGContextDrawImage(context, imageRect, imageRef);
-    CGImageRef decompressedImageRef = CGBitmapContextCreateImage(context);
-
-    CGContextRelease(context);
-
-    UIImage *decompressedImage = [UIImage imageWithCGImage:decompressedImageRef scale:image.scale orientation:image.imageOrientation];
-    CGImageRelease(decompressedImageRef);
+    
+    // new decompression method
+    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    CGImageRef cgImage = CGImageSourceCreateImageAtIndex(source, 0, (__bridge CFDictionaryRef)@{(id)kCGImageSourceShouldCacheImmediately: @YES});
+    
+    UIImage *decompressedImage = [UIImage imageWithCGImage:cgImage scale:image.scale orientation:image.imageOrientation];
+    CGImageRelease(cgImage);
+    CFRelease(source);
     return decompressedImage;
 }
 

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -380,7 +380,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
             // Do not force decoding animated GIFs
             if (!image.images) {
                 if (self.shouldDecompressImages) {
-                    image = [UIImage decodedImageWithImage:image];
+                    image = [UIImage decodedImageWithImage:image data:self.imageData];
                 }
             }
             if (CGSizeEqualToSize(image.size, CGSizeZero)) {


### PR DESCRIPTION
I did this quick hack to fix the memory usage problems I was having on iOS7/8 using the current decoding method.

This isn't iOS5/6 compatible, and I'm sure there's a better way to handle ```decodedImageWithImage:``` when the raw image data is not available.