### PR TITLE
Fixed Offline/Online image download error #1282

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -194,7 +194,7 @@
 
                     BOOL shouldBeFailedURLAlliOSVersion = (error.code != NSURLErrorNotConnectedToInternet && error.code != NSURLErrorCancelled && error.code != NSURLErrorTimedOut);
                     BOOL shouldBeFailedURLiOS7 = (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_6_1 && error.code != NSURLErrorInternationalRoamingOff && error.code != NSURLErrorCallIsActive && error.code != NSURLErrorDataNotAllowed);
-                    if (shouldBeFailedURLAlliOSVersion || shouldBeFailedURLiOS7) {
+                    if (shouldBeFailedURLAlliOSVersion && shouldBeFailedURLiOS7) {
                         @synchronized (self.failedURLs) {
                             [self.failedURLs addObject:url];
                         }


### PR DESCRIPTION
The two conditions should be true at the same time in order to place a url in the failed list.
The url should make it to the failed url list id the error code is neither one of the error codes:
<li>
NSURLErrorNotConnectedToInternet
NSURLErrorCancelled
NSURLErrorTimedOut
NSURLErrorInternationalRoamingOff
NSURLErrorCallIsActive
NSURLErrorDataNotAllowed
</li>
and <li>
iOS version  > 6.1
 </li>