### PR TITLE
Correct available subspecs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ use_frameworks!
 
 #### Subspecs
 
-There are 3 subspecs available now: `Core`, `MapKit` and `WebP` (this means you can install only some of the SDWebImage modules. By default, you get just `Core`, so if you need `WebP`, you need to specify it). 
+There are 4 subspecs available now: `Core`, `MapKit`, `GIF` and `WebP` (this means you can install only some of the SDWebImage modules. By default, you get just `Core`, so if you need `WebP`, you need to specify it). 
 
 Podfile example:
 ```


### PR DESCRIPTION
Add a missing `GIF` subspecs in README according to `SDWebImage.podspec`