### PR TITLE
Add missing prefix to uiimageview category methods

### DIFF
--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -179,14 +179,14 @@
 /**
  *  Show activity UIActivityIndicatorView
  */
-- (void)setShowActivityIndicatorView:(BOOL)show;
+- (void)sd_setShowActivityIndicatorView:(BOOL)show;
 
 /**
  *  set desired UIActivityIndicatorViewStyle
  *
  *  @param style The style of the UIActivityIndicatorView
  */
-- (void)setIndicatorStyle:(UIActivityIndicatorViewStyle)style;
+- (void)sd_setIndicatorStyle:(UIActivityIndicatorViewStyle)style;
 
 @end
 
@@ -209,5 +209,8 @@
 - (void)cancelCurrentArrayLoad __deprecated_msg("Use `sd_cancelCurrentAnimationImagesLoad`");
 
 - (void)cancelCurrentImageLoad __deprecated_msg("Use `sd_cancelCurrentImageLoad`");
+
+- (void)setShowActivityIndicatorView:(BOOL)show __deprecated_msg("Use `sd_setShowActivityIndicatorView`");
+- (void)setIndicatorStyle:(UIActivityIndicatorViewStyle)style __deprecated_msg("Use `sd_setIndicatorStyle`");
 
 @end

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -155,7 +155,7 @@ static char TAG_ACTIVITY_SHOW;
     objc_setAssociatedObject(self, &TAG_ACTIVITY_INDICATOR, activityIndicator, OBJC_ASSOCIATION_RETAIN);
 }
 
-- (void)setShowActivityIndicatorView:(BOOL)show{
+- (void)sd_setShowActivityIndicatorView:(BOOL)show{
     objc_setAssociatedObject(self, &TAG_ACTIVITY_SHOW, [NSNumber numberWithBool:show], OBJC_ASSOCIATION_RETAIN);
 }
 
@@ -163,7 +163,7 @@ static char TAG_ACTIVITY_SHOW;
     return [objc_getAssociatedObject(self, &TAG_ACTIVITY_SHOW) boolValue];
 }
 
-- (void)setIndicatorStyle:(UIActivityIndicatorViewStyle)style{
+- (void)sd_setIndicatorStyle:(UIActivityIndicatorViewStyle)style{
     objc_setAssociatedObject(self, &TAG_ACTIVITY_STYLE, [NSNumber numberWithInt:style], OBJC_ASSOCIATION_RETAIN);
 }
 
@@ -272,6 +272,14 @@ static char TAG_ACTIVITY_SHOW;
 
 - (void)setAnimationImagesWithURLs:(NSArray *)arrayOfURLs {
     [self sd_setAnimationImagesWithURLs:arrayOfURLs];
+}
+
+- (void)setShowActivityIndicatorView:(BOOL)show {
+    [self sd_setShowActivityIndicatorView:show];
+}
+
+- (void)setIndicatorStyle:(UIActivityIndicatorViewStyle)style {
+    [self sd_setIndicatorStyle:style];
 }
 
 @end


### PR DESCRIPTION
The activity indicator methods on the UIImageView category methods are missing the `sd` prefix.