### PR TITLE
Fix FLAnimatedImage import when using CocoaPods

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -10,7 +10,7 @@
 
 #if SD_UIKIT
 
-#if COCOAPODS
+#if !COCOAPODS
 @import FLAnimatedImage;
 #else
 #import "FLAnimatedImageView.h"

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -10,8 +10,8 @@
 
 #if SD_UIKIT
 
-#if !COCOAPODS
-@import FLAnimatedImage;
+#if __has_include(<FLAnimatedImage/FLAnimatedImage.h>)
+#import <FLAnimatedImage/FLAnimatedImage.h>
 #else
 #import "FLAnimatedImageView.h"
 #endif


### PR DESCRIPTION
### New Pull Request Checklist
- [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
- [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
- [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none
- [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necesarry)
- [ ] I have run the tests and they pass
- [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...
### Pull Request Description

This fix the import issue when trying to use `SDWebImage/GIF` with CocoaPods.
