### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,10 @@ There are three ways to use SDWebImage in your project:
 #### Podfile
 ```
 platform :ios, '7.0'
+
+target 'TargetName' do
 pod 'SDWebImage', '~>3.8'
+end
 ```
 
 If you are using Swift, be sure to add `use_frameworks!` and set your target to iOS 8+:


### PR DESCRIPTION
Update the content of the section `Installation with CocoaPods` in `README.md`, since the older one could lead to the following error with the latest CocoaPods:
```
The dependency `SDWebImage (~> 3.8)` is not used in any concrete target.
```