### PR TITLE
Add handling for additional error codes that shouldn't be considered a permanent failure

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -192,7 +192,9 @@
                         }
                     });
 
-                    if (error.code != NSURLErrorNotConnectedToInternet && error.code != NSURLErrorCancelled && error.code != NSURLErrorTimedOut) {
+                    BOOL shouldBeFailedURLAlliOSVersion = (error.code != NSURLErrorNotConnectedToInternet && error.code != NSURLErrorCancelled && error.code != NSURLErrorTimedOut);
+                    BOOL shouldBeFailedURLiOS7 = (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1 && error.code != NSURLErrorInternationalRoamingOff && error.code != NSURLErrorCallIsActive && error.code != NSURLErrorDataNotAllowed);
+                    if (shouldBeFailedURLAlliOSVersion && (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_6_1 || shouldBeFailedURLiOS7)) {
                         @synchronized (self.failedURLs) {
                             [self.failedURLs addObject:url];
                         }

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -194,7 +194,7 @@
 
                     BOOL shouldBeFailedURLAlliOSVersion = (error.code != NSURLErrorNotConnectedToInternet && error.code != NSURLErrorCancelled && error.code != NSURLErrorTimedOut);
                     BOOL shouldBeFailedURLiOS7 = (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1 && error.code != NSURLErrorInternationalRoamingOff && error.code != NSURLErrorCallIsActive && error.code != NSURLErrorDataNotAllowed);
-                    if (shouldBeFailedURLAlliOSVersion && (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_6_1 || shouldBeFailedURLiOS7)) {
+                    if (shouldBeFailedURLAlliOSVersion || shouldBeFailedURLiOS7) {
                         @synchronized (self.failedURLs) {
                             [self.failedURLs addObject:url];
                         }


### PR DESCRIPTION
This PR makes `SDWebImageManager` handle the error codes `NSURLErrorInternationalRoamingOff`, `NSURLErrorCallIsActive` or `NSURLErrorDataNotAllowed` on iOS 7 so that the URL that triggered the error isn't put in the failed URL anymore, as the URL can be tried again once the conditions are right (Since the error doesn't come from the server)