### PR TITLE
Fixing casing for #import "webp/decode.h"

### DIFF
--- a/SDWebImage/UIImage+WebP.m
+++ b/SDWebImage/UIImage+WebP.m
@@ -8,7 +8,7 @@
 
 #ifdef SD_WEBP
 #import "UIImage+WebP.h"
-#import "webp/decode.h"
+#import "WebP/decode.h"
 
 // Callback for CGDataProviderRelease
 static void FreeImageData(void *info, const void *data, size_t size)


### PR DESCRIPTION
webp needs to be WebP of compile will not work on case sensitive HDs