### PR TITLE
Protect against malformed frame

### DIFF
--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -32,8 +32,9 @@
 
         for (size_t i = 0; i < count; i++) {
             CGImageRef image = CGImageSourceCreateImageAtIndex(source, i, NULL);
-            if (!image)
+            if (!image) {
                 continue;
+            }
 
             duration += [self sd_frameDurationAtIndex:i source:source];
 

--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -32,6 +32,8 @@
 
         for (size_t i = 0; i < count; i++) {
             CGImageRef image = CGImageSourceCreateImageAtIndex(source, i, NULL);
+            if (!image)
+                continue;
 
             duration += [self sd_frameDurationAtIndex:i source:source];
 


### PR DESCRIPTION
We came upon an amimated gif that contained a frame that would return a nil CGImageRef, when adding this image reference to the image array, our app crashed. 
This is the bad gif:
![12f62f3e2cb15337](https://cloud.githubusercontent.com/assets/541179/12566808/7c51b30e-c370-11e5-9c93-db7abbd1315b.gif)

This change skips the malformed frames and avoids the crash. 
