### PR TITLE
fixed crash on ios7 user device

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -61,7 +61,7 @@
         if (NSClassFromString(@"NSURLComponents") && [NSURLComponents instancesRespondToSelector:@selector(string)]) {
             NSURLComponents *urlComponents = [[NSURLComponents alloc] initWithURL:url resolvingAgainstBaseURL:NO];
             urlComponents.query = nil; // Strip out query parameters.
-            return urlComponents.string;
+            return [urlComponents.URL absoluteString];
         } else {
             return [url absoluteString];
         }


### PR DESCRIPTION
fixed crash that string property of NSURLComponents can`t use on iOS7