### PR TITLE
Applied patch for issue #1074

### DIFF
--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -13,7 +13,7 @@
 #error SDWebImage does not support Objective-C Garbage Collection
 #endif
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_5_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED != 20000 && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_5_0
 #error SDWebImage doesn't support Deployement Target version < 5.0
 #endif
 


### PR DESCRIPTION
When the code is copied within a swift module, or when a target is linked against the static library or when using from cocoapods - the debugger not longer gets broken.