### PR TITLE
Making image downloading cache policy more clearer

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -23,6 +23,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     /**
      * Call completion block with nil image/imageData if the image was read from NSURLCache
      * (to be combined with `SDWebImageDownloaderUseNSURLCache`).
+     * I think this option should be renamed to 'SDWebImageDownloaderUsingCachedResponseDontLoad'
      */
 
     SDWebImageDownloaderIgnoreCachedResponse = 1 << 3,

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -153,7 +153,16 @@
         }
 
         // In order to prevent from potential duplicate caching (NSURLCache + SDImageCache) we disable the cache for image requests if told otherwise
-        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url cachePolicy:(options & SDWebImageDownloaderUseNSURLCache ? NSURLRequestUseProtocolCachePolicy : NSURLRequestReloadIgnoringLocalCacheData) timeoutInterval:timeoutInterval];
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:timeoutInterval];
+        if (options & SDWebImageDownloaderUseNSURLCache) {
+            if (options & SDWebImageDownloaderIgnoreCachedResponse) {
+                request.cachePolicy = NSURLRequestReturnCacheDataDontLoad;
+            }
+            else {
+                request.cachePolicy = NSURLRequestUseProtocolCachePolicy;
+            }
+        }
+        
         request.HTTPShouldHandleCookies = (options & SDWebImageDownloaderHandleCookies);
         request.HTTPShouldUsePipelining = YES;
         if (sself.headersFilter) {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -52,7 +52,8 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 #if SD_UIKIT || SD_WATCH
     UIImageOrientation orientation;
 #endif
-    BOOL responseFromCached;
+    //useless now
+//    BOOL responseFromCached;
 }
 
 @synthesize executing = _executing;
@@ -74,7 +75,7 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
         _finished = NO;
         _expectedSize = 0;
         _unownedSession = session;
-        responseFromCached = YES; // Initially wrong until `- URLSession:dataTask:willCacheResponse:completionHandler: is called or not called
+//        responseFromCached = YES; // Initially wrong until `- URLSession:dataTask:willCacheResponse:completionHandler: is called or not called
         _barrierQueue = dispatch_queue_create("com.hackemist.SDWebImageDownloaderOperationBarrierQueue", DISPATCH_QUEUE_CONCURRENT);
     }
     return self;
@@ -387,7 +388,7 @@ didReceiveResponse:(NSURLResponse *)response
  willCacheResponse:(NSCachedURLResponse *)proposedResponse
  completionHandler:(void (^)(NSCachedURLResponse *cachedResponse))completionHandler {
 
-    responseFromCached = NO; // If this method is called, it means the response wasn't read from cache
+//    responseFromCached = NO; // If this method is called, it means the response wasn't read from cache
     NSCachedURLResponse *cachedResponse = proposedResponse;
 
     if (self.request.cachePolicy == NSURLRequestReloadIgnoringLocalCacheData) {
@@ -422,10 +423,18 @@ didReceiveResponse:(NSURLResponse *)response
              *    and images for which responseFromCached is YES (only the ones that cannot be cached).
              *  Note: responseFromCached is set to NO inside `willCacheResponse:`. This method doesn't get called for large images or images behind authentication
              */
-            if (self.options & SDWebImageDownloaderIgnoreCachedResponse && responseFromCached && [[NSURLCache sharedURLCache] cachedResponseForRequest:self.request]) {
-                // hack
-                [self callCompletionBlocksWithImage:nil imageData:nil error:nil finished:YES];
-            } else if (self.imageData) {
+            
+            /**
+                If you specified to use `NSURLCache`, then the response you get here is what you need.
+                if you specified to only use cached data via `SDWebImageDownloaderIgnoreCachedResponse`(This name is confusing),
+                the response data will be nil.
+                So we don't need to check the cache option here, because we have set the cache option of the request already, and system will obey it.
+             */
+            
+//            if (self.options & SDWebImageDownloaderUseNSURLCache) {
+//                // hack
+//                [self callCompletionBlocksWithImage:nil imageData:nil error:nil finished:YES];
+//            } else if (self.imageData) {
                 UIImage *image = [UIImage sd_imageWithData:self.imageData];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                 image = [self scaledImageForKey:key image:image];
@@ -451,7 +460,7 @@ didReceiveResponse:(NSURLResponse *)response
             } else {
                 [self callCompletionBlocksWithError:[NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Image data is nil"}]];
             }
-        }
+//        }
     }
     [self done];
 }

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -430,11 +430,7 @@ didReceiveResponse:(NSURLResponse *)response
                 the response data will be nil.
                 So we don't need to check the cache option here, because we have set the cache option of the request already, and system will obey it.
              */
-            
-//            if (self.options & SDWebImageDownloaderUseNSURLCache) {
-//                // hack
-//                [self callCompletionBlocksWithImage:nil imageData:nil error:nil finished:YES];
-//            } else if (self.imageData) {
+            if (self.imageData) {
                 UIImage *image = [UIImage sd_imageWithData:self.imageData];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                 image = [self scaledImageForKey:key image:image];
@@ -460,7 +456,7 @@ didReceiveResponse:(NSURLResponse *)response
             } else {
                 [self callCompletionBlocksWithError:[NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Image data is nil"}]];
             }
-//        }
+        }
     }
     [self done];
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

I think the problem is that when calling `[[NSURLCache sharedURLCache] cachedResponseForRequest:`, the iOS system will do some `cache merging`. See the last line of the crash log:
` -[NSCachedURLResponse _reestablishInternalCFCachedURLResponse:] `
This implies that every time you call this method, the response caches will be reestablished. I think this is the cause of our problem. If we are caching multiple responses on different threads, then it may cause a crash.

After digging into the code, I found that this call is reductant. If we specify to use system cache, then the system will do it correctly, which means what you get in `- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error` is already handled. If you specified to only use cached response, and there is no local data available, then you will get nil.
