### PR TITLE
it is better to judge block is nil before dispatch

### DIFF
--- a/SDWebImage/MKAnnotationView+WebCache.m
+++ b/SDWebImage/MKAnnotationView+WebCache.m
@@ -70,12 +70,12 @@ static char imageURLKey;
         }];
         [self sd_setImageLoadOperation:operation forKey:@"MKAnnotationViewImage"];
     } else {
-        dispatch_main_async_safe(^{
-            NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Trying to load a nil url"}];
-            if (completedBlock) {
+        if (completedBlock) {
+            dispatch_main_async_safe(^{
+                NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Trying to load a nil url"}];
                 completedBlock(nil, error, SDImageCacheTypeNone, url);
-            }
-        });
+            });
+        }
     }
 }
 

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -84,11 +84,11 @@
     
     if (isInMemoryCache) {
         // making sure we call the completion block on the main queue
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (completionBlock) {
+        if (completionBlock) {
+            dispatch_async(dispatch_get_main_queue(), ^{
                 completionBlock(YES);
-            }
-        });
+            });
+        }
         return;
     }
     

--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -56,12 +56,12 @@ static char imageURLStorageKey;
     if (!url) {
         [self.imageURLStorage removeObjectForKey:@(state)];
         
-        dispatch_main_async_safe(^{
-            if (completedBlock) {
+        if (completedBlock) {
+            dispatch_main_async_safe(^{
                 NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Trying to load a nil url"}];
                 completedBlock(nil, error, SDImageCacheTypeNone, url);
-            }
-        });
+            });
+        }
         
         return;
     }
@@ -137,12 +137,12 @@ static char imageURLStorageKey;
         }];
         [self sd_setBackgroundImageLoadOperation:operation forState:state];
     } else {
-        dispatch_main_async_safe(^{
-            NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Trying to load a nil url"}];
-            if (completedBlock) {
+        if (completedBlock) {
+            dispatch_main_async_safe(^{
+                NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Trying to load a nil url"}];
                 completedBlock(nil, error, SDImageCacheTypeNone, url);
-            }
-        });
+            });
+        }
     }
 }
 

--- a/SDWebImage/UIImageView+HighlightedWebCache.m
+++ b/SDWebImage/UIImageView+HighlightedWebCache.m
@@ -55,12 +55,12 @@
         }];
         [self sd_setImageLoadOperation:operation forKey:UIImageViewHighlightedWebCacheOperationKey];
     } else {
-        dispatch_main_async_safe(^{
-            NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Trying to load a nil url"}];
-            if (completedBlock) {
+        if (completedBlock) {
+            dispatch_main_async_safe(^{
+                NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Trying to load a nil url"}];
                 completedBlock(nil, error, SDImageCacheTypeNone, url);
-            }
-        });
+            });
+        }
     }
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

it is better to judge block is nil before dispatch
...


