### PR TITLE
feature to control each image download to use different download operation

### DIFF
--- a/SDWebImage/NSObject+MultiDownload.h
+++ b/SDWebImage/NSObject+MultiDownload.h
@@ -1,0 +1,14 @@
+//
+//  NSObject+MultiDownload.h
+//  SDWebImage
+//
+//  Created by guodi.ggd on 6/30/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface NSObject (MultiDownload)
+- (id)sd_tag;
+- (void)sd_setTag:(id)tag;
+@end

--- a/SDWebImage/NSObject+MultiDownload.m
+++ b/SDWebImage/NSObject+MultiDownload.m
@@ -1,0 +1,26 @@
+//
+//  NSObject+MultiDownload.m
+//  SDWebImage
+//
+//  Created by guodi.ggd on 6/30/15.
+//
+//
+
+#import "NSObject+MultiDownload.h"
+#import <objc/runtime.h>
+
+static char sd_objectMultiDownloadKey;
+
+@implementation NSObject (MultiDownload)
+- (id)sd_tag {
+    return objc_getAssociatedObject(self, &sd_objectMultiDownloadKey);
+}
+
+- (void)sd_setTag:(id)tag {
+    if (tag) {
+        objc_setAssociatedObject(self, &sd_objectMultiDownloadKey, tag, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    } else {
+        objc_setAssociatedObject(self, &sd_objectMultiDownloadKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+@end

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -10,6 +10,13 @@
 #import "SDWebImageCompat.h"
 #import "SDWebImageOperation.h"
 
+@class SDWebImageDownloader;
+@protocol SDWebImageDownloaderDelegate <NSObject>
+
+- (Class)imageDownloader:(SDWebImageDownloader *)imageDownloader downloadOperationClassForURL:(NSURL *)url sdTag:(id)sdTag;
+
+@end
+
 typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     SDWebImageDownloaderLowPriority = 1 << 0,
     SDWebImageDownloaderProgressiveDownload = 1 << 1,
@@ -78,6 +85,8 @@ typedef NSDictionary *(^SDWebImageDownloaderHeadersFilterBlock)(NSURL *url, NSDi
  * Asynchronous downloader dedicated and optimized for image loading.
  */
 @interface SDWebImageDownloader : NSObject
+
+@property (assign, nonatomic) id<SDWebImageDownloaderDelegate> delegate;
 
 @property (assign, nonatomic) NSInteger maxConcurrentDownloads;
 

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -8,6 +8,8 @@
 
 #import "SDWebImageCompat.h"
 #import "SDWebImageManager.h"
+#import "NSObject+MultiDownload.h"
+
 
 /**
  * Integrates SDWebImage async downloading and caching of remote images with UIImageView.

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -10,7 +10,9 @@
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 
+
 static char imageURLKey;
+static char sd_imageURLMultiDownloadKey;
 
 @implementation UIImageView (WebCache)
 
@@ -41,7 +43,8 @@ static char imageURLKey;
 - (void)sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock {
     [self sd_cancelCurrentImageLoad];
     objc_setAssociatedObject(self, &imageURLKey, url, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-
+    [url sd_setTag:self.sd_tag];
+    
     if (!(options & SDWebImageDelayPlaceholder)) {
         dispatch_main_async_safe(^{
             self.image = placeholder;


### PR DESCRIPTION
sometimes we hope to control some url(depend on url host) or some UIImageView (depend on different pages to show image view) to download image in a special way.

so i  add a feature to NSObject a method sd_setTag: to attach additional information so that we could have an opportunity to choose download operation class to perform file download.

how to use this feature?
1: UIImageView: call sd_setTag:  method to attach additional information before call  sd_setImageWithURL to show image.
2: for other situations, such as directly call [SDWebImageManager downloadImageWithURL.....] or [SDWebImageDownloader downloadImageWithURL....],  we could call [NSURL sd_setTag:] to attach additional informations before call those methods.