### PR TITLE
#1619: Adds NSError as input to resourceValuesForKeys:error: method t…

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -528,10 +528,11 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         //  2. Storing file attributes for the size-based cleanup pass.
         NSMutableArray *urlsToDelete = [[NSMutableArray alloc] init];
         for (NSURL *fileURL in fileEnumerator) {
-            NSDictionary *resourceValues = [fileURL resourceValuesForKeys:resourceKeys error:NULL];
-
-            // Skip directories.
-            if ([resourceValues[NSURLIsDirectoryKey] boolValue]) {
+            NSError *error;
+            NSDictionary *resourceValues = [fileURL resourceValuesForKeys:resourceKeys error:&error];
+            
+            // Skip directories and errors.
+            if (error || [resourceValues[NSURLIsDirectoryKey] boolValue]) {
                 continue;
             }
 

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -532,7 +532,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             NSDictionary *resourceValues = [fileURL resourceValuesForKeys:resourceKeys error:&error];
             
             // Skip directories and errors.
-            if (error || [resourceValues[NSURLIsDirectoryKey] boolValue]) {
+            if (/*error || */[resourceValues[NSURLIsDirectoryKey] boolValue]) {
                 continue;
             }
 

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -532,7 +532,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             NSDictionary *resourceValues = [fileURL resourceValuesForKeys:resourceKeys error:&error];
             
             // Skip directories and errors.
-            if (/*error || */[resourceValues[NSURLIsDirectoryKey] boolValue]) {
+            if (error || [resourceValues[NSURLIsDirectoryKey] boolValue]) {
                 continue;
             }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description
This fixes handling of a potential unexpected error in SDImageCache, when cleanDiskWithCompletionBlock: is executed when an implementing app is sent to the background. Instead of passing NULL as the NSError argument, we now pass a NSError reference and continue the loop if an error occurred while reading resourceValues for a random cached image. The crash is only seen happening for iOS10 users.
