### PR TITLE
Fix FLAnimatedImageView+WebCache.m not got compiled

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -6,9 +6,9 @@
  * file that was distributed with this source code.
  */
 
-#if SD_UIKIT
-
 #import "FLAnimatedImageView+WebCache.h"
+
+#if SD_UIKIT
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 #import "UIView+WebCache.h"
@@ -53,9 +53,9 @@
                              options:options
                         operationKey:nil
                        setImageBlock:^(UIImage *image, NSData *imageData) {
-                           SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:data];
+                           SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
                            if (imageFormat == SDImageFormatGIF) {
-                               weakSelf.animatedImage = [FLAnimatedImage animatedImageWithGIFData:data];
+                               weakSelf.animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
                                weakSelf.image = nil;
                            } else {
                                weakSelf.image = image;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Fix FLAnimatedImageView+WebCache.m not got compiled
Because of missing SD_UIKIT definition.

This is critical to merge pull request, because animated gifs are not working at all.
