### PR TITLE
fix cache location paths for init and initWithNameSpace:

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -84,8 +84,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 }
 
 - (id)initWithNamespace:(NSString *)ns {
-    NSString *path = [self makeDiskCachePath:ns];
-    return [self initWithNamespace:ns diskCacheDirectory:path];
+    return [self initWithNamespace:ns diskCacheDirectory:nil];
 }
 
 - (id)initWithNamespace:(NSString *)ns diskCacheDirectory:(NSString *)directory {


### PR DESCRIPTION
When calling init and initWithNameSpace: I believe it is expected that the cache will go in Library/Caches/<namespace>, while calling initWithNamespace:diskCacheDirectory: with directory not nil the user wants a different location for the namespaces, so they'll go to <directory>/<full_namespace>.

Without this change, the cache will end up in Library/Caches/<namespace>/<full_namespace>.