### PR TITLE
Fixes a bug where image scale & orientation are ignored when decoding / decompressing an image.

### DIFF
--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -54,7 +54,7 @@
         // Draw the image into the context and retrieve the new image, which will now have an alpha layer
         CGContextDrawImage(context, CGRectMake(0, 0, width, height), imageRef);
         CGImageRef imageRefWithAlpha = CGBitmapContextCreateImage(context);
-        UIImage *imageWithAlpha = [UIImage imageWithCGImage:imageRefWithAlpha];
+        UIImage *imageWithAlpha = [UIImage imageWithCGImage:imageRefWithAlpha scale:image.scale orientation:image.imageOrientation];
     
         if (unsupportedColorSpace)
             CGColorSpaceRelease(colorspaceRef);


### PR DESCRIPTION
When downloading an image for the first time or retrieving the image from memory or disk cache, the image would be scaled correctly using SDScaledImageForKey in SDWebImageCompat, but later when it was being decompressed it would lose the correct scale. This decompression happens for all downloads, and for all memory or disk cache hits when shouldDecompressImages set to YES in SDImageCache.

For example, a 200x200px image @2x should report an image.size of 100x100pt rather than 200x200pt (which happens with this bug).

This issue was fixed years ago in f800a52f1c6eb409760bf14a5af5a636f3391100 but recently broken in 4cfb12c01cef5e4f45aa1215d38afcbb2381b594