### PR TITLE
Allow to specify NSURLSessionConfiguration for SDWebImageDownloader

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -107,7 +107,7 @@ typedef NSDictionary *(^SDWebImageDownloaderHeadersFilterBlock)(NSURL *url, NSDi
  *
  *  @return global shared instance of downloader class
  */
-+ (SDWebImageDownloader *)sharedDownloader;
++ (instancetype)sharedDownloader;
 
 /**
  *  Set the default URL credential to be set for request operations.
@@ -131,6 +131,13 @@ typedef NSDictionary *(^SDWebImageDownloaderHeadersFilterBlock)(NSURL *url, NSDi
  * NSDictionary will be used as headers in corresponding HTTP request.
  */
 @property (nonatomic, copy) SDWebImageDownloaderHeadersFilterBlock headersFilter;
+
+/**
+ * Creates an instance of a downloader with specified session configuration.
+ * *Note*: `timeoutIntervalForRequest` is going to be overwritten.
+ * @return new instance of downloader class
+ */
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration NS_DESIGNATED_INITIALIZER;
 
 /**
  * Set a value for a HTTP header to be appended to each download HTTP request.

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -53,7 +53,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
     }
 }
 
-+ (SDWebImageDownloader *)sharedDownloader {
++ (instancetype)sharedDownloader {
     static dispatch_once_t once;
     static id instance;
     dispatch_once(&once, ^{
@@ -62,7 +62,11 @@ static NSString *const kCompletedCallbackKey = @"completed";
     return instance;
 }
 
-- (id)init {
+- (instancetype)init {
+    return [self initWithSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+}
+
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration {
     if ((self = [super init])) {
         _operationClass = [SDWebImageDownloaderOperation class];
         _shouldDecompressImages = YES;
@@ -78,15 +82,14 @@ static NSString *const kCompletedCallbackKey = @"completed";
         _barrierQueue = dispatch_queue_create("com.hackemist.SDWebImageDownloaderBarrierQueue", DISPATCH_QUEUE_CONCURRENT);
         _downloadTimeout = 15.0;
 
-        NSURLSessionConfiguration *sessionConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
-        sessionConfig.timeoutIntervalForRequest = _downloadTimeout;
+        sessionConfiguration.timeoutIntervalForRequest = _downloadTimeout;
 
         /**
          *  Create the session for this task
          *  We send nil as delegate queue so that the session creates a serial operation queue for performing all delegate
          *  method calls and completion handler calls.
          */
-        self.session = [NSURLSession sessionWithConfiguration:sessionConfig
+        self.session = [NSURLSession sessionWithConfiguration:sessionConfiguration
                                                      delegate:self
                                                 delegateQueue:nil];
     }


### PR DESCRIPTION
## Background
We are using https://www.packetzoom.com - service intended to optimize loading performance of images by rerouting HTTP requests. In order for their SDK to work we need to specify their `NSURLProtocol` class in `NSURLSessionConfiguration.protocolClasses`.

## Description
This pull request exposes an initializer on `SDWebImageDownloader` allowing to pass session configuration that'll be used by the downloader.

There are no breaking changes introduced, everyone who used the only public initializer available up to now will get the same behavior as they use to.