### PR TITLE
Replace deprecated NSURLConnection with NSURLSession

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -26,13 +26,6 @@ extern NSString *const SDWebImageDownloadFinishNotification;
 @property (assign, nonatomic) BOOL shouldDecompressImages;
 
 /**
- * Whether the URL connection should consult the credential storage for authenticating the connection. `YES` by default.
- *
- * This is the value that is returned in the `NSURLConnectionDelegate` method `-connectionShouldUseCredentialStorage:`.
- */
-@property (nonatomic, assign) BOOL shouldUseCredentialStorage;
-
-/**
  * The credential used for authentication challenges in `-connection:didReceiveAuthenticationChallenge:`.
  *
  * This will be overridden by any shared credentials that exist for the username or password of the request URL, if present.

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -67,10 +67,6 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
     return self;
 }
 
-- (void)dealloc {
-    
-}
-
 - (void)start {
     @synchronized (self) {
         if (self.isCancelled) {
@@ -99,6 +95,12 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
 #endif
         NSURLSessionConfiguration *sessionConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
         sessionConfig.timeoutIntervalForRequest = 15;
+        
+        /**
+         *  Create the session for this task
+         *  We send nil as delegate queue so that the session creates a serial operation queue for performing all delegate
+         *  method calls and completion handler calls.
+         */
         self.session = [NSURLSession sessionWithConfiguration:sessionConfig
                                                      delegate:self
                                                 delegateQueue:nil];


### PR DESCRIPTION
* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This pull request fixes the following issues: #1291 #1318 #823 #1566

### Pull Request Description

- one session per operation to preserve the ordering and priority functionalities
- removed all the runloop code that was only used to keep the operation running. I am relying on non-setting the isFinished property to keep the operation running
- todo: check deallocation, test background tasks