### PR TITLE
resolve problem when use SDWebImageDelayPlaceholder and dequeued tabl…

### DIFF
--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -49,6 +49,10 @@ static char TAG_ACTIVITY_SHOW;
         dispatch_main_async_safe(^{
             self.image = placeholder;
         });
+    } else {
+        dispatch_main_async_safe(^{
+            self.image = nil;
+        });
     }
     
     if (url) {


### PR DESCRIPTION
when use SDWebImageDelayPlaceholder ，
tableViewCell.imageView.image will use image in dequeued cell temporarily.
