### PR TITLE
- 404 http status code handling

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -214,7 +214,8 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
     
     //'304 Not Modified' is an exceptional one
-    if (![response respondsToSelector:@selector(statusCode)] || ([((NSHTTPURLResponse *)response) statusCode] < 400 && [((NSHTTPURLResponse *)response) statusCode] != 304)) {
+    //'404 Not Found' response body may contain an image
+    if (![response respondsToSelector:@selector(statusCode)] || (response.expectedContentLength > 0 && [((NSHTTPURLResponse *)response) statusCode] == 404 && [[response MIMEType] hasPrefix:@"image"]) ||  ([((NSHTTPURLResponse *)response) statusCode] < 400 && [((NSHTTPURLResponse *)response) statusCode] != 304)) {
         NSInteger expected = response.expectedContentLength > 0 ? (NSInteger)response.expectedContentLength : 0;
         self.expectedSize = expected;
         if (self.progressBlock) {


### PR DESCRIPTION
Response body may contain an image.
For example see https://i.ytimg.com/vi/Ly_cr9GByj8/default.jpg