### PR TITLE
Enhance transforming image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 *.xcscmblueprint
-
+.DS_Store
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However

--- a/Examples/SDWebImage Demo.xcodeproj/project.pbxproj
+++ b/Examples/SDWebImage Demo.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		53A2B50D155B155A00B12423 /* placeholder.png in Resources */ = {isa = PBXBuildFile; fileRef = 53A2B50B155B155A00B12423 /* placeholder.png */; };
 		53A2B50E155B155A00B12423 /* placeholder@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 53A2B50C155B155A00B12423 /* placeholder@2x.png */; };
 		53EEC18916484553007601E1 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 53EEC18816484553007601E1 /* Default-568h@2x.png */; };
+		A767FD981D1E294900439F4D /* UIImage+CCKit.m in Sources */ = {isa = PBXBuildFile; fileRef = A767FD951D1E294900439F4D /* UIImage+CCKit.m */; };
+		A767FD991D1E294900439F4D /* UIView+CCKit.m in Sources */ = {isa = PBXBuildFile; fileRef = A767FD971D1E294900439F4D /* UIView+CCKit.m */; };
 		DA248D44195470FD00390AB0 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 537612E3155ABA3C005750A4 /* MapKit.framework */; };
 		DA248D79195484A500390AB0 /* libSDWebImage+WebP.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DA248D761954841D00390AB0 /* libSDWebImage+WebP.a */; };
 /* End PBXBuildFile section */
@@ -85,6 +87,10 @@
 		53A2B50B155B155A00B12423 /* placeholder.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = placeholder.png; sourceTree = "<group>"; };
 		53A2B50C155B155A00B12423 /* placeholder@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "placeholder@2x.png"; sourceTree = "<group>"; };
 		53EEC18816484553007601E1 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "../Default-568h@2x.png"; sourceTree = "<group>"; };
+		A767FD941D1E294900439F4D /* UIImage+CCKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+CCKit.h"; sourceTree = "<group>"; };
+		A767FD951D1E294900439F4D /* UIImage+CCKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+CCKit.m"; sourceTree = "<group>"; };
+		A767FD961D1E294900439F4D /* UIView+CCKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+CCKit.h"; sourceTree = "<group>"; };
+		A767FD971D1E294900439F4D /* UIView+CCKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+CCKit.m"; sourceTree = "<group>"; };
 		DA248D6C1954841D00390AB0 /* SDWebImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDWebImage.xcodeproj; path = ../SDWebImage.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -138,6 +144,10 @@
 		5376129F155AB74D005750A4 /* SDWebImage Demo */ = {
 			isa = PBXGroup;
 			children = (
+				A767FD941D1E294900439F4D /* UIImage+CCKit.h */,
+				A767FD951D1E294900439F4D /* UIImage+CCKit.m */,
+				A767FD961D1E294900439F4D /* UIView+CCKit.h */,
+				A767FD971D1E294900439F4D /* UIView+CCKit.m */,
 				3E75A9851742DBE700DA412D /* CustomPathImages */,
 				537612A8155AB74D005750A4 /* AppDelegate.h */,
 				537612A9155AB74D005750A4 /* AppDelegate.m */,
@@ -289,9 +299,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				537612A6155AB74D005750A4 /* main.m in Sources */,
+				A767FD991D1E294900439F4D /* UIView+CCKit.m in Sources */,
 				537612AA155AB74D005750A4 /* AppDelegate.m in Sources */,
 				537612AD155AB74D005750A4 /* MasterViewController.m in Sources */,
 				537612B0155AB74D005750A4 /* DetailViewController.m in Sources */,
+				A767FD981D1E294900439F4D /* UIImage+CCKit.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/SDWebImage Demo/DetailViewController.h
+++ b/Examples/SDWebImage Demo/DetailViewController.h
@@ -7,10 +7,13 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <SDWebImage/SDWebImageManager.h>
 
 @interface DetailViewController : UIViewController
 
 @property (strong, nonatomic) NSURL *imageURL;
+@property (copy, nonatomic) SDWebImageTransformDownloadedImageBlock transformImage;
+@property (copy, nonatomic) NSString *transformKey;
 
 @property (strong, nonatomic) IBOutlet UIImageView *imageView;
 

--- a/Examples/SDWebImage Demo/DetailViewController.m
+++ b/Examples/SDWebImage Demo/DetailViewController.m
@@ -34,6 +34,7 @@
     if (self.imageURL) {
         __block UIActivityIndicatorView *activityIndicator;
         __weak UIImageView *weakImageView = self.imageView;
+        [weakImageView sd_setTransformDownloadedImageBlock:_transformImage transformKey:_transformKey];
         [self.imageView sd_setImageWithURL:self.imageURL
                           placeholderImage:nil
                                    options:SDWebImageProgressiveDownload

--- a/Examples/SDWebImage Demo/MasterViewController.m
+++ b/Examples/SDWebImage Demo/MasterViewController.m
@@ -11,6 +11,8 @@
 #import "DetailViewController.h"
 #import "UIImage+CCKit.h"
 
+const CGFloat CellHeight = 100.0;
+
 @interface SDTableViewCell : UITableViewCell
 
 @property (nonatomic) UIImageView *sdImageView;
@@ -25,6 +27,7 @@
         _sdImageView = [[UIImageView alloc] init];
         [self.contentView addSubview:_sdImageView];
         _sdImageView.contentMode = UIViewContentModeScaleAspectFill;
+        _sdImageView.clipsToBounds = YES;
     }
     return self;
 }
@@ -32,7 +35,7 @@
 - (void)layoutSubviews {
     [super layoutSubviews];
     
-    _sdImageView.frame = CGRectMake(0, 0, self.contentView.bounds.size.height, self.contentView.bounds.size.height);
+    _sdImageView.frame = CGRectMake(1, 1, CellHeight-2, CellHeight-2);
 }
 
 @end
@@ -78,7 +81,7 @@
             [_objects addObject:[NSString stringWithFormat:@"https://s3.amazonaws.com/fast-image-cache/demo-images/FICDDemoImage%03d.jpg", i]];
         }
         
-        self.tableView.rowHeight = 100;
+        self.tableView.rowHeight = CellHeight;
 
     }
     [SDWebImageManager.sharedManager.imageDownloader setValue:@"SDWebImage Demo" forHTTPHeaderField:@"AppName"];
@@ -126,7 +129,7 @@
     cell.sdImageView.contentMode = UIViewContentModeScaleAspectFill;
     if (indexPath.row % 2 == 1) {
         [cell.sdImageView sd_setTransformDownloadedImageBlock:^UIImage *(UIImage *image, NSURL *imageUrl) {
-            CGSize size = CGSizeMake(tableView.rowHeight, tableView.rowHeight);
+            CGSize size = CGSizeMake(CellHeight-2, CellHeight-2);
             if (image.images) {
                 NSMutableArray *mArray = [NSMutableArray array];
                 for (UIImage *imageItem in image.images) {

--- a/Examples/SDWebImage Demo/MasterViewController.m
+++ b/Examples/SDWebImage Demo/MasterViewController.m
@@ -97,6 +97,7 @@
     [cell.imageView setIndicatorStyle:UIActivityIndicatorViewStyleGray];
 
     cell.textLabel.text = [NSString stringWithFormat:@"Image #%ld", (long)indexPath.row];
+    cell.imageView.frame = CGRectMake(cell.imageView.frame.origin.x, cell.imageView.frame.origin.y, 100.0, 100.0);
     cell.imageView.contentMode = UIViewContentModeScaleAspectFill;
     if (indexPath.row % 2 == 1) {
         [cell.imageView sd_setTransformDownloadedImageBlock:^UIImage *(UIImage *image, NSURL *imageUrl) {

--- a/Examples/SDWebImage Demo/MasterViewController.m
+++ b/Examples/SDWebImage Demo/MasterViewController.m
@@ -11,6 +11,32 @@
 #import "DetailViewController.h"
 #import "UIImage+CCKit.h"
 
+@interface SDTableViewCell : UITableViewCell
+
+@property (nonatomic) UIImageView *sdImageView;
+
+@end
+
+@implementation SDTableViewCell
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        _sdImageView = [[UIImageView alloc] init];
+        [self.contentView addSubview:_sdImageView];
+        _sdImageView.contentMode = UIViewContentModeScaleAspectFill;
+    }
+    return self;
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    
+    _sdImageView.frame = CGRectMake(0, 0, self.contentView.bounds.size.height, self.contentView.bounds.size.height);
+}
+
+@end
+
 @interface MasterViewController () {
     NSMutableArray *_objects;
 }
@@ -39,8 +65,8 @@
         _objects = [NSMutableArray arrayWithObjects:
                     @"http://www.httpwatch.com/httpgallery/authentication/authenticatedimage/default.aspx?0.35786508303135633",     // requires HTTP auth, used to demo the NTLM auth
                     @"http://www.httpwatch.com/httpgallery/authentication/authenticatedimage/default.aspx?0.35786508303135633",
-                    @"http://assets.sbnation.com/assets/2512203/dogflops.gif",
-                    @"http://assets.sbnation.com/assets/2512203/dogflops.gif",
+                    @"http://img1.cache.netease.com/catchpic/1/15/15D5A7755A09D20CD7AF179F1AD0ACE5.gif",
+                    @"http://img1.cache.netease.com/catchpic/1/15/15D5A7755A09D20CD7AF179F1AD0ACE5.gif",
                     @"http://www.ioncannon.net/wp-content/uploads/2011/06/test2.webp",
                     @"http://www.ioncannon.net/wp-content/uploads/2011/06/test2.webp",
                     @"http://www.ioncannon.net/wp-content/uploads/2011/06/test9.webp",
@@ -87,21 +113,20 @@
 {
     static NSString *CellIdentifier = @"Cell";
     
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
+    SDTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:CellIdentifier];
     if (cell == nil)
     {
-        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
+        cell = [[SDTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CellIdentifier];
     }
 
-    [cell.imageView setShowActivityIndicatorView:YES];
-    [cell.imageView setIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    [cell.sdImageView setShowActivityIndicatorView:YES];
+    [cell.sdImageView setIndicatorStyle:UIActivityIndicatorViewStyleGray];
 
     cell.textLabel.text = [NSString stringWithFormat:@"Image #%ld", (long)indexPath.row];
-    cell.imageView.frame = CGRectMake(cell.imageView.frame.origin.x, cell.imageView.frame.origin.y, 100.0, 100.0);
-    cell.imageView.contentMode = UIViewContentModeScaleAspectFill;
+    cell.sdImageView.contentMode = UIViewContentModeScaleAspectFill;
     if (indexPath.row % 2 == 1) {
-        [cell.imageView sd_setTransformDownloadedImageBlock:^UIImage *(UIImage *image, NSURL *imageUrl) {
-            CGSize size = cell.imageView.bounds.size;
+        [cell.sdImageView sd_setTransformDownloadedImageBlock:^UIImage *(UIImage *image, NSURL *imageUrl) {
+            CGSize size = CGSizeMake(tableView.rowHeight, tableView.rowHeight);
             if (image.images) {
                 NSMutableArray *mArray = [NSMutableArray array];
                 for (UIImage *imageItem in image.images) {
@@ -113,10 +138,10 @@
             }
         } transformKey:@"cornerRound"];
     } else {
-        [cell.imageView sd_setTransformDownloadedImageBlock:nil transformKey:nil];
+        [cell.sdImageView sd_setTransformDownloadedImageBlock:nil transformKey:nil];
     }
-    [cell.imageView sd_setImageWithURL:[NSURL URLWithString:[_objects objectAtIndex:indexPath.row]]
-                      placeholderImage:[UIImage imageNamed:@"placeholder"] options:indexPath.row == 0 ? SDWebImageRefreshCached : 0];
+    [cell.sdImageView sd_setImageWithURL:[NSURL URLWithString:[_objects objectAtIndex:indexPath.row]]
+                        placeholderImage:[UIImage imageNamed:@"placeholder"] options:indexPath.row == 0 ? SDWebImageRefreshCached:SDWebImageTransformAnimatedImage];
     return cell;
 }
 

--- a/Examples/SDWebImage Demo/UIImage+CCKit.h
+++ b/Examples/SDWebImage Demo/UIImage+CCKit.h
@@ -1,0 +1,17 @@
+//
+//  UIImage+CCKit.h
+//  performance
+//
+//  Created by KudoCC on 16/5/9.
+//  Copyright © 2016年 KudoCC. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIImage (CCKit)
+
+- (UIImage *)cc_imageWithSize:(CGSize)size cornerRadius:(CGFloat)radius;
+- (UIImage *)cc_imageWithSize:(CGSize)size cornerRadius:(CGFloat)radius contentMode:(UIViewContentMode)contentMode;
+- (UIImage *)cc_imageWithSize:(CGSize)size cornerRadius:(CGFloat)radius borderWidth:(CGFloat)borderWidth borderColor:(UIColor *)borderColor contentMode:(UIViewContentMode)contentMode;
+
+@end

--- a/Examples/SDWebImage Demo/UIImage+CCKit.m
+++ b/Examples/SDWebImage Demo/UIImage+CCKit.m
@@ -1,0 +1,48 @@
+//
+//  UIImage+CCKit.m
+//  performance
+//
+//  Created by KudoCC on 16/5/9.
+//  Copyright © 2016年 KudoCC. All rights reserved.
+//
+
+#import "UIImage+CCKit.h"
+#import <ImageIO/ImageIO.h>
+#import "UIView+CCKit.h"
+
+@implementation UIImage (CCKit)
+
+- (UIImage *)cc_imageWithSize:(CGSize)size cornerRadius:(CGFloat)radius {
+    return [self cc_imageWithSize:size cornerRadius:radius contentMode:UIViewContentModeScaleToFill];
+}
+
+- (UIImage *)cc_imageWithSize:(CGSize)size cornerRadius:(CGFloat)radius contentMode:(UIViewContentMode)contentMode {
+    return [self cc_imageWithSize:size cornerRadius:radius borderWidth:0 borderColor:nil contentMode:contentMode];
+}
+
+- (UIImage *)cc_imageWithSize:(CGSize)size cornerRadius:(CGFloat)radius borderWidth:(CGFloat)borderWidth borderColor:(UIColor *)borderColor contentMode:(UIViewContentMode)contentMode {
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
+    
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    // add clip area
+    UIBezierPath *path = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0.0, 0.0, size.width, size.height) cornerRadius:radius];
+    [path addClip];
+    
+    // draw image
+    CGRect frame = [UIView cc_frameOfContentWithContentSize:self.size containerSize:size contentMode:contentMode];
+    [self drawInRect:frame];
+    
+    // draw border
+    if (borderWidth > 0 && borderColor) {
+        path.lineWidth = borderWidth*2;
+        CGContextSetStrokeColorWithColor(context, borderColor.CGColor);
+        [path stroke];
+    }
+    
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+@end

--- a/Examples/SDWebImage Demo/UIImage+CCKit.m
+++ b/Examples/SDWebImage Demo/UIImage+CCKit.m
@@ -7,7 +7,6 @@
 //
 
 #import "UIImage+CCKit.h"
-#import <ImageIO/ImageIO.h>
 #import "UIView+CCKit.h"
 
 @implementation UIImage (CCKit)

--- a/Examples/SDWebImage Demo/UIView+CCKit.h
+++ b/Examples/SDWebImage Demo/UIView+CCKit.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+@interface UIView (CCKit)
+
++ (CGRect)cc_frameOfContentWithContentSize:(CGSize)contentSize
+                             containerSize:(CGSize)size
+                               contentMode:(UIViewContentMode)contentMode;
+
+@end

--- a/Examples/SDWebImage Demo/UIView+CCKit.m
+++ b/Examples/SDWebImage Demo/UIView+CCKit.m
@@ -1,0 +1,99 @@
+#import "UIView+CCKit.h"
+
+@implementation UIView (CCKit)
+
++ (CGRect)cc_frameOfContentWithContentSize:(CGSize)contentSize
+                             containerSize:(CGSize)size
+                               contentMode:(UIViewContentMode)contentMode {
+    CGFloat (^centerImageOriX)(void) = ^{
+        return size.width/2 - contentSize.width/2;
+    };
+    CGFloat (^centerImageOriY)(void) = ^{
+        return size.height/2 - contentSize.height/2;
+    };
+    
+    CGRect frameImage = CGRectMake(0.0, 0.0, contentSize.width, contentSize.height);
+    switch (contentMode) {
+        case UIViewContentModeScaleToFill:
+            frameImage = CGRectMake(0, 0, size.width, size.height);
+            break;
+        case UIViewContentModeScaleAspectFit: {
+            CGFloat ratioW = size.width/contentSize.width;
+            CGFloat ratioH = size.height/contentSize.height;
+            CGFloat ratio = MIN(ratioW, ratioH);
+            frameImage.size = CGSizeMake(floor(ratio * contentSize.width), floor(ratio * contentSize.height));
+            frameImage.origin.x = size.width/2 - frameImage.size.width/2;
+            frameImage.origin.y = size.height/2 - frameImage.size.height/2;
+        }
+            break;
+        case UIViewContentModeScaleAspectFill: {
+            CGFloat ratioW = size.width/contentSize.width;
+            CGFloat ratioH = size.height/contentSize.height;
+            CGFloat ratio = MAX(ratioW, ratioH);
+            frameImage.size = CGSizeMake(floor(ratio * contentSize.width), floor(ratio * contentSize.height));
+            frameImage.origin.x = size.width/2 - frameImage.size.width/2;
+            frameImage.origin.y = size.height/2 - frameImage.size.height/2;
+        }
+            break;
+            
+        case UIViewContentModeCenter: {
+            frameImage.origin.x = centerImageOriX();
+            frameImage.origin.y = centerImageOriY();
+        }
+            break;
+            
+        case UIViewContentModeTop: {
+            frameImage.origin.x = centerImageOriX();
+            frameImage.origin.y = 0.0;
+        }
+            break;
+            
+        case UIViewContentModeBottom: {
+            frameImage.origin.x = centerImageOriX();
+            frameImage.origin.y = size.height - contentSize.height;
+        }
+            break;
+            
+        case UIViewContentModeLeft: {
+            frameImage.origin.x = 0.0;
+            frameImage.origin.y = centerImageOriY();
+        }
+            break;
+            
+        case UIViewContentModeRight: {
+            frameImage.origin.x = size.width - contentSize.width;
+            frameImage.origin.y = centerImageOriY();
+        }
+            break;
+            
+        case UIViewContentModeTopLeft: {
+            frameImage.origin.x = 0.0;
+            frameImage.origin.y = 0.0;
+        }
+            break;
+            
+        case UIViewContentModeTopRight: {
+            frameImage.origin.x = size.width - contentSize.width;
+            frameImage.origin.y = centerImageOriY();
+        }
+            break;
+            
+        case UIViewContentModeBottomLeft: {
+            frameImage.origin.x = 0.0;
+            frameImage.origin.y = size.height - contentSize.height;
+        }
+            break;
+            
+        case UIViewContentModeBottomRight: {
+            frameImage.origin.x = size.width - contentSize.width;
+            frameImage.origin.y = size.height - contentSize.height;
+        }
+            break;
+            
+        default:
+            break;
+    }
+    return frameImage;
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ handled for you, from async downloads to caching management.
 }
 ```
 
+You can transform the image and keep it in a separated memory cache with a `transformBlock` and a `transformKey`. For the same url, you will get different images for different `transformKey`s.
+
+```objective-c
+#import <SDWebImage/UIImageView+WebCache.h>
+
+...
+
+[cell.imageView sd_setTransformDownloadedImageBlock:^UIImage *(UIImage *image, NSURL *imageUrl) {
+    ... transform code here ...
+} transformKey:@"cornerRound"];
+```
+
 ### Using blocks
 
 With blocks, you can be notified about the image download progress and whenever the image retrieval

--- a/SDWebImage.xcworkspace/contents.xcworkspacedata
+++ b/SDWebImage.xcworkspace/contents.xcworkspacedata
@@ -14,10 +14,10 @@
       location = "group:README.md">
    </FileRef>
    <FileRef
-      location = "group:SDWebImage.podspec">
+      location = "group:CHANGELOG.md">
    </FileRef>
    <FileRef
-      location = "group:CHANGELOG.md">
+      location = "group:SDWebImage_Transform.podspec">
    </FileRef>
    <FileRef
       location = "group:Tests/Pods/Pods.xcodeproj">

--- a/SDWebImage.xcworkspace/contents.xcworkspacedata
+++ b/SDWebImage.xcworkspace/contents.xcworkspacedata
@@ -19,7 +19,4 @@
    <FileRef
       location = "group:SDWebImage_Transform.podspec">
    </FileRef>
-   <FileRef
-      location = "group:Tests/Pods/Pods.xcodeproj">
-   </FileRef>
 </Workspace>

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -26,9 +26,13 @@ typedef NS_ENUM(NSInteger, SDImageCacheType) {
 
 typedef void(^SDWebImageQueryCompletedBlock)(UIImage *image, SDImageCacheType cacheType);
 
+typedef void(^SDWebImageStoreCompletedBlock)(UIImage *imageCacheInMemory);
+
 typedef void(^SDWebImageCheckCacheCompletionBlock)(BOOL isInCache);
 
 typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger totalSize);
+
+typedef UIImage *(^SDWebImageTransformImageBlock)(UIImage *imageOri);
 
 /**
  * SDImageCache maintains a memory cache and an optional disk cache. Disk cache write operations are performed
@@ -124,15 +128,15 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 /**
  * Store an image into memory and optionally disk cache at the given key.
  *
- * @param image       The image to store
- * @param recalculate BOOL indicates if imageData can be used or a new data should be constructed from the UIImage
- * @param imageData   The image data as returned by the server, this representation will be used for disk storage
- *                    instead of converting the given image object into a storable/compressed image format in order
- *                    to save quality and CPU
- * @param key         The unique image cache key, usually it's image absolute URL
- * @param toDisk      Store the image to disk cache if YES
+ * @param image        The image to store in memory, if the downloaded image is transformed, image represents the transformed image
+ * @param imageData    The image data as returned by the server, this representation will be used for disk storage
+ *                     instead of converting the given image object into a storable/compressed image format in order
+ *                     to save quality and CPU
+ * @param key          The unique image cache key, usually it's image absolute URL
+ * @param transformKey The transform key used to cache the image to specific memory cache
+ * @param toDisk       Store the image to disk cache if YES
  */
-- (void)storeImage:(UIImage *)image recalculateFromImage:(BOOL)recalculate imageData:(NSData *)imageData forKey:(NSString *)key toDisk:(BOOL)toDisk;
+- (void)storeImage:(UIImage *)image imageData:(NSData *)imageData forKey:(NSString *)key transformKey:(NSString *)transformKey toDisk:(BOOL)toDisk;
 
 /**
  * Store image NSData into disk cache at the given key.
@@ -150,11 +154,28 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 - (NSOperation *)queryDiskCacheForKey:(NSString *)key done:(SDWebImageQueryCompletedBlock)doneBlock;
 
 /**
+ * Query the disk cache asynchronously.
+ *
+ * @param key The unique key used to store the wanted image
+ * @param transformKey The transform key used to identify memory cache
+ * @param transformBlock The transform block used to transform image fetched from disk and keep it in memory cache
+ */
+- (NSOperation *)queryDiskCacheForKey:(NSString *)key transformKey:(NSString *)transformKey transformBlock:(SDWebImageTransformImageBlock)transformBlock done:(SDWebImageQueryCompletedBlock)doneBlock;
+
+/**
  * Query the memory cache synchronously.
  *
  * @param key The unique key used to store the wanted image
  */
 - (UIImage *)imageFromMemoryCacheForKey:(NSString *)key;
+
+/**
+ * Query the memory cache synchronously.
+ *
+ * @param key The unique key used to store the wanted image
+ * @param transformKey The transform key used to identify memory cache
+ */
+- (UIImage *)imageFromMemoryCacheForKey:(NSString *)key transformKey:(NSString *)transformKey;
 
 /**
  * Query the disk cache synchronously after checking the memory cache.

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -26,8 +26,6 @@ typedef NS_ENUM(NSInteger, SDImageCacheType) {
 
 typedef void(^SDWebImageQueryCompletedBlock)(UIImage *image, SDImageCacheType cacheType);
 
-typedef void(^SDWebImageStoreCompletedBlock)(UIImage *imageCacheInMemory);
-
 typedef void(^SDWebImageCheckCacheCompletionBlock)(BOOL isInCache);
 
 typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger totalSize);
@@ -109,7 +107,7 @@ typedef UIImage *(^SDWebImageTransformImageBlock)(UIImage *imageOri);
 - (void)addReadOnlyCachePath:(NSString *)path;
 
 /**
- * Store an image into memory and disk cache at the given key.
+ * Store an image into default memory cache and disk cache at the given key.
  *
  * @param image The image to store
  * @param key   The unique image cache key, usually it's image absolute URL
@@ -117,7 +115,7 @@ typedef UIImage *(^SDWebImageTransformImageBlock)(UIImage *imageOri);
 - (void)storeImage:(UIImage *)image forKey:(NSString *)key;
 
 /**
- * Store an image into memory and optionally disk cache at the given key.
+ * Store an image into default memory cache and optionally disk cache at the given key.
  *
  * @param image  The image to store
  * @param key    The unique image cache key, usually it's image absolute URL
@@ -126,7 +124,7 @@ typedef UIImage *(^SDWebImageTransformImageBlock)(UIImage *imageOri);
 - (void)storeImage:(UIImage *)image forKey:(NSString *)key toDisk:(BOOL)toDisk;
 
 /**
- * Store an image into memory and optionally disk cache at the given key.
+ * Store an image into specific memory cache indicated by `transformKey` and optionally disk cache at the given key.
  *
  * @param image        The image to store in memory, if the downloaded image is transformed, image represents the transformed image
  * @param imageData    The image data as returned by the server, this representation will be used for disk storage
@@ -147,14 +145,14 @@ typedef UIImage *(^SDWebImageTransformImageBlock)(UIImage *imageOri);
 - (void)storeImageDataToDisk:(NSData *)imageData forKey:(NSString *)key;
 
 /**
- * Query the disk cache asynchronously.
+ * Query the disk cache asynchronously and keep the result in default memory cache.
  *
  * @param key The unique key used to store the wanted image
  */
 - (NSOperation *)queryDiskCacheForKey:(NSString *)key done:(SDWebImageQueryCompletedBlock)doneBlock;
 
 /**
- * Query the disk cache asynchronously.
+ * Query the disk cache asynchronously, transform the image with `transformBlock` and keep the result in specific memory cache indicated by `transformKey`.
  *
  * @param key The unique key used to store the wanted image
  * @param transformKey The transform key used to identify memory cache
@@ -170,7 +168,7 @@ typedef UIImage *(^SDWebImageTransformImageBlock)(UIImage *imageOri);
 - (UIImage *)imageFromMemoryCacheForKey:(NSString *)key;
 
 /**
- * Query the memory cache synchronously.
+ * Query the specific memory cache indicated by `transformKey` synchronously.
  *
  * @param key The unique key used to store the wanted image
  * @param transformKey The transform key used to identify memory cache
@@ -185,9 +183,11 @@ typedef UIImage *(^SDWebImageTransformImageBlock)(UIImage *imageOri);
 - (UIImage *)imageFromDiskCacheForKey:(NSString *)key;
 
 /**
- * Query the disk cache synchronously after checking the memory cache.
+ * Query the disk cache synchronously after checking the specific memory cache indicated by `transformKey`. If the image is fetched from the disk, use `transformBlock` to transform it and keep transformed image into memory cache indicated by `transformKey`.
  *
  * @param key The unique key used to store the wanted image
+ * @param transformKey The transform key used to identify memory cache
+ * @param transformBlock The transform block used to transform image fetched from disk and keep it in memory cache, if it is nil, `transformKey` is ignored.
  */
 - (UIImage *)imageFromDiskCacheForKey:(NSString *)key transformKey:(NSString *)transformKey transformBlock:(SDWebImageTransformImageBlock)transformBlock;
 

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -156,7 +156,7 @@ typedef UIImage *(^SDWebImageTransformImageBlock)(UIImage *imageOri);
  *
  * @param key The unique key used to store the wanted image
  * @param transformKey The transform key used to identify memory cache
- * @param transformBlock The transform block used to transform image fetched from disk and keep it in memory cache
+ * @param transformBlock The transform block used to transform image fetched from disk and keep it in memory cache, if the block returns nil, cache it in default memory.
  */
 - (NSOperation *)queryDiskCacheForKey:(NSString *)key transformKey:(NSString *)transformKey transformBlock:(SDWebImageTransformImageBlock)transformBlock done:(SDWebImageQueryCompletedBlock)doneBlock;
 

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -163,7 +163,7 @@ typedef UIImage *(^SDWebImageTransformImageBlock)(UIImage *imageOri);
 - (NSOperation *)queryDiskCacheForKey:(NSString *)key transformKey:(NSString *)transformKey transformBlock:(SDWebImageTransformImageBlock)transformBlock done:(SDWebImageQueryCompletedBlock)doneBlock;
 
 /**
- * Query the memory cache synchronously.
+ * Query the default memory cache synchronously.
  *
  * @param key The unique key used to store the wanted image
  */
@@ -178,11 +178,18 @@ typedef UIImage *(^SDWebImageTransformImageBlock)(UIImage *imageOri);
 - (UIImage *)imageFromMemoryCacheForKey:(NSString *)key transformKey:(NSString *)transformKey;
 
 /**
- * Query the disk cache synchronously after checking the memory cache.
+ * Query the disk cache synchronously after checking the default memory cache.
  *
  * @param key The unique key used to store the wanted image
  */
 - (UIImage *)imageFromDiskCacheForKey:(NSString *)key;
+
+/**
+ * Query the disk cache synchronously after checking the memory cache.
+ *
+ * @param key The unique key used to store the wanted image
+ */
+- (UIImage *)imageFromDiskCacheForKey:(NSString *)key transformKey:(NSString *)transformKey transformBlock:(SDWebImageTransformImageBlock)transformBlock;
 
 /**
  * Remove the image from memory and disk cache asynchronously

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -334,6 +334,9 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 }
 
 - (void)setMemCacheWithImage:(UIImage *)image forKey:(NSString *)key transformKey:(NSString *)transformKey {
+    if (!image || !key) {
+        return;
+    }
     NSCache *cache = [self memCacheForTransformKey:transformKey];
     NSUInteger cost = SDCacheCostForImage(image);
     [cache setObject:image forKey:key cost:cost];
@@ -451,14 +454,10 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             UIImage *diskImage = [self diskImageForKey:key];
             UIImage *cacheImage = diskImage;
             if (diskImage && self.shouldCacheImagesInMemory) {
-                NSCache *cache = [self memCacheForTransformKey:transformKey];
                 if (transformKey && transformBlock) {
                     cacheImage = transformBlock(diskImage);
                 }
-                if (cacheImage) {
-                    NSUInteger cost = SDCacheCostForImage(cacheImage);
-                    [cache setObject:cacheImage forKey:key cost:cost];
-                }
+                [self setMemCacheWithImage:cacheImage forKey:key transformKey:transformKey];
             }
             
             dispatch_async(dispatch_get_main_queue(), ^{

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -367,6 +367,11 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         return image;
     }
     
+    if (!transformBlock) {
+        // ignore transformKey if transformBlock is nil
+        transformKey = nil;
+    }
+    
     // Second check the disk cache...
     UIImage *diskImage = [self diskImageForKey:key];
     UIImage *memCacheImage = diskImage;

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -471,7 +471,13 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
                 if (transformKey && transformBlock) {
                     cacheImage = transformBlock(diskImage);
                 }
-                [self setMemCacheWithImage:cacheImage forKey:key transformKey:transformKey];
+                // if transform block return nil, we must keep the disk image in default cache rather than the cache indicated by tranform key
+                if (!cacheImage) {
+                    cacheImage = diskImage;
+                    [self setMemCacheWithImage:cacheImage forKey:key transformKey:nil];
+                } else {
+                    [self setMemCacheWithImage:cacheImage forKey:key transformKey:transformKey];
+                }
             }
             
             dispatch_async(dispatch_get_main_queue(), ^{

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -150,6 +150,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
         else {
             request.allHTTPHeaderFields = wself.HTTPHeaders;
         }
+        NSLog(@"begin download url:%@", url);
         operation = [[wself.operationClass alloc] initWithRequest:request
                                                         inSession:self.session
                                                           options:options

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -216,6 +216,30 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
                                         progress:(SDWebImageDownloaderProgressBlock)progressBlock
                                        completed:(SDWebImageCompletionWithFinishedBlock)completedBlock;
 
+/**
+ * Downloads the image at the given URL if not present in cache or return the cached version otherwise.
+ *
+ * @param url            The URL to the image
+ * @param options        A mask to specify options to use for this request
+ * @param transformBlock A block called while image is downloaded or image is fetched from disk. The first parameter is the downloaded image, the second is url of the image, you're responsible to return transformed image, if the transformed image is nil, we will pass the original image in `completedBlock` and keep the image in default memory cache. The block is called in background thread.
+ * @param transformKey   A key used to indicate the memory cache the tranformed image saved in, if `transformBlock` is nil, this param would be ignored.
+ * @param progressBlock  A block called while image is downloading
+ * @param completedBlock A block called when operation has been completed.
+ *
+ *   This parameter is required.
+ *
+ *   This block has no return value and takes the requested UIImage as first parameter.
+ *   In case of error the image parameter is nil and the second parameter may contain an NSError.
+ *
+ *   The third parameter is an `SDImageCacheType` enum indicating if the image was retrieved from the local cache
+ *   or from the memory cache or from the network.
+ *
+ *   The last parameter is set to NO when the SDWebImageProgressiveDownload option is used and the image is
+ *   downloading. This block is thus called repeatedly with a partial image. When image is fully downloaded, the
+ *   block is called a last time with the full image and the last parameter set to YES.
+ *
+ * @return Returns an NSObject conforming to SDWebImageOperation. Should be an instance of SDWebImageDownloaderOperation
+ */
 - (id <SDWebImageOperation>)downloadImageWithURL:(NSURL *)url
                                          options:(SDWebImageOptions)options
                              transformImageBlock:(SDWebImageTransformDownloadedImageBlock)transformBlock

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -96,6 +96,8 @@ typedef void(^SDWebImageCompletionWithFinishedBlock)(UIImage *image, NSError *er
 
 typedef NSString *(^SDWebImageCacheKeyFilterBlock)(NSURL *url);
 
+typedef UIImage *(^SDWebImageTransformDownloadedImageBlock)(UIImage *image, NSURL *imageUrl);
+
 
 @class SDWebImageManager;
 
@@ -211,6 +213,13 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
  */
 - (id <SDWebImageOperation>)downloadImageWithURL:(NSURL *)url
                                          options:(SDWebImageOptions)options
+                                        progress:(SDWebImageDownloaderProgressBlock)progressBlock
+                                       completed:(SDWebImageCompletionWithFinishedBlock)completedBlock;
+
+- (id <SDWebImageOperation>)downloadImageWithURL:(NSURL *)url
+                                         options:(SDWebImageOptions)options
+                             transformImageBlock:(SDWebImageTransformDownloadedImageBlock)transformBlock
+                                    transformKey:(NSString *)transformKey
                                         progress:(SDWebImageDownloaderProgressBlock)progressBlock
                                        completed:(SDWebImageCompletionWithFinishedBlock)completedBlock;
 

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -163,7 +163,11 @@
     SDWebImageTransformImageBlock cacheTransformImageBlock = nil;
     if (transformBlock) {
         cacheTransformImageBlock = ^(UIImage *image) {
-            return transformBlock(image, url);
+            if (!image.images || (options & SDWebImageTransformAnimatedImage)) {
+                return transformBlock(image, url);
+            } else {
+                return (UIImage *)nil;
+            }
         };
     }
     operation.cacheOperation = [self.imageCache queryDiskCacheForKey:key transformKey:transformKey transformBlock:cacheTransformImageBlock done:^(UIImage *image, SDImageCacheType cacheType) {

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -44,6 +44,12 @@
  */
 @interface UIImageView (WebCache)
 
+- (void)sd_setTransformDownloadedImageBlock:(SDWebImageTransformDownloadedImageBlock)transformBlock transformKey:(NSString *)transformKey;
+
+- (NSString *)sd_transformKey;
+
+- (SDWebImageTransformDownloadedImageBlock)sd_transformBlock;
+
 /**
  * Get the current image URL.
  *

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -11,6 +11,8 @@
 #import "UIView+WebCacheOperation.h"
 
 static char imageURLKey;
+static char imageTransformBlockKey;
+static char imageTransformKey;
 static char TAG_ACTIVITY_INDICATOR;
 static char TAG_ACTIVITY_STYLE;
 static char TAG_ACTIVITY_SHOW;
@@ -51,6 +53,9 @@ static char TAG_ACTIVITY_SHOW;
         });
     }
     
+    NSString *transformKey = [self sd_transformKey];
+    SDWebImageTransformDownloadedImageBlock transformBlock = [self sd_transformBlock];
+    
     if (url) {
 
         // check if activityView is enabled or not
@@ -59,7 +64,7 @@ static char TAG_ACTIVITY_SHOW;
         }
 
         __weak __typeof(self)wself = self;
-        id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+        id <SDWebImageOperation> operation = [SDWebImageManager.sharedManager downloadImageWithURL:url options:options transformImageBlock:transformBlock transformKey:transformKey progress:progressBlock completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             [wself removeActivityIndicator];
             if (!wself) return;
             dispatch_main_sync_safe(^{
@@ -104,6 +109,25 @@ static char TAG_ACTIVITY_SHOW;
 
 - (NSURL *)sd_imageURL {
     return objc_getAssociatedObject(self, &imageURLKey);
+}
+
+- (void)sd_setTransformDownloadedImageBlock:(SDWebImageTransformDownloadedImageBlock)transformBlock
+                               transformKey:(NSString *)transformKey {
+    if (transformBlock && transformKey) {
+        objc_setAssociatedObject(self, &imageTransformBlockKey, transformBlock, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        objc_setAssociatedObject(self, &imageTransformKey, transformKey, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    } else {
+        objc_setAssociatedObject(self, &imageTransformBlockKey, nil, OBJC_ASSOCIATION_COPY_NONATOMIC);
+        objc_setAssociatedObject(self, &imageTransformKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+}
+
+- (NSString *)sd_transformKey {
+    return objc_getAssociatedObject(self, &imageTransformKey);
+}
+
+- (SDWebImageTransformDownloadedImageBlock)sd_transformBlock {
+    return objc_getAssociatedObject(self, &imageTransformBlockKey);
 }
 
 - (void)sd_setAnimationImagesWithURLs:(NSArray *)arrayOfURLs {

--- a/SDWebImage_Transform.podspec
+++ b/SDWebImage_Transform.podspec
@@ -1,13 +1,12 @@
 Pod::Spec.new do |s|
-  s.name = 'SDWebImage'
-  s.version = '3.8.1'
+  s.name = 'SDWebImage_Transform'
+  s.version = '0.0.1'
   s.ios.deployment_target = '7.0'
-  s.tvos.deployment_target = '9.0'
   s.license = 'MIT'
-  s.summary = 'Asynchronous image downloader with cache support with an UIImageView category.'
-  s.homepage = 'https://github.com/rs/SDWebImage'
-  s.author = { 'Olivier Poitrey' => 'rs@dailymotion.com' }
-  s.source = { :git => 'https://github.com/rs/SDWebImage.git', :tag => s.version.to_s }
+  s.summary = 'Transform image using block instead of delegate, keep transformed file in memcache instread of disk'
+  s.homepage = 'https://github.com/kudocc/SDWebImage'
+  s.author = { 'KudoCC' => 'cangmuma@gmail.com' }
+  s.source = { :git => 'https://github.com/kudocc/SDWebImage.git', :tag => s.version.to_s }
 
   s.description = 'This library provides a category for UIImageView with support for remote '      \
                   'images coming from the web. It provides an UIImageView category adding web '    \


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

#### Can't apply different transform to the same URL
The transform method in `SDWebImageManagerDelegate` will transform the image and save the transformed image into the disk for specific URL. Suppose we have two places where use different transform method to the same URL, we can't achieve that perfectly because the first download request will transform the downloaded image and save it into disk, the second request fetch the image from disk, but the image is damaged.

The pull request add two parameters to `downloadImageWithURL:...`, they are `transformKey` and `transformBlock`, the transform key is used to identify different ways to transform images (for example: add a 5-point corner radius or shrink image to specific size), the transform block is the method used to apply transforming to image. If you don't want to apply a transform to a image, just use the original interface `downloadImageWithURL:options:progress:completed:`.

I also modify `SDImageCache.h', ``SDImageCache.m' to support this feature. The disk cache keeps the original image data instead of transformed data, and there is one memory cache for each transform key. Instead of using `memCache`, I create `NSMutableDictionary` whose key is `transformKey` and its value is `AutoPurgeCache`, there is a default memory cache created for non transformed data, its key is "default".
