### PR TITLE
Updated dispatch_ macro in order to avoid redefinition when included as Pod

### DIFF
--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -57,16 +57,20 @@ typedef void(^SDWebImageNoParamsBlock)();
 
 extern NSString *const SDWebImageErrorDomain;
 
+#ifndef dispatch_main_sync_safe
 #define dispatch_main_sync_safe(block)\
     if ([NSThread isMainThread]) {\
         block();\
     } else {\
         dispatch_sync(dispatch_get_main_queue(), block);\
     }
+#endif
 
+#ifndef dispatch_main_async_safe
 #define dispatch_main_async_safe(block)\
     if ([NSThread isMainThread]) {\
         block();\
     } else {\
         dispatch_async(dispatch_get_main_queue(), block);\
     }
+#endif


### PR DESCRIPTION
I wanted to have 0 warning coming from my Pods but SDWebImage had this warning about Macro redefinition.
In our own project we also had the dispatch_main_sync_safe macro.

by simply adding #ifndef dispatch_main_sync_safe
It will now display no warning in such specific case.