### PR TITLE
Add activity indicator category methods for UIButton

### DIFF
--- a/SDWebImage/UIButton+WebCache.h
+++ b/SDWebImage/UIButton+WebCache.h
@@ -199,6 +199,18 @@
  */
 - (void)sd_cancelBackgroundImageLoadForState:(UIControlState)state;
 
+/**
+ *  Show activity UIActivityIndicatorView
+ */
+- (void)sd_setShowActivityIndicatorView:(BOOL)show;
+
+/**
+ *  set desired UIActivityIndicatorViewStyle
+ *
+ *  @param style The style of the UIActivityIndicatorView
+ */
+- (void)sd_setIndicatorStyle:(UIActivityIndicatorViewStyle)style;
+
 @end
 
 


### PR DESCRIPTION
UIImageView+WebCache has support for displaying an activity indicator while loading an image, but this functionality is missing from UIButton+WebCache.