### PR TITLE
Added method to add new urls to the SDWebImagePrefetcher array of prefetchURLs

### DIFF
--- a/SDWebImage/SDWebImagePrefetcher.h
+++ b/SDWebImage/SDWebImagePrefetcher.h
@@ -80,6 +80,13 @@ typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger noOfFinishedUrls, 
 - (void)prefetchURLs:(NSArray *)urls;
 
 /**
+ * Add a list of URLs to the SDWebImagePrefetcher prefetch queue
+ *
+ * @param urls list of URLs to prefetch
+ */
+- (void)addPrefetchURLs:(NSArray *)urls;
+
+/**
  * Assign list of URLs to let SDWebImagePrefetcher to queue the prefetching,
  * currently one image is downloaded at a time,
  * and skips images for failed downloads and proceed to the next image in the list

--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -114,6 +114,15 @@
     [self prefetchURLs:urls progress:nil completed:nil];
 }
 
+- (void)addPrefetchURLs:(NSArray *)urls
+{
+    if (self.startedTime && self.prefetchURLs) {
+        self.prefetchURLs = [self.prefetchURLs arrayByAddingObjectsFromArray:urls];
+    } else {
+        [self prefetchURLs:urls];
+    }
+}
+
 - (void)prefetchURLs:(NSArray *)urls progress:(SDWebImagePrefetcherProgressBlock)progressBlock completed:(SDWebImagePrefetcherCompletionBlock)completionBlock {
     [self cancelPrefetching]; // Prevent duplicate prefetch request
     self.startedTime = CFAbsoluteTimeGetCurrent();


### PR DESCRIPTION
If the prefetcher is already prefetching URLs, this method adds an array of URLs to the existing prefetchURLs, otherwise it calls prefetchURLs: