### PR TITLE
Use NSProcessInfo for background tasks rather than UIApplication

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -467,21 +467,14 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 }
 
 - (void)backgroundCleanDisk {
-#ifndef SD_APP_EXTENSION
-    UIApplication *application = [UIApplication sharedApplication];
-    __block UIBackgroundTaskIdentifier bgTask = [application beginBackgroundTaskWithExpirationHandler:^{
-        // Clean up any unfinished task business by marking where you
-        // stopped or ending the task outright.
-        [application endBackgroundTask:bgTask];
-        bgTask = UIBackgroundTaskInvalid;
-    }];
+    
+    __block id bgTask = [[NSProcessInfo processInfo] beginActivityWithOptions:NSActivityBackground reason:@"background-clean-disk"];
 
     // Start the long-running task and return immediately.
     [self cleanDiskWithCompletionBlock:^{
-        [application endBackgroundTask:bgTask];
-        bgTask = UIBackgroundTaskInvalid;
+        [[NSProcessInfo processInfo] endActivity:bgTask];
+        bgTask = nil;
     }];
-#endif
 }
 
 - (NSUInteger)getSize {

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -467,6 +467,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
 }
 
 - (void)backgroundCleanDisk {
+#ifndef SD_APP_EXTENSION
     UIApplication *application = [UIApplication sharedApplication];
     __block UIBackgroundTaskIdentifier bgTask = [application beginBackgroundTaskWithExpirationHandler:^{
         // Clean up any unfinished task business by marking where you
@@ -480,6 +481,7 @@ BOOL ImageDataHasPNGPreffix(NSData *data) {
         [application endBackgroundTask:bgTask];
         bgTask = UIBackgroundTaskInvalid;
     }];
+#endif
 }
 
 - (NSUInteger)getSize {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -68,7 +68,7 @@
             return;
         }
 
-#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
+#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0 && !defined(SD_APP_EXTENSION)
         if ([self shouldContinueWhenAppEntersBackground]) {
             __weak __typeof__ (self) wself = self;
             self.backgroundTaskId = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
@@ -83,7 +83,7 @@
             }];
         }
 #endif
-
+		
         self.executing = YES;
         self.connection = [[NSURLConnection alloc] initWithRequest:self.request delegate:self startImmediately:NO];
         self.thread = [NSThread currentThread];
@@ -118,12 +118,13 @@
         }
     }
 
-#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
+#if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0 && !defined(SD_APP_EXTENSION)
     if (self.backgroundTaskId != UIBackgroundTaskInvalid) {
         [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTaskId];
         self.backgroundTaskId = UIBackgroundTaskInvalid;
     }
 #endif
+
 }
 
 - (void)cancel {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -75,8 +75,6 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
 
         self.backgroundTaskId = nil;
 #if TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_4_0
-        Class UIApplicationClass = NSClassFromString(@"UIApplication");
-        BOOL hasApplication = UIApplicationClass && [UIApplicationClass respondsToSelector:@selector(sharedApplication)];
         if ([self shouldContinueWhenAppEntersBackground]) {
             self.backgroundTaskId = [[NSProcessInfo processInfo] beginActivityWithOptions:NSActivityBackground reason:@"webimage-downloader"];
         }


### PR DESCRIPTION
The extension safe way of performing background tasks is to use `NSProcessInfo`. 

Currently SDWebImage calls `[UIApplication sharedApplication]` and does some fudging to work around the fact that the compiler throws an error if it detects usage of `-sharedApplication` in extensions.

This PR removes the fudging and switches background processing to use NSProcessInfo, meaning both the extension and app can do background cleanup and there is no unsafe API usage.

Hints that `-sharedApplication` could be problematic in the future:
https://twitter.com/steve_holt/status/609488053841719296