### PR TITLE
Add NSCache countLimit property

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -48,6 +48,11 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 @property (assign, nonatomic) NSUInteger maxMemoryCost;
 
 /**
+ * The maximum number of objects the cache should hold.
+ */
+@property (assign, nonatomic) NSUInteger maxMemoryCountLimit;
+
+/**
  * The maximum length of time to keep an image in the cache, in seconds
  */
 @property (assign, nonatomic) NSInteger maxCacheAge;

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -377,6 +377,14 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     return self.memCache.totalCostLimit;
 }
 
+- (NSUInteger)maxMemoryCountLimit {
+    return self.memCache.countLimit;
+}
+
+- (void)setMaxMemoryCountLimit:(NSUInteger)maxCountLimit {
+    self.memCache.countLimit = maxCountLimit;
+}
+
 - (void)clearMemory {
     [self.memCache removeAllObjects];
 }


### PR DESCRIPTION
Addresses https://github.com/rs/SDWebImage/issues/538

I just did the following test. 

Setting the limit to 40, scrolling full screen images on an iphone6. During the session my persisted allocation hovered around ~28mb 
![screenshot 2015-05-11 11 04 54](https://cloud.githubusercontent.com/assets/102188/7571611/9ebfefec-f7cd-11e4-98a2-4de5d37c77c3.png)

Setting the limit to 400 created a session that grew well past 100mb until a memory pressure event  
![screenshot 2015-05-11 11 16 29](https://cloud.githubusercontent.com/assets/102188/7571860/3418de54-f7cf-11e4-8786-df664a82406d.png)
