### PR TITLE
Improved WebP support

### DIFF
--- a/SDWebImage/UIImage+WebP.h
+++ b/SDWebImage/UIImage+WebP.h
@@ -12,14 +12,13 @@
 
 // Fix for issue #416 Undefined symbols for architecture armv7 since WebP introduction when deploying to device
 void WebPInitPremultiplyNEON(void);
-
 void WebPInitUpsamplersNEON(void);
-
 void VP8DspInitNEON(void);
 
 @interface UIImage (WebP)
 
 + (UIImage *)sd_imageWithWebPData:(NSData *)data;
++ (UIImage *)sd_imageWithWebPData:(NSData *)data scale:(CGFloat)scale;
 
 @end
 

--- a/SDWebImage/UIImage+WebP.m
+++ b/SDWebImage/UIImage+WebP.m
@@ -16,14 +16,17 @@
 #endif
 
 // Callback for CGDataProviderRelease
-static void FreeImageData(void *info, const void *data, size_t size)
-{
+static void FreeImageData(void *info, const void *data, size_t size) {
     free((void *)data);
 }
 
-@implementation UIImage (WebP)
+@implementation UIImage (WebP);
 
 + (UIImage *)sd_imageWithWebPData:(NSData *)data {
+    return [self sd_imageWithWebPData:data scale:1.0];
+}
+
++ (UIImage *)sd_imageWithWebPData:(NSData *)data scale:(CGFloat)scale {
     WebPDecoderConfig config;
     if (!WebPInitDecoderConfig(&config)) {
         return nil;
@@ -33,8 +36,11 @@ static void FreeImageData(void *info, const void *data, size_t size)
         return nil;
     }
 
-    config.output.colorspace = config.input.has_alpha ? MODE_rgbA : MODE_RGB;
-    config.options.use_threads = 1;
+#if kCGBitmapByteOrder32Host == kCGBitmapByteOrder32Little
+    config.output.colorspace = config.input.has_alpha ? MODE_bgrA : MODE_RGB;
+#else
+    config.output.colorspace = config.input.has_alpha ? MODE_Argb : MODE_RGB;
+#endif
 
     // Decode the WebP image data into a RGBA value array.
     if (WebPDecode(data.bytes, data.length, &config) != VP8_STATUS_OK) {
@@ -48,19 +54,23 @@ static void FreeImageData(void *info, const void *data, size_t size)
         height = config.options.scaled_height;
     }
 
+#if kCGBitmapByteOrder32Host == kCGBitmapByteOrder32Little
+    const CGBitmapInfo bitmapInfo = config.input.has_alpha ? kCGBitmapByteOrder32Little | kCGImageAlphaPremultipliedFirst : kCGBitmapByteOrderDefault | kCGImageAlphaNone;
+#else
+    const CGBitmapInfo bitmapInfo = config.input.has_alpha ? kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedFirst : kCGBitmapByteOrderDefault | kCGImageAlphaNone;
+#endif
+
+    const size_t components = config.input.has_alpha ? 4 : 3;
+
     // Construct a UIImage from the decoded RGBA value array.
-    CGDataProviderRef provider =
-    CGDataProviderCreateWithData(NULL, config.output.u.RGBA.rgba, config.output.u.RGBA.size, FreeImageData);
+    CGDataProviderRef provider = CGDataProviderCreateWithData(NULL, config.output.u.RGBA.rgba, config.output.u.RGBA.size, FreeImageData);
     CGColorSpaceRef colorSpaceRef = CGColorSpaceCreateDeviceRGB();
-    CGBitmapInfo bitmapInfo = config.input.has_alpha ? kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast : 0;
-    size_t components = config.input.has_alpha ? 4 : 3;
-    CGColorRenderingIntent renderingIntent = kCGRenderingIntentDefault;
-    CGImageRef imageRef = CGImageCreate(width, height, 8, components * 8, components * width, colorSpaceRef, bitmapInfo, provider, NULL, NO, renderingIntent);
+    CGImageRef imageRef = CGImageCreate(width, height, 8, components * 8, config.output.u.RGBA.stride, colorSpaceRef, bitmapInfo, provider, NULL, NO, kCGRenderingIntentDefault);
 
     CGColorSpaceRelease(colorSpaceRef);
     CGDataProviderRelease(provider);
 
-    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef];
+    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
     CGImageRelease(imageRef);
 
     return image;


### PR DESCRIPTION
- Updated libwebp to v0.4.4
- Added `-[UIImage sd_imageWithWebPData:scale:]`
- Improved performance on iOS by removing `use_threads` and using
  `kCGBitmapByteOrder32Little`
