### PR TITLE
Fixed changed image size (#1437)

### DIFF
--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -28,7 +28,7 @@ inline UIImage *SDScaledImageForKey(NSString *key, UIImage *image) {
     }
     else {
         if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
-            CGFloat scale = [UIScreen mainScreen].scale;
+            CGFloat scale = 1;
             if (key.length >= 8) {
                 NSRange range = [key rangeOfString:@"@2x."];
                 if (range.location != NSNotFound) {


### PR DESCRIPTION
Images without a specified resolution (@2x, @3x etc) shouldn't be resized when loaded from the cache. Instead, the original size and (1x) resolution should be maintained.