### PR TITLE
Add SDImageDownloadGroupManage

### DIFF
--- a/SDWebImage/MSDImageDownloadGroup/MSDImageDownloadGroupManage.h
+++ b/SDWebImage/MSDImageDownloadGroup/MSDImageDownloadGroupManage.h
@@ -1,0 +1,37 @@
+//
+//  MSDImageDownloadGroupManage.h
+//  vb
+//
+//  Created by 马权 on 3/17/16.
+//  Copyright © 2016 maquan. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+FOUNDATION_EXPORT NSString *const MSDImageDownloadDefaultGroupIdentifier;
+
+@protocol SDWebImageOperation;
+
+@interface MSDImageDownloadGroup : NSObject
+
+@property (nonatomic, assign) NSInteger maxConcurrentDownloads;
+
+- (instancetype)initWithGroupIdentifier:(NSString *)identifier NS_DESIGNATED_INITIALIZER;
+
+@end
+
+@interface MSDImageDownloadGroupManage : NSObject
+
++ (instancetype)shareInstance;
+
+- (void)addGroup:(MSDImageDownloadGroup *)group;
+
+- (void)removeGroupWithIdentifier:(NSString *)identifier;
+
+- (void)setImageDownLoadOperation:(id<SDWebImageOperation>)operation toGroup:(NSString *)identifier forKey:(NSString *)key;
+
+- (void)removeImageDownLoadOperation:(id<SDWebImageOperation>)operation fromGroup:(NSString *)identifier forKey:(NSString *)key;
+
+- (void)debug:(BOOL)debug;
+
+@end

--- a/SDWebImage/MSDImageDownloadGroup/MSDImageDownloadGroupManage.m
+++ b/SDWebImage/MSDImageDownloadGroup/MSDImageDownloadGroupManage.m
@@ -1,0 +1,163 @@
+//
+//  MSDImageDownloadGroupManage.m
+//  vb
+//
+//  Created by 马权 on 3/17/16.
+//  Copyright © 2016 maquan. All rights reserved.
+//
+
+#import "MSDImageDownloadGroupManage.h"
+#import "SDWebImageManager.h"
+
+NSString *const MSDImageDownloadDefaultGroupIdentifier = @"msd.download.group.default";
+
+@interface MSDImageDownloadGroup ()
+
+{
+@public
+    NSMutableDictionary<NSString *, NSMutableArray<id<SDWebImageOperation>> *> *_downloadOperationsDic;
+    NSMutableArray<NSString *> *_downloadOperationKeys;
+    NSString *_identifier;
+}
+
+@end
+
+@implementation MSDImageDownloadGroup
+
+- (instancetype)init
+{
+    self = [self initWithGroupIdentifier:MSDImageDownloadDefaultGroupIdentifier];
+    if (self) {
+
+    }
+    return self;
+}
+
+- (instancetype)initWithGroupIdentifier:(NSString *)identifier
+{
+    self = [super init];
+    if (self) {
+        _downloadOperationsDic = [@{} mutableCopy];
+        _downloadOperationKeys = [@[] mutableCopy];
+        _maxConcurrentDownloads = 20;
+        _identifier = [identifier copy];
+    }
+    return self;
+}
+
+@end
+
+@implementation MSDImageDownloadGroupManage
+
+{
+    NSMutableDictionary<NSString *, MSDImageDownloadGroup *> *_downloadGroupsDic;
+}
+
++ (instancetype)shareInstance
+{
+    static id instance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[MSDImageDownloadGroupManage alloc] init];
+    });
+    return instance;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _downloadGroupsDic = [@{} mutableCopy];
+    }
+    return self;
+}
+
+
+//  MARK: Public
+- (void)addGroup:(MSDImageDownloadGroup *)group
+{
+    MSDImageDownloadGroup *downloadGroup = _downloadGroupsDic[group->_identifier];
+    if (downloadGroup) {
+        return;
+    }
+    _downloadGroupsDic[group->_identifier] = group;
+}
+
+- (void)removeGroupWithIdentifier:(NSString *)identifier
+{
+    [_downloadGroupsDic removeObjectForKey:identifier];
+}
+
+- (void)setImageDownLoadOperation:(id<SDWebImageOperation>)operation toGroup:(NSString *)identifier forKey:(NSString *)key
+{
+    MSDImageDownloadGroup *downloadGroup = _downloadGroupsDic[identifier];
+    if (!downloadGroup) {
+        downloadGroup = [[MSDImageDownloadGroup alloc] initWithGroupIdentifier:identifier];
+        _downloadGroupsDic[identifier] = downloadGroup;
+    }
+    
+    NSMutableArray<NSString *> *downloadOperationKeys = downloadGroup->_downloadOperationKeys;
+    
+    if (downloadGroup && downloadOperationKeys) {
+        if ([downloadOperationKeys containsObject:key]) {
+            [downloadOperationKeys removeObject:key];
+            [downloadOperationKeys insertObject:key atIndex:0];
+            NSMutableArray<id<SDWebImageOperation>> *operations = downloadGroup->_downloadOperationsDic[key];
+            [operations addObject:operation];
+        }
+        else {
+            NSMutableArray<id<SDWebImageOperation>> *operations = [@[operation] mutableCopy];
+            downloadGroup->_downloadOperationsDic[key] = operations;
+            [downloadOperationKeys insertObject:key atIndex:0];
+        }
+        if ([downloadOperationKeys count] > downloadGroup.maxConcurrentDownloads) {
+            NSString *lastKey = [downloadOperationKeys lastObject];
+            NSMutableArray<id<SDWebImageOperation>> *lastOperations = downloadGroup->_downloadOperationsDic[lastKey];
+            [lastOperations makeObjectsPerformSelector:@selector(cancel)];
+            [downloadGroup->_downloadOperationsDic removeObjectForKey:lastKey];
+            [downloadOperationKeys removeLastObject];
+        }
+    }
+    else {
+        NSMutableArray<id<SDWebImageOperation>> *operations = [@[operation] mutableCopy];
+        
+        downloadGroup = [[MSDImageDownloadGroup alloc] initWithGroupIdentifier:identifier];
+        _downloadGroupsDic[identifier] = downloadGroup;
+        
+        downloadGroup->_downloadOperationKeys[0] = identifier;
+        downloadGroup->_downloadOperationsDic[identifier] = operations;
+    }
+}
+
+- (void)removeImageDownLoadOperation:(id<SDWebImageOperation>)operation fromGroup:(NSString *)identifier forKey:(NSString *)key
+{
+    if (_debug) {
+        NSLog(@"groups count = %lu\n", (unsigned long)_downloadGroupsDic.count);
+        [_downloadGroupsDic enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, MSDImageDownloadGroup * _Nonnull obj, BOOL * _Nonnull stop) {
+            NSLog(@"group id = %@, key count = %lu\n", obj->_identifier, (unsigned long)obj->_downloadOperationsDic.count);
+            [obj->_downloadOperationsDic enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, NSMutableArray<id<SDWebImageOperation>> * _Nonnull obj, BOOL * _Nonnull stop) {
+                NSLog(@"operation key = %@, operation count = %lu\n", key,  obj.count);
+                [obj enumerateObjectsUsingBlock:^(id<SDWebImageOperation>  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+                    NSLog(@"operation = %@", obj);
+                }];
+            }];
+        }];
+    }
+
+    MSDImageDownloadGroup *downloadGroup = _downloadGroupsDic[identifier];
+    NSMutableArray<id<SDWebImageOperation>> *operations = downloadGroup->_downloadOperationsDic[key];
+    [operations removeObject:operation];
+    if (operations.count == 0) {
+        [downloadGroup->_downloadOperationKeys removeObject:key];
+        [downloadGroup->_downloadOperationsDic removeObjectForKey:key];
+    }
+}
+
+static BOOL _debug = NO;
+
+- (void)debug:(BOOL)debug
+{
+    _debug = debug;
+}
+
+@end

--- a/SDWebImage/MSDImageDownloadGroup/UIImageView+msd_WebCache.h
+++ b/SDWebImage/MSDImageDownloadGroup/UIImageView+msd_WebCache.h
@@ -1,0 +1,33 @@
+//
+//  UIImageView+msd_WebCache.h
+//  vb
+//
+//  Created by 马权 on 3/17/16.
+//  Copyright © 2016 maquan. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@import SDWebImage;
+
+@interface UIImageView (msd_WebCache)
+
+- (NSURL *)msd_imageURL;
+
+- (void)msd_setImageWithURL:(NSURL *)url;
+
+- (void)msd_setImageWithURL:(NSURL *)url groupIdentifier:(NSString *)identifier;
+
+- (void)msd_setImageWithURL:(NSURL *)url groupIdentifier:(NSString *)identifier placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options;
+
+- (void)msd_setImageWithURL:(NSURL *)url completed:(SDWebImageCompletionBlock)completedBlock;
+
+- (void)msd_setImageWithURL:(NSURL *)url groupIdentifier:(NSString *)identifier completed:(SDWebImageCompletionBlock)completedBlock;
+
+- (void)msd_setImageWithURL:(NSURL *)url groupIdentifier:(NSString *)identifier placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options completed:(SDWebImageCompletionBlock)completedBlock;
+
+- (void)msd_setImageWithURL:(NSURL *)url groupIdentifier:(NSString *)identifier placeholderImage:(UIImage *)placeholder options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageCompletionBlock)completedBlock;
+
+- (void)msd_cancelCurrentImageDownload;
+
+@end

--- a/SDWebImage/MSDImageDownloadGroup/UIImageView+msd_WebCache.m
+++ b/SDWebImage/MSDImageDownloadGroup/UIImageView+msd_WebCache.m
@@ -1,0 +1,172 @@
+//
+//  UIImageView+msd_WebCache.m
+//  vb
+//
+//  Created by 马权 on 3/17/16.
+//  Copyright © 2016 maquan. All rights reserved.
+//
+
+#import "UIImageView+msd_WebCache.h"
+#import "SDWebImageManager.h"
+#import "MSDImageDownloadGroupManage.h"
+#import "objc/runtime.h"
+
+@interface UIImageView ()
+
+@property (nonatomic, strong) NSURL *msd_imageURL;
+@property (nonatomic, copy) NSString *msd_downloadGroupIdentifier;
+@property (nonatomic, strong) id<SDWebImageOperation> msd_operation;
+
+@end
+
+@implementation UIImageView (msd_WebCache)
+
+//  MARK: Public
+- (void)msd_setImageWithURL:(NSURL *)url
+{
+    [self msd_setImageWithURL:url groupIdentifier:MSDImageDownloadDefaultGroupIdentifier placeholderImage:nil options:0 progress:nil completed:nil];
+}
+
+- (void)msd_setImageWithURL:(NSURL *)url
+           groupIdentifier:(NSString *)identifier
+{
+    [self msd_setImageWithURL:url groupIdentifier:identifier placeholderImage:nil options:0 progress:nil completed:nil];
+}
+
+- (void)msd_setImageWithURL:(NSURL *)url
+           groupIdentifier:(NSString *)identifier
+          placeholderImage:(UIImage *)placeholder
+                   options:(SDWebImageOptions)options
+{
+    [self msd_setImageWithURL:url groupIdentifier:identifier placeholderImage:placeholder options:options progress:nil completed:nil];
+}
+
+- (void)msd_setImageWithURL:(NSURL *)url
+                 completed:(SDWebImageCompletionBlock)completedBlock
+{
+    [self msd_setImageWithURL:url groupIdentifier:MSDImageDownloadDefaultGroupIdentifier placeholderImage:nil options:0 progress:nil completed:completedBlock];
+}
+
+- (void)msd_setImageWithURL:(NSURL *)url
+           groupIdentifier:(NSString *)identifier
+                 completed:(SDWebImageCompletionBlock)completedBlock
+{
+    [self msd_setImageWithURL:url groupIdentifier:identifier placeholderImage:nil options:0 progress:nil completed:completedBlock];
+}
+
+- (void)msd_setImageWithURL:(NSURL *)url
+           groupIdentifier:(NSString *)identifier
+          placeholderImage:(UIImage *)placeholder
+                   options:(SDWebImageOptions)options
+                 completed:(SDWebImageCompletionBlock)completedBlock
+{
+    [self msd_setImageWithURL:url groupIdentifier:identifier placeholderImage:placeholder options:options progress:nil completed:completedBlock];
+}
+
+- (void)msd_setImageWithURL:(NSURL *)url
+           groupIdentifier:(NSString *)identifier
+          placeholderImage:(UIImage *)placeholder
+                   options:(SDWebImageOptions)options
+                  progress:(SDWebImageDownloaderProgressBlock)progressBlock
+                 completed:(SDWebImageCompletionBlock)completedBlock
+{
+    self.msd_imageURL = url;
+    
+    __weak typeof(self) weakSelf = self;
+    if (!(options & SDWebImageDelayPlaceholder)) {
+        dispatch_main_async_safe(^{
+            if (!weakSelf) {
+                return;
+            }
+            if ([weakSelf.msd_imageURL.absoluteString isEqualToString:url.absoluteString]) {
+                weakSelf.image = placeholder;
+            }
+        });
+    }
+    
+    if (url) {
+        __weak typeof(self) weakSelf = self;
+        __block id <SDWebImageOperation> operation = [[SDWebImageManager sharedManager] downloadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (operation && identifier) {
+                    [[MSDImageDownloadGroupManage shareInstance] removeImageDownLoadOperation:operation fromGroup:identifier forKey:imageURL.absoluteString];
+                }
+                if (!weakSelf) {
+                    return;
+                }
+                if ([weakSelf.msd_imageURL.absoluteString isEqualToString:imageURL.absoluteString]) {
+                    weakSelf.msd_operation = nil;
+                    weakSelf.msd_imageURL = nil;
+                    weakSelf.msd_downloadGroupIdentifier = nil;
+                    if (image) {
+                        weakSelf.image = image;
+                        [weakSelf setNeedsLayout];
+                    }
+                }
+                if (completedBlock && finished) {
+                    completedBlock(image, error, cacheType, imageURL);
+                }
+            });
+        }];
+        
+        if (operation && identifier) {
+            [[MSDImageDownloadGroupManage shareInstance] setImageDownLoadOperation:operation toGroup:identifier forKey:[url absoluteString]];
+            self.msd_operation = operation;
+            self.msd_downloadGroupIdentifier = identifier;
+        }
+    }
+    else {
+        dispatch_main_async_safe(^{
+            NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Trying to load a nil url"}];
+            if (completedBlock) {
+                completedBlock(nil, error, SDImageCacheTypeNone, url);
+            }
+        });
+    }
+}
+
+- (void)msd_cancelCurrentImageDownload
+{
+    id<SDWebImageOperation> operation = [self msd_operation];
+    if (!operation) {
+        return;
+    }
+    [operation cancel];
+    [[MSDImageDownloadGroupManage shareInstance] removeImageDownLoadOperation:operation fromGroup:self.msd_downloadGroupIdentifier forKey:self.msd_imageURL.absoluteString];
+    self.msd_operation = nil;
+    self.msd_imageURL = nil;
+    self.msd_downloadGroupIdentifier = nil;
+}
+
+//  MARK: objc_setAssociatedObject
+- (void)setMsd_imageURL:(NSURL *)msd_imageURL
+{
+    objc_setAssociatedObject(self, @selector(msd_imageURL), msd_imageURL, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (NSURL *)msd_imageURL
+{
+    return objc_getAssociatedObject(self, @selector(msd_imageURL));
+}
+
+- (void)setMsd_downloadGroupIdentifier:(NSString *)msd_downloadGroupIdentifier
+{
+    objc_setAssociatedObject(self, @selector(msd_downloadGroupIdentifier), msd_downloadGroupIdentifier, OBJC_ASSOCIATION_COPY);
+}
+
+- (NSString *)msd_downloadGroupIdentifier
+{
+    return objc_getAssociatedObject(self, @selector(msd_downloadGroupIdentifier));
+}
+
+- (void)setMsd_operation:(id<SDWebImageOperation>)msd_operation
+{
+    objc_setAssociatedObject(self, @selector(msd_operation), msd_operation, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (id<SDWebImageOperation>)msd_operation
+{
+    return objc_getAssociatedObject(self, @selector(msd_operation));
+}
+
+@end


### PR DESCRIPTION
A image download group, UIImageView download can divide groups and limit number of concurrent in group. For the more feature，look [this](https://github.com/maquannene/MSDImageDownloadGroup](url)).

If you think it is useful，I can change MSD -> SD and add more category.
