### PR TITLE
failedURLs can be removed at the appropriate time.

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -199,6 +199,12 @@
                     }
                 }
                 else {
+                    if ((options & SDWebImageRetryFailed)) {
+                        @synchronized (self.failedURLs) {
+                            [self.failedURLs removeObject:url];
+                        }
+                    }
+                    
                     BOOL cacheOnDisk = !(options & SDWebImageCacheMemoryOnly);
 
                     if (options & SDWebImageRefreshCached && image && !downloadedImage) {


### PR DESCRIPTION
For example:
- A image download failed at first.
- I have used `SDWebImageRetryFailed` to retry download a image, now the image is ok.
- But then I use the same url to download image with no `SDWebImageRetryFailed`, it's still failed.

I think it's a bug.
:)