### PR TITLE
Returning the full response for error status codes

### DIFF
--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -56,6 +56,8 @@ extern UIImage *SDScaledImageForKey(NSString *key, UIImage *image);
 typedef void(^SDWebImageNoParamsBlock)();
 
 extern NSString *const SDWebImageErrorDomain;
+extern NSString *const SDWebImageErrorResponseKey;
+extern NSString *const SDWebImageErrorResponseDataKey;
 
 #define dispatch_main_sync_safe(block)\
     if ([NSThread isMainThread]) {\

--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -49,3 +49,5 @@ inline UIImage *SDScaledImageForKey(NSString *key, UIImage *image) {
 }
 
 NSString *const SDWebImageErrorDomain = @"SDWebImageErrorDomain";
+NSString *const SDWebImageErrorResponseKey = @"SDWebImageErrorResponseKey";
+NSString *const SDWebImageErrorResponseDataKey = @"SDWebImageErrorResponseDataKey";

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -56,7 +56,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
      * block which includes the entire response body. Set this flag if the response body may contain something that is important to
      * you such as a 404 image.
      */
-    SDWebImageDownloaderShouldFailSlow = 1 << 8,
+    SDWebImageDownloaderIncludesResponseOnFail = 1 << 8,
 };
 
 typedef NS_ENUM(NSInteger, SDWebImageDownloaderExecutionOrder) {

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -49,6 +49,14 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
      * Put the image in the high priority queue.
      */
     SDWebImageDownloaderHighPriority = 1 << 7,
+    
+    /**
+     * If the status code for the HTTP response is greater than or equal to 400, setting this flag will NOT immediately cancel
+     * the request. Instead the downloader will wait until the full response has been received and sends an error to the completion
+     * block which includes the entire response body. Set this flag if the response body may contain something that is important to
+     * you such as a 404 image.
+     */
+    SDWebImageDownloaderShouldFailSlow = 1 << 8,
 };
 
 typedef NS_ENUM(NSInteger, SDWebImageDownloaderExecutionOrder) {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -214,7 +214,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
     
     //'304 Not Modified' is an exceptional one
-    if (![response respondsToSelector:@selector(statusCode)] || ([((NSHTTPURLResponse *)response) statusCode] < 400 && [((NSHTTPURLResponse *)response) statusCode] != 304) || ([((NSHTTPURLResponse *)response) statusCode] >= 400 && (self.options & SDWebImageDownloaderShouldFailSlow))) {
+    if (![response respondsToSelector:@selector(statusCode)] || ([((NSHTTPURLResponse *)response) statusCode] < 400 && [((NSHTTPURLResponse *)response) statusCode] != 304) || ([((NSHTTPURLResponse *)response) statusCode] >= 400 && (self.options & SDWebImageDownloaderIncludesResponseOnFail))) {
         NSInteger expected = response.expectedContentLength > 0 ? (NSInteger)response.expectedContentLength : 0;
         self.expectedSize = expected;
         if (self.progressBlock) {
@@ -392,8 +392,8 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
                 }
             }
             
-            if ([((NSHTTPURLResponse *)self.response) statusCode] >= 400 && (self.options & SDWebImageDownloaderShouldFailSlow)) {
-                // Return the response body along with an error if SDWebImageDownloaderShouldFailSlow is set
+            if ([((NSHTTPURLResponse *)self.response) statusCode] >= 400 && (self.options & SDWebImageDownloaderIncludesResponseOnFail)) {
+                // Return the response body along with an error if SDWebImageDownloaderIncludesResponseOnFail is set
                 NSData *responseData = self.imageData == nil ? [NSData data] : self.imageData;
                 completionBlock(nil, nil, [NSError errorWithDomain:NSURLErrorDomain code:[((NSHTTPURLResponse *)self.response) statusCode] userInfo:@{SDWebImageErrorResponseKey : self.response, SDWebImageErrorResponseDataKey : responseData}], YES);
             } else {
@@ -405,8 +405,8 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
                 }
             }
         } else {
-            if ([((NSHTTPURLResponse *)self.response) statusCode] >= 400 && (self.options & SDWebImageDownloaderShouldFailSlow)) {
-                // Return the response body along with an error if SDWebImageDownloaderShouldFailSlow is set
+            if ([((NSHTTPURLResponse *)self.response) statusCode] >= 400 && (self.options & SDWebImageDownloaderIncludesResponseOnFail)) {
+                // Return the response body along with an error if SDWebImageDownloaderIncludesResponseOnFail is set
                 completionBlock(nil, nil, [NSError errorWithDomain:NSURLErrorDomain code:[((NSHTTPURLResponse *)self.response) statusCode] userInfo:@{SDWebImageErrorResponseKey : self.response}], YES);
             } else {
                 completionBlock(nil, nil, [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Image data is nil"}], YES);

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -214,7 +214,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
     
     //'304 Not Modified' is an exceptional one
-    if (![response respondsToSelector:@selector(statusCode)] || ([((NSHTTPURLResponse *)response) statusCode] < 400 && [((NSHTTPURLResponse *)response) statusCode] != 304)) {
+    if (![response respondsToSelector:@selector(statusCode)] || ([((NSHTTPURLResponse *)response) statusCode] < 400 && [((NSHTTPURLResponse *)response) statusCode] != 304) || ([((NSHTTPURLResponse *)response) statusCode] >= 400 && (self.options & SDWebImageDownloaderShouldFailSlow))) {
         NSInteger expected = response.expectedContentLength > 0 ? (NSInteger)response.expectedContentLength : 0;
         self.expectedSize = expected;
         if (self.progressBlock) {
@@ -391,14 +391,26 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
                     image = [UIImage decodedImageWithImage:image];
                 }
             }
-            if (CGSizeEqualToSize(image.size, CGSizeZero)) {
-                completionBlock(nil, nil, [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Downloaded image has 0 pixels"}], YES);
-            }
-            else {
-                completionBlock(image, self.imageData, nil, YES);
+            
+            if ([((NSHTTPURLResponse *)self.response) statusCode] >= 400 && (self.options & SDWebImageDownloaderShouldFailSlow)) {
+                // Return the response body along with an error if SDWebImageDownloaderShouldFailSlow is set
+                NSData *responseData = self.imageData == nil ? [NSData data] : self.imageData;
+                completionBlock(nil, nil, [NSError errorWithDomain:NSURLErrorDomain code:[((NSHTTPURLResponse *)self.response) statusCode] userInfo:@{SDWebImageErrorResponseKey : self.response, SDWebImageErrorResponseDataKey : responseData}], YES);
+            } else {
+                if (CGSizeEqualToSize(image.size, CGSizeZero)) {
+                    completionBlock(nil, nil, [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Downloaded image has 0 pixels"}], YES);
+                }
+                else {
+                    completionBlock(image, self.imageData, nil, YES);
+                }
             }
         } else {
-            completionBlock(nil, nil, [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Image data is nil"}], YES);
+            if ([((NSHTTPURLResponse *)self.response) statusCode] >= 400 && (self.options & SDWebImageDownloaderShouldFailSlow)) {
+                // Return the response body along with an error if SDWebImageDownloaderShouldFailSlow is set
+                completionBlock(nil, nil, [NSError errorWithDomain:NSURLErrorDomain code:[((NSHTTPURLResponse *)self.response) statusCode] userInfo:@{SDWebImageErrorResponseKey : self.response}], YES);
+            } else {
+                completionBlock(nil, nil, [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Image data is nil"}], YES);
+            }
         }
     }
     self.completionBlock = nil;

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -88,7 +88,16 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * have the hand before setting the image (apply a filter or add it with cross-fade animation for instance)
      * Use this flag if you want to manually set the image in the completion when success
      */
-    SDWebImageAvoidAutoSetImage = 1 << 11
+    SDWebImageAvoidAutoSetImage = 1 << 11,
+    
+    /**
+     * If the status code for the HTTP response is greater than or equal to 400, setting this flag will NOT immediately cancel
+     * the request. Instead the downloader will wait until the full response has been received and sends an error to the completion
+     * block which includes the entire response body. Set this flag if the response body may contain something that is important to
+     * you such as a 404 image.
+     */
+    SDWebImageShouldFailSlow = 1 << 12,
+    
 };
 
 typedef void(^SDWebImageCompletionBlock)(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL);

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -96,7 +96,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * block which includes the entire response body. Set this flag if the response body may contain something that is important to
      * you such as a 404 image.
      */
-    SDWebImageShouldFailSlow = 1 << 12,
+    SDWebImageIncludesResponseOnFail = 1 << 12,
     
 };
 

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -173,7 +173,7 @@
             if (options & SDWebImageHandleCookies) downloaderOptions |= SDWebImageDownloaderHandleCookies;
             if (options & SDWebImageAllowInvalidSSLCertificates) downloaderOptions |= SDWebImageDownloaderAllowInvalidSSLCertificates;
             if (options & SDWebImageHighPriority) downloaderOptions |= SDWebImageDownloaderHighPriority;
-            if (options & SDWebImageShouldFailSlow) downloaderOptions |= SDWebImageDownloaderShouldFailSlow;
+            if (options & SDWebImageIncludesResponseOnFail) downloaderOptions |= SDWebImageDownloaderIncludesResponseOnFail;
             if (image && options & SDWebImageRefreshCached) {
                 // force progressive off if image already cached but forced refreshing
                 downloaderOptions &= ~SDWebImageDownloaderProgressiveDownload;

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -173,6 +173,7 @@
             if (options & SDWebImageHandleCookies) downloaderOptions |= SDWebImageDownloaderHandleCookies;
             if (options & SDWebImageAllowInvalidSSLCertificates) downloaderOptions |= SDWebImageDownloaderAllowInvalidSSLCertificates;
             if (options & SDWebImageHighPriority) downloaderOptions |= SDWebImageDownloaderHighPriority;
+            if (options & SDWebImageShouldFailSlow) downloaderOptions |= SDWebImageDownloaderShouldFailSlow;
             if (image && options & SDWebImageRefreshCached) {
                 // force progressive off if image already cached but forced refreshing
                 downloaderOptions &= ~SDWebImageDownloaderProgressiveDownload;


### PR DESCRIPTION
My team at TrueCar needed to make some modifications to the library in order to get the full response from the server even when the status code was 404. Our server returns an 'image unavailable' 404 image and our app displays this image to the user.

The changes here enable this new functionality with a flag (SDWebImageIncludesResponseOnFail) that can be passed as an option. If this option is enabled and the download manager receives a response with a status code >= 400, the manager will NOT cancel the request and instead wait until the full response is received. When the full response id received, the completion block is called with an error that contains the NSURLResponse object and the request body NSData object.