### PR TITLE
change dispatch_sync to dispatch_barrier_sync and add self nil check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,7 @@ script:
 
     - pod install --project-directory=Tests
     - xctool -workspace SDWebImage.xcworkspace -scheme 'SDWebImage' -sdk iphonesimulator clean
-    - xctool -workspace SDWebImage.xcworkspace -scheme 'Tests' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' test
+    - xctool -workspace SDWebImage.xcworkspace -scheme 'Tests' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
+
+after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -158,15 +158,16 @@ static NSString *const kCompletedCallbackKey = @"completed";
                                                              SDWebImageDownloader *sself = wself;
                                                              if (!sself) return;
                                                              __block NSArray *callbacksForURL;
-                                                             dispatch_sync(sself.barrierQueue, ^{
+                                                             dispatch_barrier_sync(sself.barrierQueue, ^{
                                                                  callbacksForURL = [sself.URLCallbacks[url] copy];
                                                              });
-                                                             for (NSDictionary *callbacks in callbacksForURL) {
-                                                                 dispatch_async(dispatch_get_main_queue(), ^{
+                                                             if (!sself) return;
+                                                             dispatch_async(dispatch_get_main_queue(), ^{
+                                                                 for (NSDictionary *callbacks in callbacksForURL) {
                                                                      SDWebImageDownloaderProgressBlock callback = callbacks[kProgressCallbackKey];
                                                                      if (callback) callback(receivedSize, expectedSize);
-                                                                 });
-                                                             }
+                                                                 }
+                                                             });
                                                          }
                                                         completed:^(UIImage *image, NSData *data, NSError *error, BOOL finished) {
                                                             SDWebImageDownloader *sself = wself;


### PR DESCRIPTION
The crash is occurred in the progress block in SDWebImageDownloader randomly. I changed dispath_sync to dispatch_barrier_sync. When the crash was happened, self object was deallocated but still block statement was trying to run the code. So I added self nil check just after the sync block.
