### PR TITLE
Added initial support for ALAsset and PHAsset

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Core' do |core|
     core.source_files = 'SDWebImage/{NS,SD,UI}*.{h,m}'
-    core.exclude_files = 'SDWebImage/UIImage+WebP.{h,m}'
+    core.exclude_files = 'SDWebImage/UIImage+WebP.{h,m}', 'SDWebImage/SDWebImageManager+ALAsset.{h,m}', 'SDWebImage/SDWebImageManager+PHAsset.{h,m}'
     core.tvos.exclude_files = 'SDWebImage/MKAnnotationView+WebCache.*'
   end
 
@@ -63,5 +63,19 @@ Pod::Spec.new do |s|
     }
     webp.dependency 'SDWebImage/Core'
     webp.dependency 'libwebp'
+  end
+
+  s.subspec 'ALAsset' do |al|
+    al.source_files = 'SDWebImage/SDWebImageManager+ALAsset.{h,m}'
+    al.framework = 'AssetsLibrary'
+    al.dependency 'SDWebImage/Core'
+  end
+
+  s.subspec 'PHAsset' do |ph|
+    ph.source_files = 'SDWebImage/SDWebImageManager+PHAsset.{h,m}'
+    ph.ios.deployment_target = '8.0'
+    ph.tvos.deployment_target = '10.0'
+    ph.framework = 'Photos'
+    ph.dependency 'SDWebImage/Core'
   end
 end

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -39,6 +39,16 @@
 		00733A711BC4880E00A5A117 /* UIImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D95148C56230056699D /* UIImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00733A721BC4880E00A5A117 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00733A731BC4880E00A5A117 /* SDWebImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A2CAE031AB4BB5400B6BC39 /* SDWebImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D194E171DB1FC0A00493076 /* SDWebImageManager+ALAsset.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D4F08791DB1DE5F00ED5854 /* SDWebImageManager+ALAsset.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D194E1D1DB2065F00493076 /* SDWebImageManager+PHAsset.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D194E1B1DB2065F00493076 /* SDWebImageManager+PHAsset.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D194E1E1DB2065F00493076 /* SDWebImageManager+PHAsset.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D194E1C1DB2065F00493076 /* SDWebImageManager+PHAsset.m */; };
+		2D194E1F1DB2088400493076 /* SDWebImageManager+PHAsset.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D194E1B1DB2065F00493076 /* SDWebImageManager+PHAsset.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D194E201DB2088400493076 /* SDWebImageManager+PHAsset.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D194E1B1DB2065F00493076 /* SDWebImageManager+PHAsset.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D194E211DB2088800493076 /* SDWebImageManager+PHAsset.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D194E1C1DB2065F00493076 /* SDWebImageManager+PHAsset.m */; };
+		2D194E221DB2088800493076 /* SDWebImageManager+PHAsset.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D194E1C1DB2065F00493076 /* SDWebImageManager+PHAsset.m */; };
+		2D4F087B1DB1DE6000ED5854 /* SDWebImageManager+ALAsset.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D4F08791DB1DE5F00ED5854 /* SDWebImageManager+ALAsset.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D4F087C1DB1DE6000ED5854 /* SDWebImageManager+ALAsset.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D4F087A1DB1DE6000ED5854 /* SDWebImageManager+ALAsset.m */; };
+		2D4F087D1DB1E02B00ED5854 /* SDWebImageManager+ALAsset.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D4F087A1DB1DE6000ED5854 /* SDWebImageManager+ALAsset.m */; };
 		4314D11E1D0E0E3B004B36C9 /* huffman.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB21998E60B007367ED /* huffman.c */; };
 		4314D11F1D0E0E3B004B36C9 /* quant_levels.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB71998E60B007367ED /* quant_levels.c */; };
 		4314D1201D0E0E3B004B36C9 /* idec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D601998E6B2007367ED /* idec.c */; };
@@ -931,6 +941,10 @@
 
 /* Begin PBXFileReference section */
 		00733A4C1BC487C000A5A117 /* SDWebImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D194E1B1DB2065F00493076 /* SDWebImageManager+PHAsset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SDWebImageManager+PHAsset.h"; path = "SDWebImage/SDWebImageManager+PHAsset.h"; sourceTree = "<group>"; };
+		2D194E1C1DB2065F00493076 /* SDWebImageManager+PHAsset.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "SDWebImageManager+PHAsset.m"; path = "SDWebImage/SDWebImageManager+PHAsset.m"; sourceTree = "<group>"; };
+		2D4F08791DB1DE5F00ED5854 /* SDWebImageManager+ALAsset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SDWebImageManager+ALAsset.h"; path = "SDWebImage/SDWebImageManager+ALAsset.h"; sourceTree = "<group>"; };
+		2D4F087A1DB1DE6000ED5854 /* SDWebImageManager+ALAsset.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "SDWebImageManager+ALAsset.m"; path = "SDWebImage/SDWebImageManager+ALAsset.m"; sourceTree = "<group>"; };
 		4314D1991D0E0E3B004B36C9 /* libSDWebImage watchOS static.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libSDWebImage watchOS static.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		431BB7031D06D2C1006A3455 /* SDWebImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4369C2751D9807EC007E863A /* UIView+WebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIView+WebCache.h"; path = "SDWebImage/UIView+WebCache.h"; sourceTree = "<group>"; };
@@ -1167,6 +1181,10 @@
 				53922D96148C56230056699D /* UIImageView+WebCache.m */,
 				4369C2751D9807EC007E863A /* UIView+WebCache.h */,
 				4369C2761D9807EC007E863A /* UIView+WebCache.m */,
+				2D4F08791DB1DE5F00ED5854 /* SDWebImageManager+ALAsset.h */,
+				2D4F087A1DB1DE6000ED5854 /* SDWebImageManager+ALAsset.m */,
+				2D194E1B1DB2065F00493076 /* SDWebImageManager+PHAsset.h */,
+				2D194E1C1DB2065F00493076 /* SDWebImageManager+PHAsset.m */,
 			);
 			name = "WebCache Categories";
 			path = ..;
@@ -1512,6 +1530,7 @@
 				431739351CDFC8B20008FEB9 /* bit_reader.h in Headers */,
 				43DA7D5D1D1086600028BE58 /* mips_macro.h in Headers */,
 				00733A6F1BC4880E00A5A117 /* UIImage+WebP.h in Headers */,
+				2D194E201DB2088400493076 /* SDWebImageManager+PHAsset.h in Headers */,
 				43DA7D471D1086600028BE58 /* dsp.h in Headers */,
 				431739431CDFC8B20008FEB9 /* quant_levels.h in Headers */,
 				00733A681BC4880E00A5A117 /* SDWebImageManager.h in Headers */,
@@ -1787,11 +1806,13 @@
 				43DA7D351D10865F0028BE58 /* yuv.h in Headers */,
 				43DA7D251D10865F0028BE58 /* lossless.h in Headers */,
 				4A2CAE2F1AB4BB7500B6BC39 /* UIImage+MultiFormat.h in Headers */,
+				2D194E171DB1FC0A00493076 /* SDWebImageManager+ALAsset.h in Headers */,
 				4A2CAE1A1AB4BB6400B6BC39 /* SDWebImageOperation.h in Headers */,
 				431738CE1CDFC8A30008FEB9 /* vp8i.h in Headers */,
 				43DA7DDE1D10867B0028BE58 /* extras.h in Headers */,
 				431738D01CDFC8A30008FEB9 /* vp8li.h in Headers */,
 				431739201CDFC8B20008FEB9 /* color_cache.h in Headers */,
+				2D194E1F1DB2088400493076 /* SDWebImageManager+PHAsset.h in Headers */,
 				431739331CDFC8B20008FEB9 /* utils.h in Headers */,
 				4A2CAE1B1AB4BB6800B6BC39 /* SDWebImageDownloader.h in Headers */,
 				431739251CDFC8B20008FEB9 /* huffman.h in Headers */,
@@ -1826,6 +1847,7 @@
 				43DA7CB81D1086570028BE58 /* mips_macro.h in Headers */,
 				431738B21CDFC2630008FEB9 /* quant_levels.h in Headers */,
 				5D5B9142188EE8DD006D06BD /* NSData+ImageContentType.h in Headers */,
+				2D194E1D1DB2065F00493076 /* SDWebImageManager+PHAsset.h in Headers */,
 				431738C11CDFC2660008FEB9 /* mux.h in Headers */,
 				431738AE1CDFC2630008FEB9 /* huffman.h in Headers */,
 				53761318155AD0D5005750A4 /* SDWebImageCompat.h in Headers */,
@@ -1855,6 +1877,7 @@
 				431738791CDFC2580008FEB9 /* alphai.h in Headers */,
 				43DA7C161D1086000028BE58 /* common.h in Headers */,
 				431738C01CDFC2660008FEB9 /* format_constants.h in Headers */,
+				2D4F087B1DB1DE6000ED5854 /* SDWebImageManager+ALAsset.h in Headers */,
 				431738B81CDFC2630008FEB9 /* rescaler.h in Headers */,
 				43CE75761CFE9427006C64D0 /* FLAnimatedImage.h in Headers */,
 				438096721CDFC08200DC626B /* MKAnnotationView+WebCache.h in Headers */,
@@ -2168,6 +2191,7 @@
 				00733A5D1BC4880000A5A117 /* UIImage+GIF.m in Sources */,
 				43DA7D501D1086600028BE58 /* filters_sse2.c in Sources */,
 				43DA7D4E1D1086600028BE58 /* enc.c in Sources */,
+				2D194E221DB2088800493076 /* SDWebImageManager+PHAsset.m in Sources */,
 				43DA7D6B1D1086600028BE58 /* yuv.c in Sources */,
 				431738DC1CDFC8A40008FEB9 /* vp8.c in Sources */,
 				43CE757B1CFE9427006C64D0 /* FLAnimatedImage.m in Sources */,
@@ -2521,6 +2545,7 @@
 				43DA7D2B1D10865F0028BE58 /* rescaler_sse2.c in Sources */,
 				43DA7D091D10865F0028BE58 /* dec_clip_tables.c in Sources */,
 				4317392E1CDFC8B20008FEB9 /* rescaler.c in Sources */,
+				2D4F087D1DB1E02B00ED5854 /* SDWebImageManager+ALAsset.m in Sources */,
 				431738CB1CDFC8A30008FEB9 /* quant.c in Sources */,
 				43DA7D081D10865F0028BE58 /* cpu.c in Sources */,
 				431739301CDFC8B20008FEB9 /* thread.c in Sources */,
@@ -2589,6 +2614,7 @@
 				43DA7D001D10865F0028BE58 /* alpha_processing.c in Sources */,
 				4369C2801D9807EC007E863A /* UIView+WebCache.m in Sources */,
 				43DA7D321D10865F0028BE58 /* yuv_mips32.c in Sources */,
+				2D194E211DB2088800493076 /* SDWebImageManager+PHAsset.m in Sources */,
 				43DA7D281D10865F0028BE58 /* rescaler_mips_dsp_r2.c in Sources */,
 				431738C81CDFC8A30008FEB9 /* frame.c in Sources */,
 				4317391A1CDFC8B20008FEB9 /* bit_reader.c in Sources */,
@@ -2646,6 +2672,7 @@
 				43DA7CBC1D1086570028BE58 /* rescaler_neon.c in Sources */,
 				43DA7C911D1086570028BE58 /* alpha_processing_sse41.c in Sources */,
 				43DA7CBF1D1086570028BE58 /* upsampling_mips_dsp_r2.c in Sources */,
+				2D4F087C1DB1DE6000ED5854 /* SDWebImageManager+ALAsset.m in Sources */,
 				5376130D155AD0D5005750A4 /* SDWebImagePrefetcher.m in Sources */,
 				43A9186B1D8308FE00B3925F /* SDImageCacheConfig.m in Sources */,
 				43DA7C981D1086570028BE58 /* cost_sse2.c in Sources */,
@@ -2694,6 +2721,7 @@
 				43DA7C921D1086570028BE58 /* alpha_processing.c in Sources */,
 				4369C27E1D9807EC007E863A /* UIView+WebCache.m in Sources */,
 				43DA7CC41D1086570028BE58 /* yuv_mips32.c in Sources */,
+				2D194E1E1DB2065F00493076 /* SDWebImageManager+PHAsset.m in Sources */,
 				43DA7CBA1D1086570028BE58 /* rescaler_mips_dsp_r2.c in Sources */,
 				4317387C1CDFC2580008FEB9 /* frame.c in Sources */,
 				431738A31CDFC2630008FEB9 /* bit_reader.c in Sources */,

--- a/SDWebImage/SDWebImageManager+ALAsset.h
+++ b/SDWebImage/SDWebImageManager+ALAsset.h
@@ -1,0 +1,34 @@
+//
+//  SDImageCache+ALAssets.h
+//  SDWebImage
+//
+//  Created by skyline on 16/10/15.
+//  Copyright © 2016年 Dailymotion. All rights reserved.
+//
+
+#import "SDWebImageCompat.h"
+
+#if SD_IOS
+
+#import "SDWebImageManager.h"
+#import <AssetsLibrary/AssetsLibrary.h>
+
+typedef void (^SDLocalALAssetRetrievalCompletionBlock)(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType);
+
+@interface SDWebImageManager (ALAsset)
+
+
+/**
+ * Load image from ALAssetsLibaray using the given URL if not present in cache or return the cached version otherwise.
+ *
+ * @param url            The URL of the asset, which can be acquired from ALAsset using `ALAssetPropertyAssetURL`.
+ * @param targetSize     The image size. Note this will also be used as part of cache key.
+ * @param completedBlock A block called when query has been completed.
+ */
+- (void)loadImageWithALAssetURL:(nullable NSURL *)url
+                     targetSize:(CGSize)targetSize
+                     completion:(nullable SDLocalALAssetRetrievalCompletionBlock)completedBlock;
+
+@end
+
+#endif

--- a/SDWebImage/SDWebImageManager+ALAsset.h
+++ b/SDWebImage/SDWebImageManager+ALAsset.h
@@ -1,10 +1,10 @@
-//
-//  SDImageCache+ALAssets.h
-//  SDWebImage
-//
-//  Created by skyline on 16/10/15.
-//  Copyright © 2016年 Dailymotion. All rights reserved.
-//
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 #import "SDWebImageCompat.h"
 

--- a/SDWebImage/SDWebImageManager+ALAsset.m
+++ b/SDWebImage/SDWebImageManager+ALAsset.m
@@ -1,0 +1,198 @@
+//
+//  SDImageCache+ALAssets.m
+//  SDWebImage
+//
+//  Created by skyline on 16/10/15.
+//  Copyright © 2016年 Dailymotion. All rights reserved.
+//
+
+#import "SDWebImageManager+ALAsset.h"
+
+#if SD_IOS
+
+#import "objc/runtime.h"
+
+typedef NS_ENUM(NSUInteger, SDLocalALAssetSize) {
+    SDLocalALAssetSizeAspectThumbnail,
+    SDLocalALAssetSizeSquareThumbnail,
+    SDLocalALAssetSizeAspectFullscreen,
+    SDLocalALAssetSizeAspectOriginal
+};
+
+static char SDLocalALAssetsLibraryPropertyKey;
+static char SDLocalALAssetsAssetURLToAssetPropertyKey;
+
+@implementation SDWebImageManager (ALAssets)
+
+- (ALAssetsLibrary *)assetsLibrary {
+    return objc_getAssociatedObject(self, &SDLocalALAssetsLibraryPropertyKey);
+}
+
+- (void)setAssetsLibrary:(ALAssetsLibrary *)assetsLibrary {
+    objc_setAssociatedObject(self, &SDLocalALAssetsLibraryPropertyKey, assetsLibrary, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (NSMutableDictionary<NSString *, ALAsset *> *)localAssetURLToAssetCache {
+    return objc_getAssociatedObject(self, &SDLocalALAssetsAssetURLToAssetPropertyKey);
+}
+
+- (void)setLocalAssetURLToAssetCache:(NSMutableDictionary *)localAssetURLToAssetCache {
+    objc_setAssociatedObject(self, &SDLocalALAssetsAssetURLToAssetPropertyKey, localAssetURLToAssetCache, OBJC_ASSOCIATION_RETAIN);
+}
+
+#pragma mark -
+
+- (SDLocalALAssetSize)localALAssetSizeForTargetSize:(CGSize)targetSize {
+
+    /*
+
+     ALAssetLibrary Thumbnail sizes come in the following flavors:
+
+     iPhone:
+     Thumbnail (Aspect):  120x90 or 90x120 (depending on aspect ratio)
+     Thumbnail (Square):  150x150
+     Fullscreen (Aspect): (screenWidth*screenScale)x(screenHeight*screenScale) or reverse (depending on aspect ratio)
+     Original:            Anything > Fullscreen size
+
+     iPad:
+     Thumbnail (Aspect): 480x360 or 360x480 (depending on aspect ratio) < WTF, pretty big for thumbnail...
+     Thumbnail (Square): 157x157 < WTF, small compared to aspect...
+     Fullscreen (Aspect): (screenWidth*screenScale)x(screenHeight*screenScale) or reverse (depending on aspect ratio)
+     Original:            Anything > Fullscreen size
+
+     */
+
+    CGFloat pixelsRequested = targetSize.width * targetSize.height;
+
+    CGFloat thumbPixels;
+
+    if (targetSize.width == targetSize.height) {
+        thumbPixels = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) ? (157 * 157) : (150 * 150);
+    } else {
+        thumbPixels = (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) ? (480 * 360) : (120 * 90);
+    }
+
+    CGFloat fullscreenPixels = (([UIScreen mainScreen].bounds.size.width * [UIScreen mainScreen].scale) * ([UIScreen mainScreen].bounds.size.height * [UIScreen mainScreen].scale));
+
+    CGFloat thumbCutoff = thumbPixels * 2.0f; // Don't scale thumbnails more than 2x
+
+    if (pixelsRequested <= thumbCutoff) {
+        if (targetSize.width == targetSize.height) {
+            return SDLocalALAssetSizeSquareThumbnail;
+        } else {
+            return SDLocalALAssetSizeAspectThumbnail;
+        }
+    } else if (pixelsRequested <= fullscreenPixels) {
+        return SDLocalALAssetSizeAspectFullscreen;
+    } else {
+        return SDLocalALAssetSizeAspectOriginal;
+    }
+}
+
+- (NSString *)cacheKeyForALAssetURL:(NSURL *)url targetSize:(CGSize)targetSize {
+
+    NSString *urlString = nil;
+    if ([url isKindOfClass:NSString.class]) {
+        urlString = (NSString *)url;
+    } else {
+        urlString = url.absoluteString;
+    }
+
+    NSString *cacheKey = [NSString stringWithFormat:@"%@-%@", urlString, NSStringFromCGSize(targetSize)];
+    return cacheKey;
+}
+
+- (void)loadImageWithALAssetURL:(NSURL *)url
+                     targetSize:(CGSize)targetSize
+                     completion:(SDLocalALAssetRetrievalCompletionBlock)completedBlock {
+    NSAssert(completedBlock != nil, @"Compelete block should not be nil");
+
+    if (!self.assetsLibrary) {
+        self.assetsLibrary = [ALAssetsLibrary new];
+    }
+
+    if (!self.localAssetURLToAssetCache) {
+        self.localAssetURLToAssetCache = @{}.mutableCopy;
+    }
+
+    if ([url isKindOfClass:NSString.class]) {
+        url = [NSURL URLWithString:(NSString *)url];
+    }
+
+    UIImage *image = [self.imageCache imageFromCacheForKey:[self cacheKeyForALAssetURL:url targetSize:targetSize]];
+    if (image) {
+        completedBlock(image, nil, SDImageCacheTypeMemory);
+        return;
+    }
+
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        NSString *cacheKey = [self cacheKeyForALAssetURL:url targetSize:targetSize];
+
+        UIImage *returnImage;
+
+        __block ALAsset *localAsset;
+        localAsset = [self.localAssetURLToAssetCache valueForKey:cacheKey];
+
+        if (!localAsset) {
+            // Force the retrieval of the ALAsset to get retrieved from the ALAssetsLibrary synchronously using a semaphore
+            dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+                [self.assetsLibrary assetForURL:url
+                                    resultBlock:^(ALAsset *asset) {
+                                        @autoreleasepool {
+                                            if (asset) {
+                                                localAsset = asset;
+                                                @synchronized(self.localAssetURLToAssetCache) {
+                                                    [self.localAssetURLToAssetCache setValue:asset forKey:url.absoluteString];
+                                                }
+                                            }
+                                        }
+                                        dispatch_semaphore_signal(sema);
+                                    } failureBlock:^(NSError *error) {
+                                        dispatch_semaphore_signal(sema);
+                                    }];
+            });
+            dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
+        }
+
+        if (localAsset) {
+            // Intelligently choose the right ALAssetRepresentation based on the size requested
+            switch ([self localALAssetSizeForTargetSize:targetSize]) {
+                case SDLocalALAssetSizeAspectOriginal:
+                    returnImage = [UIImage imageWithCGImage:localAsset.defaultRepresentation.fullResolutionImage];
+                    break;
+
+                case SDLocalALAssetSizeAspectFullscreen:
+                    returnImage = [UIImage imageWithCGImage:localAsset.defaultRepresentation.fullScreenImage];
+                    break;
+
+                case SDLocalALAssetSizeSquareThumbnail:
+                    returnImage = [UIImage imageWithCGImage:localAsset.thumbnail];
+                    break;
+
+                case SDLocalALAssetSizeAspectThumbnail:
+                default:
+                    returnImage = [UIImage imageWithCGImage:localAsset.aspectRatioThumbnail];
+                    break;
+            }
+
+            if (returnImage) {
+                [self.imageCache storeImage:returnImage forKey:cacheKey completion:nil];
+            }
+
+            dispatch_main_async_safe(^{
+                completedBlock(returnImage, nil, SDImageCacheTypeNone);
+            });
+
+        } else {
+            dispatch_main_async_safe(^{
+                NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Cannot retrieve ALAsset"}];
+                completedBlock(nil, error, SDImageCacheTypeNone);
+            });
+        }
+    });
+}
+
+@end
+
+#endif

--- a/SDWebImage/SDWebImageManager+ALAsset.m
+++ b/SDWebImage/SDWebImageManager+ALAsset.m
@@ -1,10 +1,10 @@
-//
-//  SDImageCache+ALAssets.m
-//  SDWebImage
-//
-//  Created by skyline on 16/10/15.
-//  Copyright © 2016年 Dailymotion. All rights reserved.
-//
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 #import "SDWebImageManager+ALAsset.h"
 

--- a/SDWebImage/SDWebImageManager+PHAsset.h
+++ b/SDWebImage/SDWebImageManager+PHAsset.h
@@ -1,10 +1,10 @@
-//
-//  SDWebImageManager+PHAsset.h
-//  SDWebImage
-//
-//  Created by skyline on 16/10/15.
-//  Copyright © 2016年 Dailymotion. All rights reserved.
-//
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 #import "SDWebImageCompat.h"
 

--- a/SDWebImage/SDWebImageManager+PHAsset.h
+++ b/SDWebImage/SDWebImageManager+PHAsset.h
@@ -1,0 +1,34 @@
+//
+//  SDWebImageManager+PHAsset.h
+//  SDWebImage
+//
+//  Created by skyline on 16/10/15.
+//  Copyright © 2016年 Dailymotion. All rights reserved.
+//
+
+#import "SDWebImageCompat.h"
+
+#if SD_UIKIT
+
+#import "SDWebImageManager.h"
+#import <Photos/Photos.h>
+
+@interface SDWebImageManager (PHAsset)
+
+typedef void (^SDLocalPHAssetRetrievalCompletionBlock)(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType);
+
+
+/**
+ * Load image using PHImageManager with the given identifier if not present in cache or return the cached version otherwise
+ *
+ * @param identifier     The URL of the asset, which can be acquired from PHAsset using `localIdentifier`.
+ * @param targetSize     The image size. Note this will also be used as part of cache key.
+ * @param completedBlock A block called when query has been completed.
+ */
+- (void)loadImageWithPHAssetIdentifier:(nullable NSString *)identifier
+                            targetSize:(CGSize)targetSize
+                            completion:(nullable SDLocalPHAssetRetrievalCompletionBlock)completedBlock;
+
+@end
+
+#endif

--- a/SDWebImage/SDWebImageManager+PHAsset.m
+++ b/SDWebImage/SDWebImageManager+PHAsset.m
@@ -1,10 +1,10 @@
-//
-//  SDWebImageManager+PHAsset.m
-//  SDWebImage
-//
-//  Created by skyline on 16/10/15.
-//  Copyright © 2016年 Dailymotion. All rights reserved.
-//
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 #import "SDWebImageManager+PHAsset.h"
 

--- a/SDWebImage/SDWebImageManager+PHAsset.m
+++ b/SDWebImage/SDWebImageManager+PHAsset.m
@@ -1,0 +1,120 @@
+//
+//  SDWebImageManager+PHAsset.m
+//  SDWebImage
+//
+//  Created by skyline on 16/10/15.
+//  Copyright © 2016年 Dailymotion. All rights reserved.
+//
+
+#import "SDWebImageManager+PHAsset.h"
+
+#ifdef SD_UIKIT
+
+#import "objc/runtime.h"
+
+static char SDLocalPHImageManagerPropertyKey;
+static char SDLocalPHAssetAssetIdentifierToAssetPropertyKey;
+
+@implementation SDWebImageManager (PHAsset)
+
+- (PHImageManager *)imageManager {
+    return objc_getAssociatedObject(self, &SDLocalPHImageManagerPropertyKey);
+}
+
+- (void)setImageManager:(PHImageManager *)imageManager {
+    objc_setAssociatedObject(self, &SDLocalPHImageManagerPropertyKey, imageManager, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (NSMutableDictionary<NSString *, PHAsset *> *)localAssetIdentifierToAssetCache {
+    return objc_getAssociatedObject(self, &SDLocalPHAssetAssetIdentifierToAssetPropertyKey);
+}
+
+- (void)setLocalAssetIdentifierToAssetCache:(NSMutableDictionary *)localAssetIdentifierToAssetCache {
+    objc_setAssociatedObject(self, &SDLocalPHAssetAssetIdentifierToAssetPropertyKey, localAssetIdentifierToAssetCache, OBJC_ASSOCIATION_RETAIN);
+}
+
+#pragma mark -
+
+- (NSString *)cacheKeyForPHAssetIdentifier:(NSString *)localIdentifier targetSize:(CGSize)targetSize {
+
+    NSString *cacheKey = [NSString stringWithFormat:@"%@-%@", localIdentifier, NSStringFromCGSize(targetSize)];
+
+    return cacheKey;
+}
+
+- (void)loadImageWithPHAssetIdentifier:(NSString *)localIdentifier
+                                                         targetSize:(CGSize)targetSize
+                                                         completion:(SDLocalPHAssetRetrievalCompletionBlock)completedBlock {
+    NSAssert(completedBlock != nil, @"Compelete block should not be nil");
+
+    if (!self.imageManager) {
+        self.imageManager = [PHImageManager defaultManager];
+    }
+
+    UIImage *image = [self.imageCache imageFromCacheForKey:[self cacheKeyForPHAssetIdentifier:localIdentifier targetSize:targetSize]];
+    if (image) {
+        completedBlock(image, nil, SDImageCacheTypeMemory);
+        return;
+    }
+
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        NSString *cacheKey = [self cacheKeyForPHAssetIdentifier:localIdentifier targetSize:targetSize];
+
+        void (^fetchImageBlock)() = ^(PHAsset *asset){
+            PHImageRequestOptions *requestOptions = [PHImageRequestOptions new];
+            requestOptions.version = PHImageRequestOptionsVersionCurrent;
+            requestOptions.synchronous = YES;
+            requestOptions.networkAccessAllowed = YES;
+            requestOptions.deliveryMode = PHImageRequestOptionsDeliveryModeOpportunistic;
+            requestOptions.resizeMode = PHImageRequestOptionsResizeModeExact;
+
+            [self.imageManager requestImageForAsset:asset
+                                         targetSize:targetSize
+                                        contentMode:PHImageContentModeAspectFit
+                                            options:requestOptions
+                                      resultHandler:^(UIImage *result, NSDictionary *info) {
+                                          if (result && info[PHImageResultIsDegradedKey] && ![info[PHImageResultIsDegradedKey] boolValue]) {
+                                              [self.imageCache storeImage:result forKey:cacheKey completion:nil];
+                                          }
+
+                                          if (completedBlock) {
+                                              dispatch_main_async_safe(^{
+                                                  completedBlock(result, nil, SDImageCacheTypeNone);
+                                              });
+                                          }
+                                      }];
+
+        };
+
+        PHAsset *localAsset = nil;
+        localAsset = [self.localAssetIdentifierToAssetCache valueForKey:cacheKey];
+
+        if (localAsset) {
+            fetchImageBlock(localAsset);
+        } else {
+            PHFetchOptions *fetchOptions = [PHFetchOptions new];
+            fetchOptions.includeHiddenAssets = YES;
+
+            PHFetchResult *fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[localIdentifier] options:fetchOptions];
+
+            if (fetchResult.count) {
+                PHAsset *result = fetchResult.firstObject;
+                @synchronized(self.localAssetIdentifierToAssetCache) {
+                    [self.localAssetIdentifierToAssetCache setValue:result forKey:result.localIdentifier];
+                }
+                fetchImageBlock(fetchResult.firstObject);
+            } else {
+                if (completedBlock) {
+                    NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Cannot retrieve PHAsset"}];
+                    dispatch_main_async_safe(^{
+                        completedBlock(nil, error, SDImageCacheTypeNone);
+                    });
+                }
+            }
+        }
+    });
+}
+
+@end
+
+#endif

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -46,4 +46,9 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #endif
 #if SD_UIKIT
 #import <SDWebImage/FLAnimatedImageView+WebCache.h>
+#import <SDWebImage/SDWebImageManager+PHAsset.h>
 #endif
+#if SD_IOS && (!SD_WATCH)
+#import <SDWebImage/SDWebImageManager+ALAsset.h>
+#endif
+


### PR DESCRIPTION
### New Pull Request Checklist
- [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
- [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
- [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none
- [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [X] I have updated the documentation (if necesarry)
- [ ] I have run the tests and they pass
- [ ] I have run the lint and it passes (`pod lib lint`)
### Pull Request Description

This PR is basically a successor to #906 with the following changes:
- Add category to `SDWebImageManager` instead of `SDImageCache`. This completely separates the new functionality from the existing codebase.
- Expose only `loadImage` methods while keeping most implementation private.
- Remove cache warming methods as it seems to be redundant in the perspective of main interface.
- Use both memory and disk cache. But the reporting cache type would only be memory cache.
- `loadImage` does not return a cancellable operation for now.

Thanks @donholly for his inspiring work. 

Related issue #45 .
