### PR TITLE
added CMYK unsupported color space model

### DIFF
--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -40,7 +40,7 @@
         CGColorSpaceModel imageColorSpaceModel = CGColorSpaceGetModel(CGImageGetColorSpace(imageRef));
         CGColorSpaceRef colorspaceRef = CGImageGetColorSpace(imageRef);
         
-        bool unsupportedColorSpace = (imageColorSpaceModel == 0 || imageColorSpaceModel == -1 || imageColorSpaceModel == kCGColorSpaceModelIndexed);
+        bool unsupportedColorSpace = (imageColorSpaceModel == 0 || imageColorSpaceModel == -1 || imageColorSpaceModel == kCGColorSpaceModelCMYK || imageColorSpaceModel == kCGColorSpaceModelIndexed);
         if (unsupportedColorSpace)
             colorspaceRef = CGColorSpaceCreateDeviceRGB();
     


### PR DESCRIPTION
This pull request fixes https://github.com/rs/SDWebImage/issues/1382 adding CMYK to the list of unsupported color space models.

Without forcing the ColorSpace to RGB when decoding the image it's not possible to add the Alpha channel.

I have also attached an example project that replicate this problem, even is trivial to reproduce, all you have to do is to try to download this image `https://d262o8ek72aza.cloudfront.net/mimg/debenhams_125x125_2.gif`.

Follows the logs showing the issue:
```
Dec 30 15:46:28  webimagetest[57562] <Error>: 
	CGBitmapContextCreate: unsupported parameter combination:
	 	8 integer bits/component;
	 	40 bits/pixel;
		CMYK color space model; kCGImageAlphaPremultipliedFirst;
		640 bytes/row.
	Valid parameters for CMYK color space model are:
		32  bits per pixel,		 8  bits per component,		 kCGImageAlphaNone
		64  bits per pixel,		 16 bits per component,		 kCGImageAlphaNone
		128 bits per pixel,		 32 bits per component,		 kCGImageAlphaNone |kCGBitmapFloatComponentsSee Quartz 2D Programming Guide (available online) for more information.
Dec 30 15:46:28  webimagetest[57562] <Error>: CGContextDrawImage: invalid context 0x0. Backtrace:
	  <-[SDImageCache diskImageForKey:]+235>
	   <__42-[SDImageCache queryDiskCacheForKey:done:]_block_invoke+115>
	    <_dispatch_call_block_and_release+12>
	     <_dispatch_client_callout+8>
	      <_dispatch_queue_drain+2215>
	       <_dispatch_queue_invoke+601>
	        <_dispatch_root_queue_drain+1420>
	         <_dispatch_worker_thread3+111>
	          <_pthread_wqthread+1129>
Dec 30 15:46:28  webimagetest[57562] <Error>: CGBitmapContextCreateImage: invalid context 0x0. Backtrace:
	  <+[UIImage(ForceDecode) decodedImageWithImage:]+755>
	   <-[SDImageCache diskImageForKey:]+235>
	    <__42-[SDImageCache queryDiskCacheForKey:done:]_block_invoke+115>
	     <_dispatch_call_block_and_release+12>
	      <_dispatch_client_callout+8>
	       <_dispatch_queue_drain+2215>
	        <_dispatch_queue_invoke+601>
	         <_dispatch_root_queue_drain+1420>
	          <_dispatch_worker_thread3+111>
	           <_pthread_wqthread+1129>
Dec 30 15:46:29  webimagetest[57562] <Error>: 
	CGBitmapContextCreate: unsupported parameter combination:
	 	8 integer bits/component;
	 	40 bits/pixel;
		CMYK color space model; kCGImageAlphaPremultipliedFirst;
		640 bytes/row.
	Valid parameters for CMYK color space model are:
		32  bits per pixel,		 8  bits per component,		 kCGImageAlphaNone
		64  bits per pixel,		 16 bits per component,		 kCGImageAlphaNone
		128 bits per pixel,		 32 bits per component,		 kCGImageAlphaNone |kCGBitmapFloatComponentsSee Quartz 2D Programming Guide (available online) for more information.
Dec 30 15:46:29  webimagetest[57562] <Error>: CGContextDrawImage: invalid context 0x0. Backtrace:
	  <-[SDWebImageDownloaderOperation connectionDidFinishLoading:]+1274>
	   <__65-[NSURLConnectionInternal _withConnectionAndDelegate:onlyActive:]_block_invoke+69>
	    <-[NSURLConnectionInternal _withConnectionAndDelegate:onlyActive:]+199>
	     <-[NSURLConnectionInternal _withActiveConnectionAndDelegate:]+48>
	      <___ZN27URLConnectionClient_Classic26_delegate_didFinishLoadingEU13block_pointerFvvE_block_invoke+104>
	       <___ZN27URLConnectionClient_Classic18_withDelegateAsyncEPKcU13block_pointerFvP16_CFURLConnectionPK33CFURLConnectionClien
	        <_dispatch_client_callout+8>
	         <_dispatch_block_invoke+716>
	          <_ZN19RunloopBlockContext13_invoke_blockEPKvPv+24>
	           <CFArrayApplyFunction+68>
	            <_ZN19RunloopBlockContext7performEv+137>
	             <_ZN17MultiplexerSource7performEv+282>
	              <_ZN17MultiplexerSource8_performEPv+72>
	               <__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+17>
	                <__CFRunLoopDoSources0+556>
	                 <__CFRunLoopRun+867>
	                  <CFRunLoopRunSpecific+488>
	                   <CFRunLoopRun+97>
	                    <-[SDWebImageDownloaderOperation start]+1868>
	                     <__NSOQSchedule_f+194>
	                      <_dispatch_client_callout+8>
	                       <_dispatch_queue_drain+2215>
	                        <_dispatch_queue_invoke+601>
	                         <_dispatch_root_queue_drain+1420>
	                          <_dispatch_worker_thread3+111>
	                           <_pthread_wqthread+1129>
Dec 30 15:46:29  webimagetest[57562] <Error>: CGBitmapContextCreateImage: invalid context 0x0. Backtrace:
	  <+[UIImage(ForceDecode) decodedImageWithImage:]+755>
	   <-[SDWebImageDownloaderOperation connectionDidFinishLoading:]+1274>
	    <__65-[NSURLConnectionInternal _withConnectionAndDelegate:onlyActive:]_block_invoke+69>
	     <-[NSURLConnectionInternal _withConnectionAndDelegate:onlyActive:]+199>
	      <-[NSURLConnectionInternal _withActiveConnectionAndDelegate:]+48>
	       <___ZN27URLConnectionClient_Classic26_delegate_didFinishLoadingEU13block_pointerFvvE_block_invoke+104>
	        <___ZN27URLConnectionClient_Classic18_withDelegateAsyncEPKcU13block_pointerFvP16_CFURLConnectionPK33CFURLConnectionClie
	         <_dispatch_client_callout+8>
	          <_dispatch_block_invoke+716>
	           <_ZN19RunloopBlockContext13_invoke_blockEPKvPv+24>
	            <CFArrayApplyFunction+68>
	             <_ZN19RunloopBlockContext7performEv+137>
	              <_ZN17MultiplexerSource7performEv+282>
	               <_ZN17MultiplexerSource8_performEPv+72>
	                <__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__+17>
	                 <__CFRunLoopDoSources0+556>
	                  <__CFRunLoopRun+867>
	                   <CFRunLoopRunSpecific+488>
	                    <CFRunLoopRun+97>
	                     <-[SDWebImageDownloaderOperation start]+1868>
	                      <__NSOQSchedule_f+194>
	                       <_dispatch_client_callout+8>
	                        <_dispatch_queue_drain+2215>
	                         <_dispatch_queue_invoke+601>
	                          <_dispatch_root_queue_drain+1420>
	                           <_dispatch_worker_thread3+111>
	                            <_pthread_wqthread+1129>
```
[SDWebImage.zip](https://github.com/rs/SDWebImage/files/74950/SDWebImage.zip)
