### PR TITLE
Update FLAnimatedImageView+WebCache.h (Fix FLAnimatedImage import statement)

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -7,11 +7,7 @@
  */
 
 
-#if COCOAPODS
-    @import FLAnimatedImage;
-#else
-    #import "FLAnimatedImageView.h"
-#endif
+#import <FLAnimatedImage/FLAnimatedImageView.h>
 
 #import "SDWebImageManager.h"
 


### PR DESCRIPTION

Instead of using `@import FLAnimatedImage`, switched to `#import <FLAnimatedImage/FLAnimatedImageView.h>`, to support CocoaPods-projects that do not work with `use_frameworks!` in the Podfile.