### PR TITLE
Remove XML special characters from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009 Olivier Poitrey rs@dailymotion.com
+Copyright (c) 2016 Olivier Poitrey rs@dailymotion.com
  
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009 Olivier Poitrey <rs@dailymotion.com>
+Copyright (c) 2009 Olivier Poitrey rs@dailymotion.com
  
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Here is the story.

I'd like to show the LICENSE on TVML, but since TVML is just a kind of XML, TVMLKit's DOMParser cannot parse XML special characters.  
We need to escape these characters to let DOMParser parse the strings.  
Since not every one would use TVML, I didn't escape them but deleted.