### PR TITLE
Added shouldScaleImage in order to support LCR images

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -43,6 +43,11 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 @property (assign, nonatomic) BOOL shouldDecompressImages;
 
 /**
+ *  [defaults to YES]
+ */
+@property (assign, nonatomic) BOOL shouldScaleImage;
+
+/**
  *  disable iCloud backup [defaults to YES]
  */
 @property (assign, nonatomic) BOOL shouldDisableiCloud;

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -116,6 +116,8 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         // Set decompression to YES
         _shouldDecompressImages = YES;
 
+        _shouldScaleImage = YES;
+        
         // memory cache enabled
         _shouldCacheImagesInMemory = YES;
 
@@ -370,7 +372,10 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     NSData *data = [self diskImageDataBySearchingAllPathsForKey:key];
     if (data) {
         UIImage *image = [UIImage sd_imageWithData:data];
-        image = [self scaledImageForKey:key image:image];
+        if (self.shouldScaleImage) {
+            image = [self scaledImageForKey:key image:image];
+        }
+        
         if (self.shouldDecompressImages) {
             image = [UIImage decodedImageWithImage:image];
         }

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -83,6 +83,8 @@ typedef NSDictionary *(^SDWebImageDownloaderHeadersFilterBlock)(NSURL *url, NSDi
  */
 @property (assign, nonatomic) BOOL shouldDecompressImages;
 
+@property (assign, nonatomic) BOOL shouldScaleImage;
+
 @property (assign, nonatomic) NSInteger maxConcurrentDownloads;
 
 /**

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -66,6 +66,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
     if ((self = [super init])) {
         _operationClass = [SDWebImageDownloaderOperation class];
         _shouldDecompressImages = YES;
+        _shouldScaleImage = YES;
         _executionOrder = SDWebImageDownloaderFIFOExecutionOrder;
         _downloadQueue = [NSOperationQueue new];
         _downloadQueue.maxConcurrentOperationCount = 6;
@@ -191,6 +192,7 @@ static NSString *const kCompletedCallbackKey = @"completed";
                                                             });
                                                         }];
         operation.shouldDecompressImages = wself.shouldDecompressImages;
+        operation.shouldScaleImage = wself.shouldScaleImage;
         
         if (wself.urlCredential) {
             operation.credential = wself.urlCredential;

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -30,6 +30,8 @@ extern NSString *const SDWebImageDownloadFinishNotification;
 
 @property (assign, nonatomic) BOOL shouldDecompressImages;
 
+@property (assign, nonatomic) BOOL shouldScaleImage;
+
 /**
  *  Was used to determine whether the URL connection should consult the credential storage for authenticating the connection.
  *  @deprecated Not used for a couple of versions

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -75,6 +75,7 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
     if ((self = [super init])) {
         _request = [request copy];
         _shouldDecompressImages = YES;
+        _shouldScaleImage = YES;
         _options = options;
         _progressBlock = [progressBlock copy];
         _completedBlock = [completedBlock copy];
@@ -416,7 +417,10 @@ didReceiveResponse:(NSURLResponse *)response
             } else if (self.imageData) {
                 UIImage *image = [UIImage sd_imageWithData:self.imageData];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-                image = [self scaledImageForKey:key image:image];
+                
+                if (self.shouldScaleImage) {
+                    image = [self scaledImageForKey:key image:image];
+                }
                 
                 // Do not force decoding animated GIFs
                 if (!image.images) {


### PR DESCRIPTION
### New Pull Request Checklist
- [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
- [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
- [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none
- [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necesarry)
- [ ] I have run the tests and they pass
- [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues:
https://github.com/rs/SDWebImage/issues/1519
### Pull Request Description

With the following lines, the LCR images are supported:

```
        SDImageCache.sharedImageCache().shouldDecompressImages = false
        SDImageCache.sharedImageCache().shouldScaleImage = false
        SDWebImageDownloader.sharedDownloader().shouldDecompressImages = false
        SDWebImageDownloader.sharedDownloader().shouldScaleImage = false
```

This isn't a perfect solution, because all the images won't be scaled or decompressed, but in my case that's fine because I was having memory issues (which meant I had to set shouldDecompressImages to false anyway) and I don't need to scale the images.
