### PR TITLE
add a function in UIImageView category

### DIFF
--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -79,6 +79,7 @@
  *
  * @param url         The url for the image.
  * @param placeholder The image to be set initially, until the image request finishes.
+ * @param defaultImage The image will not be set , until the image request finishes and return nil.
  * @see sd_setImageWithURL:placeholderImage:options:
  */
 

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -73,6 +73,18 @@
 - (void)sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder;
 
 /**
+ * Set the imageView `image` with an `url` and a placeholder. If the `image` is nil , a defaultImage will be set.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url         The url for the image.
+ * @param placeholder The image to be set initially, until the image request finishes.
+ * @see sd_setImageWithURL:placeholderImage:options:
+ */
+
+- (void)sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder defaultImage:(UIImage *)defaultImage;
+
+/**
  * Set the imageView `image` with an `url`, placeholder and custom options.
  *
  * The download is asynchronous and cached.
@@ -81,6 +93,8 @@
  * @param placeholder The image to be set initially, until the image request finishes.
  * @param options     The options to use when downloading the image. @see SDWebImageOptions for the possible values.
  */
+
+
 - (void)sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options;
 
 /**

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -25,6 +25,14 @@ static char TAG_ACTIVITY_SHOW;
     [self sd_setImageWithURL:url placeholderImage:placeholder options:0 progress:nil completed:nil];
 }
 
+- (void)sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder defaultImage:(UIImage *)defaultImage {
+    [self sd_setImageWithURL:url placeholderImage:placeholder options:0 progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
+        if (image == nil) {
+            self.image = defaultImage;
+        }
+    }];
+}
+
 - (void)sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options {
     [self sd_setImageWithURL:url placeholderImage:placeholder options:options progress:nil completed:nil];
 }


### PR DESCRIPTION
Hey Olivier:

    Lots of developers around me have a problem ,if the sever return a nil for a image , SDWebimage will set the nil to the imageView , and that is not what we want.
 .  So I add a function , try to slove the problem .
    Could you place to merge it ?

    BTW thanks for your SDWebImage , help me a lot in my work. Best regards.