### PR TITLE
Add an option called "SDWebImageAvoidAutoImageFill" to avoid automati…

### DIFF
--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -88,7 +88,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * have the hand before setting the image (apply a filter or add it with cross-fade animation for instance)
      * Use this flag if you want to manually set the image in the completion when success
      */
-    SDWebImageAvoidAutoImageFill = 1 << 11
+    SDWebImageAvoidAutoSetImage = 1 << 11
 };
 
 typedef void(^SDWebImageCompletionBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL);

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -82,6 +82,13 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * Use this flag to transform them anyway.
      */
     SDWebImageTransformAnimatedImage = 1 << 10,
+    
+    /**
+     * By default, image is added to the imageView after download. But in some cases, we want to
+     * have the hand before setting the image (apply a filter or add it with cross-fade animation for instance)
+     * Use this flag if you want to manually set the image in the completion when success
+     */
+    SDWebImageAvoidAutoImageFill = 1 << 11
 };
 
 typedef void(^SDWebImageCompletionBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL);

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -54,7 +54,12 @@ static char imageURLKey;
             if (!wself) return;
             dispatch_main_sync_safe(^{
                 if (!wself) return;
-                if (image) {
+                if (image && (options & SDWebImageAvoidAutoImageFill) && completedBlock)
+                {
+                    completedBlock(image, error, cacheType, url);
+                    return;
+                }
+                else if (image) {
                     wself.image = image;
                     [wself setNeedsLayout];
                 } else {

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -54,7 +54,7 @@ static char imageURLKey;
             if (!wself) return;
             dispatch_main_sync_safe(^{
                 if (!wself) return;
-                if (image && (options & SDWebImageAvoidAutoImageFill) && completedBlock)
+                if (image && (options & SDWebImageAvoidAutoSetImage) && completedBlock)
                 {
                     completedBlock(image, error, cacheType, url);
                     return;


### PR DESCRIPTION
…c image addition in UIImageView and let developer to do it himself

Hi,

As AFNetworking do, let the developer to manage the image in the completion block if download succeed, and not automatically set the image on the imageView.

In my case, I have to : 
1- transform my UIImage with a custom filter before apply it to the UIImageView
2- apply a cross fading animation when adding it for the first time (or after retrieve it on the cache)

I think it will be no regression with my code addition, but perhaps it's a "big change" about the SDWebImage conception. The old behavior will still work.

Open to discuss.

Regards,

Jean-Charles