### PR TITLE
Add check to disable [UIApplication sharedApplication] for extension targets

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -141,6 +141,10 @@
 		5D5B9145188EE8DD006D06BD /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
 		5D5B9146188EE8DD006D06BD /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
 		5D5B9147188EE8DD006D06BD /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
+		804441861B064040004E064F /* UIApplication+SafeSharedApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 804441841B064040004E064F /* UIApplication+SafeSharedApplication.h */; };
+		804441871B064040004E064F /* UIApplication+SafeSharedApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = 804441841B064040004E064F /* UIApplication+SafeSharedApplication.h */; };
+		804441881B064040004E064F /* UIApplication+SafeSharedApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 804441851B064040004E064F /* UIApplication+SafeSharedApplication.m */; };
+		804441891B064040004E064F /* UIApplication+SafeSharedApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 804441851B064040004E064F /* UIApplication+SafeSharedApplication.m */; };
 		A18A6CC7172DC28500419892 /* UIImage+GIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A18A6CC5172DC28500419892 /* UIImage+GIF.h */; };
 		A18A6CC8172DC28500419892 /* UIImage+GIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A18A6CC5172DC28500419892 /* UIImage+GIF.h */; };
 		A18A6CC9172DC28500419892 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
@@ -283,6 +287,8 @@
 		53FB894814D35E9E0020B787 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		5D5B9140188EE8DD006D06BD /* NSData+ImageContentType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+ImageContentType.h"; sourceTree = "<group>"; };
 		5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+ImageContentType.m"; sourceTree = "<group>"; };
+		804441841B064040004E064F /* UIApplication+SafeSharedApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIApplication+SafeSharedApplication.h"; sourceTree = "<group>"; };
+		804441851B064040004E064F /* UIApplication+SafeSharedApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIApplication+SafeSharedApplication.m"; sourceTree = "<group>"; };
 		A18A6CC5172DC28500419892 /* UIImage+GIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+GIF.h"; sourceTree = "<group>"; };
 		A18A6CC6172DC28500419892 /* UIImage+GIF.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+GIF.m"; sourceTree = "<group>"; };
 		AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+WebCacheOperation.h"; sourceTree = "<group>"; };
@@ -493,6 +499,8 @@
 				53922D96148C56230056699D /* UIImageView+WebCache.m */,
 				AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */,
 				AB615302192DA24600A2D8E9 /* UIView+WebCacheOperation.m */,
+				804441841B064040004E064F /* UIApplication+SafeSharedApplication.h */,
+				804441851B064040004E064F /* UIApplication+SafeSharedApplication.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -676,6 +684,7 @@
 				4A2CAE1B1AB4BB6800B6BC39 /* SDWebImageDownloader.h in Headers */,
 				4A2CAE271AB4BB7500B6BC39 /* MKAnnotationView+WebCache.h in Headers */,
 				4A2CAE231AB4BB7000B6BC39 /* SDWebImageDecoder.h in Headers */,
+				804441871B064040004E064F /* UIApplication+SafeSharedApplication.h in Headers */,
 				4A2CAE311AB4BB7500B6BC39 /* UIImage+WebP.h in Headers */,
 				4A2CAE2D1AB4BB7500B6BC39 /* UIImage+GIF.h in Headers */,
 				4A2CAE291AB4BB7500B6BC39 /* NSData+ImageContentType.h in Headers */,
@@ -712,6 +721,7 @@
 			files = (
 				53761316155AD0D5005750A4 /* SDImageCache.h in Headers */,
 				5D5B9142188EE8DD006D06BD /* NSData+ImageContentType.h in Headers */,
+				804441861B064040004E064F /* UIApplication+SafeSharedApplication.h in Headers */,
 				53761318155AD0D5005750A4 /* SDWebImageCompat.h in Headers */,
 				53761319155AD0D5005750A4 /* SDWebImageDecoder.h in Headers */,
 				5376131A155AD0D5005750A4 /* SDWebImageDownloader.h in Headers */,
@@ -966,6 +976,7 @@
 				4A2CAE381AB4BB7500B6BC39 /* UIView+WebCacheOperation.m in Sources */,
 				4A2CAE241AB4BB7000B6BC39 /* SDWebImageDecoder.m in Sources */,
 				4A2CAE341AB4BB7500B6BC39 /* UIImageView+HighlightedWebCache.m in Sources */,
+				804441891B064040004E064F /* UIApplication+SafeSharedApplication.m in Sources */,
 				4A2CAE201AB4BB6C00B6BC39 /* SDImageCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1000,6 +1011,7 @@
 				53761309155AD0D5005750A4 /* SDImageCache.m in Sources */,
 				5376130A155AD0D5005750A4 /* SDWebImageDecoder.m in Sources */,
 				5376130B155AD0D5005750A4 /* SDWebImageDownloader.m in Sources */,
+				804441881B064040004E064F /* UIApplication+SafeSharedApplication.m in Sources */,
 				5376130C155AD0D5005750A4 /* SDWebImageManager.m in Sources */,
 				5376130D155AD0D5005750A4 /* SDWebImagePrefetcher.m in Sources */,
 				5376130E155AD0D5005750A4 /* UIButton+WebCache.m in Sources */,

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -9,6 +9,7 @@
 #import "SDImageCache.h"
 #import "SDWebImageDecoder.h"
 #import "UIImage+MultiFormat.h"
+#import "UIApplication+SafeSharedApplication.h"
 #import <CommonCrypto/CommonDigest.h>
 
 // See https://github.com/rs/SDWebImage/pull/1141 for discussion
@@ -516,7 +517,10 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 }
 
 - (void)backgroundCleanDisk {
-    UIApplication *application = [UIApplication sharedApplication];
+    UIApplication *application = [UIApplication sdw_sharedApplication];
+    if (application == nil) {
+      return;
+    }
     __block UIBackgroundTaskIdentifier bgTask = [application beginBackgroundTaskWithExpirationHandler:^{
         // Clean up any unfinished task business by marking where you
         // stopped or ending the task outright.

--- a/SDWebImage/UIApplication+SafeSharedApplication.h
+++ b/SDWebImage/UIApplication+SafeSharedApplication.h
@@ -1,0 +1,13 @@
+//
+//  UIApplication+SafeSharedApplication.h
+//  SDWebImage
+//
+//  Created by Yusef Napora on 5/15/15.
+//  Copyright (c) 2015 Dailymotion. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIApplication (SafeSharedApplication)
++ (UIApplication *) sdw_sharedApplication;
+@end

--- a/SDWebImage/UIApplication+SafeSharedApplication.m
+++ b/SDWebImage/UIApplication+SafeSharedApplication.m
@@ -1,0 +1,49 @@
+//
+// UIApplication+RSKSharedApplication.m
+//
+// Copyright (c) 2015 Ruslan Skorb, http://ruslanskorb.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#import "UIApplication+SafeSharedApplication.h"
+#import <objc/runtime.h>
+
+@implementation UIApplication (SafeSharedApplication)
+
++ (void)load
+{
+  // When you build an extension based on an Xcode template, you get an extension bundle that ends in .appex.
+  // https://developer.apple.com/library/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionCreation.html
+  if (![[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"]) {
+    Method sharedApplicationMethod = class_getClassMethod([UIApplication class], @selector(sharedApplication));
+    if (sharedApplicationMethod != NULL) {
+      IMP sharedApplicationMethodImplementation = method_getImplementation(sharedApplicationMethod);
+      Method sdw_sharedApplicationMethod = class_getClassMethod([UIApplication class], @selector(sdw_sharedApplication));
+      method_setImplementation(sdw_sharedApplicationMethod, sharedApplicationMethodImplementation);
+    }
+  }
+}
+
++ (UIApplication *)sdw_sharedApplication
+{
+  return nil;
+}
+
+@end


### PR DESCRIPTION
This adds a category to `UIApplication` that provides an extension-safe `sdw_sharedApplication` method which returns `nil` when running in an app extension.  addresses #1082

This uses @ruslanskorb's  code from this gist, linked to in the discussion of #1082: https://gist.github.com/ruslanskorb/1616f0bdd1c2f6d45595

I like this approach, because it never calls `performSelector(sharedApplication)` until *after* it's determined that it's not executing inside an extension bundle.  This seems like the safest way to avoid rejection without requiring a compile-time flag.  Not using a compiler flag means that you can use SDWebImage in a shared framework that can be linked into both an app and an extension.  Code that depends on `sharedApplication` will still run in the app target, but not in the extension.  