### PR TITLE
Change url of libwebp repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Vendors/libwebp"]
 	path = Vendors/libwebp
-	url = http://git.chromium.org/webm/libwebp.git
+	url = https://chromium.googlesource.com/webm/libwebp.git


### PR DESCRIPTION
Now, `http://git.chromium.org/webm/libwebp.git` isn't available and this url redirect to `https://chromium.googlesource.com/`.
So I changed url of submodule settings.

I tried `git clone` and I got error like the following.
 
```
$ git clone http://git.chromium.org/webm/libwebp.git
fatal: http://git.chromium.org/webm/libwebp.git/info/refs not valid: is this a git repository?
```