### PR TITLE
Add support for downloading images behind redirect

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -306,6 +306,11 @@ didReceiveResponse:(NSURLResponse *)response
     [dataOperation URLSession:session task:task didCompleteWithError:error];
 }
 
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
+    
+    completionHandler(request);
+}
+
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler {
 
     // Identify the operation that runs this task and pass it the delegate method

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -69,23 +69,4 @@ static int64_t kAsyncTestTimeout = 5;
     [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
 }
 
-- (void)testTestThatItCanDownloadAnImageWithARedirection {
-    __block XCTestExpectation *expectation = [self expectationWithDescription:@"Image download completes"];
-
-    NSURL *originalImageURL = [NSURL URLWithString:@"https://graph.facebook.com/1815229585429909/picture?width=640&height=640"];
-
-    [[SDWebImageManager sharedManager] downloadImageWithURL:originalImageURL options:SDWebImageRefreshCached progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
-        
-        expect(image).toNot.beNil();
-        expect(error).to.beNil();
-        expect(originalImageURL).toNot.equal(imageURL);
-        
-        [expectation fulfill];
-        expectation = nil;
-    }];
-    
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
-
-}
-
 @end

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -72,7 +72,7 @@ static int64_t kAsyncTestTimeout = 5;
 - (void)testTestThatItCanDownloadAnImageWithARedirection {
     __block XCTestExpectation *expectation = [self expectationWithDescription:@"Image download completes"];
 
-    NSURL *originalImageURL = [NSURL URLWithString:@"https://graph.facebook.com/10153629359641544/picture?width=640&height=640"];
+    NSURL *originalImageURL = [NSURL URLWithString:@"https://graph.facebook.com/1815229585429909/picture?width=640&height=640"];
 
     [[SDWebImageManager sharedManager] downloadImageWithURL:originalImageURL options:SDWebImageRefreshCached progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
         

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -69,4 +69,23 @@ static int64_t kAsyncTestTimeout = 5;
     [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
 }
 
+- (void)testTestThatItCanDownloadAnImageWithARedirection {
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"Image download completes"];
+
+    NSURL *originalImageURL = [NSURL URLWithString:@"https://graph.facebook.com/10153629359641544/picture?width=640&height=640"];
+
+    [[SDWebImageManager sharedManager] downloadImageWithURL:originalImageURL options:SDWebImageRefreshCached progress:nil completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+        
+        expect(image).toNot.beNil();
+        expect(error).to.beNil();
+        expect(originalImageURL).toNot.equal(imageURL);
+        
+        [expectation fulfill];
+        expectation = nil;
+    }];
+    
+    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+
+}
+
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

This merge request add the support for downloading images that are behind an HTTP redirect.
