### PR TITLE
predraw gif images in background thread

### DIFF
--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -36,9 +36,22 @@
                 continue;
             }
 
+            CGFloat width = CGImageGetWidth(image);
+            CGFloat height = CGImageGetHeight(image);
+
+            UIGraphicsBeginImageContext(CGSizeMake(width, height));
+            CGContextRef context = UIGraphicsGetCurrentContext();
+            CGContextTranslateCTM(context, 0, height);
+            CGContextScaleCTM(context, 1, -1);
+
+            CGContextDrawImage(context, CGRectMake(0, 0, width, height), image);
+
+            UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+            UIGraphicsEndImageContext();
+
             duration += [self sd_frameDurationAtIndex:i source:source];
 
-            [images addObject:[UIImage imageWithCGImage:image scale:[UIScreen mainScreen].scale orientation:UIImageOrientationUp]];
+            [images addObject:newImage];
 
             CGImageRelease(image);
         }


### PR DESCRIPTION
### New Pull Request Checklist 

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

In SDWebImage version 3.x, gif image drawing job executed in main thread.
So, speed for loading gif(first playback) is quite slow.

I know SDWebImage version 4.x changed gif support based on [FLAnimatedImage](https://github.com/Flipboard/FLAnimatedImage).
But in my experience, FLAnimatedImage uses so much resources such as CPU.
So I want to use this concept(gif to uiimage animatedimage) in this version.
