### PR TITLE
Improve documentation for SDWebImageHighPriority

### DIFF
--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -64,9 +64,8 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     SDWebImageAllowInvalidSSLCertificates = 1 << 7,
 
     /**
-     * By default, image are loaded in the order they were queued. This flag move them to
-     * the front of the queue and is loaded immediately instead of waiting for the current queue to be loaded (which 
-     * could take a while).
+     * By default, images are loaded in the order in which they were queued. This flag moves them to
+     * the front of the queue.
      */
     SDWebImageHighPriority = 1 << 8,
     


### PR DESCRIPTION
- Fixed grammar issues in the first sentence.
- Removed the second sentence since it is redundant. Moving to the front of the queue implies that they will be loaded first. Also doesn't seem necessary to inform the user that the queued images might take a while to download.