### PR TITLE
Added support for SDWebImageAvoidAutoSetImage option to UIButton and …

### DIFF
--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -74,7 +74,12 @@ static char imageURLStorageKey;
         dispatch_main_sync_safe(^{
             __strong UIButton *sself = wself;
             if (!sself) return;
-            if (image) {
+            if (image && (options & SDWebImageAvoidAutoSetImage) && completedBlock)
+            {
+                completedBlock(image, error, cacheType, url);
+                return;
+            }
+            else if (image) {
                 [sself setImage:image forState:state];
             }
             if (completedBlock && finished) {
@@ -117,7 +122,12 @@ static char imageURLStorageKey;
             dispatch_main_sync_safe(^{
                 __strong UIButton *sself = wself;
                 if (!sself) return;
-                if (image) {
+                if (image && (options & SDWebImageAvoidAutoSetImage) && completedBlock)
+                {
+                    completedBlock(image, error, cacheType, url);
+                    return;
+                }
+                else if (image) {
                     [sself setBackgroundImage:image forState:state];
                 }
                 if (completedBlock && finished) {

--- a/SDWebImage/UIImageView+HighlightedWebCache.m
+++ b/SDWebImage/UIImageView+HighlightedWebCache.m
@@ -39,7 +39,12 @@
             dispatch_main_sync_safe (^
                                      {
                                          if (!wself) return;
-                                         if (image) {
+                                         if (image && (options & SDWebImageAvoidAutoSetImage) && completedBlock)
+                                         {
+                                             completedBlock(image, error, cacheType, url);
+                                             return;
+                                         }
+                                         else if (image) {
                                              wself.highlightedImage = image;
                                              [wself setNeedsLayout];
                                          }


### PR DESCRIPTION
…highlighted UIImageView categories

`SDWebImageAvoidAutoSetImage` option (which let the developer to manage the image in the completion block if download succeed instead of automatically set the image) was added by @bill350 in https://github.com/rs/SDWebImage/pull/1188 but only for **UIImageView+WebCache**.

I believe such useful option should be available for setting highlighted image of UIImageView and also for UIButton too - so added proper changes to  **UIImageView+HighlightedWebCache** and **UIButton+WebCache**. 
