### PR TITLE
Repair memory release in the iPad environment

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -126,7 +126,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             _fileManager = [NSFileManager new];
         });
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
         // Subscribe to app events
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(clearMemory)


### PR DESCRIPTION
In the iPad environment, NSCache lead to anonymous VM very high, if reaches a certain value, app will be crash. Because of SDImageCache don't clear memory when receive memory warning notification, modify define TARGET_OS_IPHONE to TARGET_OS_IOS can resolve this issue.