### PR TITLE
Set UIButton's placeholer-image even if the url is nil.

### DIFF
--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -63,10 +63,9 @@ typedef NSMutableDictionary<NSNumber *, NSURL *> SDStateImageURLDictionary;
                  completed:(nullable SDExternalCompletionBlock)completedBlock {
     if (!url) {
         [self.imageURLStorage removeObjectForKey:@(state)];
-        return;
+    } else {
+        self.imageURLStorage[@(state)] = url;
     }
-    
-    self.imageURLStorage[@(state)] = url;
     
     __weak typeof(self)weakSelf = self;
     [self sd_internalSetImageWithURL:url
@@ -109,10 +108,9 @@ typedef NSMutableDictionary<NSNumber *, NSURL *> SDStateImageURLDictionary;
                            completed:(nullable SDExternalCompletionBlock)completedBlock {
     if (!url) {
         [self.imageURLStorage removeObjectForKey:@(state)];
-        return;
+    } else {
+        self.imageURLStorage[@(state)] = url;
     }
-    
-    self.imageURLStorage[@(state)] = url;
     
     __weak typeof(self)weakSelf = self;
     [self sd_internalSetImageWithURL:url

--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -63,9 +63,10 @@ typedef NSMutableDictionary<NSNumber *, NSURL *> SDStateImageURLDictionary;
                  completed:(nullable SDExternalCompletionBlock)completedBlock {
     if (!url) {
         [self.imageURLStorage removeObjectForKey:@(state)];
-    } else {
-        self.imageURLStorage[@(state)] = url;
+        return;
     }
+    
+    self.imageURLStorage[@(state)] = url;
     
     __weak typeof(self)weakSelf = self;
     [self sd_internalSetImageWithURL:url
@@ -108,9 +109,10 @@ typedef NSMutableDictionary<NSNumber *, NSURL *> SDStateImageURLDictionary;
                            completed:(nullable SDExternalCompletionBlock)completedBlock {
     if (!url) {
         [self.imageURLStorage removeObjectForKey:@(state)];
-    } else {
-        self.imageURLStorage[@(state)] = url;
+        return;
     }
+    
+    self.imageURLStorage[@(state)] = url;
     
     __weak typeof(self)weakSelf = self;
     [self sd_internalSetImageWithURL:url

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -38,7 +38,7 @@ static char TAG_ACTIVITY_SHOW;
     [self sd_cancelImageLoadOperationWithKey:validOperationKey];
     objc_setAssociatedObject(self, &imageURLKey, url, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     
-    if (!(options & SDWebImageDelayPlaceholder)) {
+    if (!(options & SDWebImageDelayPlaceholder) || !url) {
         dispatch_main_async_safe(^{
             [self sd_setImage:placeholder imageData:nil basedOnClassOrViaCustomSetImageBlock:setImageBlock];
         });

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -38,7 +38,7 @@ static char TAG_ACTIVITY_SHOW;
     [self sd_cancelImageLoadOperationWithKey:validOperationKey];
     objc_setAssociatedObject(self, &imageURLKey, url, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     
-    if (!(options & SDWebImageDelayPlaceholder) || !url) {
+    if (!(options & SDWebImageDelayPlaceholder)) {
         dispatch_main_async_safe(^{
             [self sd_setImage:placeholder imageData:nil basedOnClassOrViaCustomSetImageBlock:setImageBlock];
         });


### PR DESCRIPTION
Yesterday，i update the SDWebImage, then i discoverred a bug which was
not existed before.I have checked the source code of SDWebImage, the
reason is that the method (- (void)sd_setImageWithURL:(nullable NSURL
*)url forState:(UIControlState)state placeholderImage:(nullable UIImage
*)placeholder) can not set the placeholder when url is nil but the old
version did. Maybe this is not a bug for you, but for us.I hope you can
consider this problem.Last, i have used this wonderful Lib for a long
time, thanks for you.