### PR TITLE
SDWebImageDownloader callbacks can only be canceled on the first downloadImageWithURL:options:progress:completed: call for a given URL

### DIFF
--- a/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
+++ b/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		5F7F38AD1AE2A77A00B0E330 /* TestImage.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5F7F38AC1AE2A77A00B0E330 /* TestImage.jpg */; };
 		ABC8501F672447AA91C788DA /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EB0D107E6B4C4094BA2FEE29 /* libPods-ios.a */; };
+		DA0832C91C123B8100D4F0A5 /* SDWebImageDownloaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DA0832C81C123B8100D4F0A5 /* SDWebImageDownloaderTests.m */; };
 		DA248D57195472AA00390AB0 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA248D56195472AA00390AB0 /* XCTest.framework */; };
 		DA248D59195472AA00390AB0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA248D58195472AA00390AB0 /* Foundation.framework */; };
 		DA248D5B195472AA00390AB0 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA248D5A195472AA00390AB0 /* UIKit.framework */; };
@@ -22,6 +23,7 @@
 		1A6DF883515E8008203AB352 /* Pods-ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.debug.xcconfig"; sourceTree = "<group>"; };
 		5F7F38AC1AE2A77A00B0E330 /* TestImage.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = TestImage.jpg; sourceTree = "<group>"; };
 		CA88E6BDE3581B2BFE933C10 /* Pods-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios/Pods-ios.release.xcconfig"; sourceTree = "<group>"; };
+		DA0832C81C123B8100D4F0A5 /* SDWebImageDownloaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDownloaderTests.m; sourceTree = "<group>"; };
 		DA248D53195472AA00390AB0 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA248D56195472AA00390AB0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		DA248D58195472AA00390AB0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -96,6 +98,7 @@
 				DA248D68195475D800390AB0 /* SDImageCacheTests.m */,
 				DA248D6A195476AC00390AB0 /* SDWebImageManagerTests.m */,
 				DA91BEBB19795BC9006F2536 /* UIImageMultiFormatTests.m */,
+				DA0832C81C123B8100D4F0A5 /* SDWebImageDownloaderTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -209,6 +212,7 @@
 			files = (
 				DA248D69195475D800390AB0 /* SDImageCacheTests.m in Sources */,
 				DA248D6B195476AC00390AB0 /* SDWebImageManagerTests.m in Sources */,
+				DA0832C91C123B8100D4F0A5 /* SDWebImageDownloaderTests.m in Sources */,
 				DA91BEBC19795BC9006F2536 /* UIImageMultiFormatTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -1,0 +1,66 @@
+//
+//  UIImageViewWebCacheTests.m
+//  SDWebImage Tests
+//
+//  Created by Mariano Heredia on 12/4/15.
+//
+//
+
+#define EXP_SHORTHAND   // required by Expecta
+
+
+#import <XCTest/XCTest.h>
+#import <Expecta.h>
+#import "SDWebImageDownloader.h"
+
+static int64_t kAsyncTestTimeout = 5;
+
+@interface UIImageViewWebCacheTests : XCTestCase
+
+@end
+
+
+@implementation UIImageViewWebCacheTests
+
+
+- (void)testThatCanceledDownloadDoNotInvokeProgressBlock {
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"Progress block canceled"];
+    
+    NSURL *imageURL = [NSURL URLWithString:@"https://duckduckgo.com/assets/icons/meta/DDG-icon_256x256.png"];
+
+    __block BOOL secondOperationHasBeenCanceled = NO;
+    
+    // Starts downloading a given URL
+    [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL
+                                                          options:0
+                                                   progress:^(NSInteger receivedSize, NSInteger expectedSize) {}
+                                                  completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {
+                                                      [expectation fulfill];
+                                                      expectation = nil;
+                                                      
+                                                  }];
+    
+    SDWebImageDownloaderProgressBlock progressBlock1 = ^(NSInteger receivedSize, NSInteger expectedSize) {
+        // Check if this progress block still needs to be called.
+        expect(secondOperationHasBeenCanceled).equal(NO);
+    };
+    
+
+    // Start a second download operation for the same imageURL
+    id <SDWebImageOperation> o = [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL
+                                                    options:0
+                                                   progress:progressBlock1
+                                                  completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {}];
+    
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.001 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        // Shortly after, cancel the download operation...
+        [o cancel];
+        secondOperationHasBeenCanceled = YES;
+    });
+
+    
+    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+}
+
+@end


### PR DESCRIPTION
Fixes a bug on `SDWebImageDownloader` where the callbacks can only be canceled on the first `downloadImageWithURL:options:progress:completed:` call for a given URL – the one that started the URL request operation.

The first call to `downloadImageWithURL:options:progress:completed:` for a given URL creates and return the download operation. From the second call on – the 1st operation for the same URL hasn't finished yet – no download operation is created and the callbacks are stored to be called when the URL download operation finishes.

The problem is that calls which return no download operation can't be canceled and it's callbacks will be called anyways.

**The fix approach**

* `SDWebImageDownloaderCancelableCallbacksOperation` class is introduced
  * it conforms to `SDWebImageOperation` protocol
  * it has a `cancelCallbacksBlock` property
* `addProgressCallback:andCompletedBlock:forURL:createCallback:` now returns an instance of `SDWebImageDownloaderCancelableCallbacksOperation` with the `cancelCallbacksBlock` set to remove the callbakcs
* `downloadImageWithURL:options:progress:completed:` returns the download operation if it's the 1st call or the cancelableCallbacksOperation for 2nd call on

**Test included**

`SDWebImageDownloaderTests`.m file which implements `testThatCanceledDownloadDoNotInvokeProgressBlock.`