### PR TITLE
Fixed completion logic in MKAnnotationView+WebCache

### DIFF
--- a/SDWebImage/MKAnnotationView+WebCache.m
+++ b/SDWebImage/MKAnnotationView+WebCache.m
@@ -51,8 +51,17 @@ static char imageURLKey;
             dispatch_main_sync_safe(^{
                 __strong MKAnnotationView *sself = wself;
                 if (!sself) return;
-                if (image) {
-                    sself.image = image;
+                if (image && (options & SDWebImageAvoidAutoSetImage) && completedBlock) {
+                    completedBlock(image, error, cacheType, url);
+                    return;
+                } else if (image) {
+                    wself.image = image;
+                    [wself setNeedsLayout];
+                } else {
+                    if ((options & SDWebImageDelayPlaceholder)) {
+                        wself.image = placeholder;
+                        [wself setNeedsLayout];
+                    }
                 }
                 if (completedBlock && finished) {
                     completedBlock(image, error, cacheType, url);


### PR DESCRIPTION
MKAnnotationView+WebCache partially ignores the options parameter. Options like SDWebImageAvoidAutoSetImage and SDWebImageDelayPlaceholder are very useful even in MKAnnotationView. 

This PR adds in the completion handler of method downloadImageWithURL:options:progress:complete: the same logic used in UIImageView+WebCache.
