### PR TITLE
Update Prefetch Docs

### DIFF
--- a/SDWebImage/SDWebImagePrefetcher.h
+++ b/SDWebImage/SDWebImagePrefetcher.h
@@ -78,7 +78,8 @@ typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger noOfFinishedUrls, 
 /**
  * Assign list of URLs to let SDWebImagePrefetcher to queue the prefetching,
  * currently one image is downloaded at a time,
- * and skips images for failed downloads and proceed to the next image in the list
+ * and skips images for failed downloads and proceed to the next image in the list.
+ * Any previously-running prefetch operations are canceled.
  *
  * @param urls list of URLs to prefetch
  */
@@ -87,7 +88,8 @@ typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger noOfFinishedUrls, 
 /**
  * Assign list of URLs to let SDWebImagePrefetcher to queue the prefetching,
  * currently one image is downloaded at a time,
- * and skips images for failed downloads and proceed to the next image in the list
+ * and skips images for failed downloads and proceed to the next image in the list.
+ * Any previously-running prefetch operations are canceled.
  *
  * @param urls            list of URLs to prefetch
  * @param progressBlock   block to be called when progress updates; 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

...


Updated prefetchUrls: and prefetchUrls:progress:completed: documentation to mention that any already running prefetch operations are canceled if the operation is called.