### PR TITLE
resolve image path extension bug

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -174,9 +174,18 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     CC_MD5(str, (CC_LONG)strlen(str), r);
     NSString *filename = [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%@",
                           r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10],
-                          r[11], r[12], r[13], r[14], r[15], [key.pathExtension isEqualToString:@""] ? @"" : [NSString stringWithFormat:@".%@", key.pathExtension]];
+                          r[11], r[12], r[13], r[14], r[15], [self correctImagePathExtension:key]];
 
     return filename;
+}
+
+- (NSString *)correctImagePathExtension:(NSString *)key{
+    NSString *originPathExtension = [[key pathExtension] lowercaseString];
+    if ([self.config.correctPathExtensionArray containsObject:originPathExtension]) {
+        return [NSString stringWithFormat:@".%@", originPathExtension];
+    } else {
+        return @"";
+    }
 }
 
 - (nullable NSString *)makeDiskCachePath:(nonnull NSString*)fullNamespace {

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -36,5 +36,9 @@
  * The maximum size of the cache, in bytes.
  */
 @property (assign, nonatomic) NSUInteger maxCacheSize;
+/**
+ * The correct image path extension.
+ */
+@property (copy, nonatomic) NSArray *correctPathExtensionArray;
 
 @end

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -19,6 +19,7 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
         _shouldCacheImagesInMemory = YES;
         _maxCacheAge = kDefaultCacheMaxCacheAge;
         _maxCacheSize = 0;
+        _correctPathExtensionArray = @[@"jpeg",@"jpg",@"png",@"gif",@"tiff",@"webp"];
     }
     return self;
 }


### PR DESCRIPTION
### New Pull Request Checklist

*  I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
*  I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
*  I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

*  I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* I have added the required tests to prove the fix/feature I am adding
* I have updated the documentation (if necesarry)
* I have run the tests and they pass
* I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues:

The incorrect image path extension cause the image can not show in WKWebView.

### Pull Request Description

Hi, I have found a bug when using SDWebImage in WKWebView. When download a image from URL like xxx.com/xxx, I found that although the image downloaded and stored all right, but the image can not show in a WKWebView. The reason is the image path extension is ".com/xxx" in this case and in WKWebView a image named like this can not be read correctly. Also, I found the pull request: #976 which brought this bug.

This pull request is to resolve this problem, simply prescribe the proper image path extension that should be added to file name, and problem resolved.


