### PR TITLE
Fix animation integration

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -170,9 +170,9 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 /**
  * Query the memory cache synchronously.
  *
- * @param key The unique key used to store the image
+ * @param key The unique key used to store the object
  */
-- (nullable UIImage *)imageFromMemoryCacheForKey:(nullable NSString *)key;
+- (nullable id)objectFromMemoryCacheForKey:(nullable NSString *)key;
 
 /**
  * Query the disk cache synchronously.

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -217,7 +217,9 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         if (imageFormat == SDImageFormatGIF) {
             [self.memCache setObject:imageData forKey:key cost: imageData.length];
         } else {
-            [self.memCache setObject:image forKey:key cost:cost];
+            if (image) {
+                [self.memCache setObject:image forKey:key cost:cost];
+            }
         }
 
     }

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -215,7 +215,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         NSUInteger cost = SDCacheCostForImage(image);
         SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
         if (imageFormat == SDImageFormatGIF) {
-            [self.memCache setObject:imageData forKey:key];
+            [self.memCache setObject:imageData forKey:key cost: imageData.length];
         } else {
             [self.memCache setObject:image forKey:key cost:cost];
         }
@@ -405,7 +405,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             UIImage *diskImage = [self diskImageForKey:key];
             if (diskImage && self.config.shouldCacheImagesInMemory) {
                 if ([NSData sd_imageFormatForImageData:diskData] == SDImageFormatGIF) {
-                    [self.memCache setObject:diskData forKey:key];
+                    [self.memCache setObject:diskData forKey:key cost: diskData.length];
                 } else {
                     NSUInteger cost = SDCacheCostForImage(diskImage);
                     [self.memCache setObject:diskImage forKey:key cost:cost];

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -443,7 +443,7 @@ didReceiveResponse:(NSURLResponse *)response
                         }
                     }
                 }
-                if (CGSizeEqualToSize(image.size, CGSizeZero)) {
+                if (CGSizeEqualToSize(image.size, CGSizeZero) && self.imageData == nil) {
                     [self callCompletionBlocksWithError:[NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Downloaded image has 0 pixels"}]];
                 } else {
                     [self callCompletionBlocksWithImage:image imageData:self.imageData error:nil finished:YES];

--- a/SDWebImage/UIImage+MultiFormat.m
+++ b/SDWebImage/UIImage+MultiFormat.m
@@ -25,7 +25,7 @@
     UIImage *image;
     SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:data];
     if (imageFormat == SDImageFormatGIF) {
-        image = [UIImage sd_animatedGIFWithData:data];
+        return [[UIImage alloc] initWithData:data];
     }
 #ifdef SD_WEBP
     else if (imageFormat == SDImageFormatWebP)

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -64,7 +64,7 @@ static char TAG_ACTIVITY_SHOW;
                 if (image && (options & SDWebImageAvoidAutoSetImage) && completedBlock) {
                     completedBlock(image, error, cacheType, url);
                     return;
-                } else if (image) {
+                } else if (image || data) {
                     [sself sd_setImage:image imageData:data basedOnClassOrViaCustomSetImageBlock:setImageBlock];
                     [sself sd_setNeedsLayout];
                 } else {

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -54,7 +54,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
                 XCTFail(@"Image should not be in cache");
             }
         }];
-        expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.equal([self imageForTesting]);
+        expect([self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey]).to.equal([self imageForTesting]);
     }];
     [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
 }
@@ -64,7 +64,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     
     [self.sharedImageCache storeImage:[self imageForTesting] forKey:kImageTestKey completion:nil];
     [self.sharedImageCache clearMemory];
-    expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.beNil;
+    expect([self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey]).to.beNil;
     [self.sharedImageCache diskImageExistsWithKey:kImageTestKey completion:^(BOOL isInCache) {
         if (isInCache) {
             [expectation fulfill];
@@ -81,7 +81,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     
     UIImage *image = [self imageForTesting];
     [self.sharedImageCache storeImage:image forKey:kImageTestKey completion:nil];
-    expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.equal(image);
+    expect([self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey]).to.equal(image);
     [self.sharedImageCache diskImageExistsWithKey:kImageTestKey completion:^(BOOL isInCache) {
         if (isInCache) {
             [expectation fulfill];
@@ -98,7 +98,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     
     UIImage *image = [self imageForTesting];
     [self.sharedImageCache storeImage:image forKey:kImageTestKey toDisk:YES completion:nil];
-    expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.equal(image);
+    expect([self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey]).to.equal(image);
     [self.sharedImageCache diskImageExistsWithKey:kImageTestKey completion:^(BOOL isInCache) {
         if (isInCache) {
             [expectation fulfill];
@@ -115,7 +115,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     UIImage *image = [self imageForTesting];
     [self.sharedImageCache storeImage:image forKey:kImageTestKey toDisk:NO completion:nil];
     
-    expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.equal([self imageForTesting]);
+    expect([self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey]).to.equal([self imageForTesting]);
     [self.sharedImageCache diskImageExistsWithKey:kImageTestKey completion:^(BOOL isInCache) {
         if (!isInCache) {
             [expectation fulfill];
@@ -124,7 +124,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
         }
     }];
     [self.sharedImageCache clearMemory];
-    expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.beNil();
+    expect([self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey]).to.beNil();
     [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
 }
 
@@ -142,7 +142,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     [self.sharedImageCache storeImage:[self imageForTesting] forKey:kImageTestKey completion:nil];
     [self.sharedImageCache removeImageForKey:kImageTestKey withCompletion:^{
         expect([self.sharedImageCache imageFromDiskCacheForKey:kImageTestKey]).to.beNil;
-        expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.beNil;
+        expect([self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey]).to.beNil;
     }];
 }
 
@@ -150,7 +150,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     [self.sharedImageCache storeImage:[self imageForTesting] forKey:kImageTestKey completion:nil];
     [self.sharedImageCache removeImageForKey:kImageTestKey fromDisk:NO withCompletion:^{
         expect([self.sharedImageCache imageFromDiskCacheForKey:kImageTestKey]).toNot.beNil;
-        expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.beNil;
+        expect([self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey]).to.beNil;
     }];
 }
 
@@ -158,7 +158,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     [self.sharedImageCache storeImage:[self imageForTesting] forKey:kImageTestKey completion:nil];
     [self.sharedImageCache removeImageForKey:kImageTestKey fromDisk:YES withCompletion:^{
         expect([self.sharedImageCache imageFromDiskCacheForKey:kImageTestKey]).to.beNil;
-        expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.beNil;
+        expect([self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey]).to.beNil;
     }];
 }
 
@@ -199,7 +199,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     NSData *imageData = [NSData dataWithContentsOfFile:[self testImagePath]];
     [self.sharedImageCache storeImageDataToDisk:imageData forKey:kImageTestKey];
     
-    UIImage *storedImageFromMemory = [self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey];
+    UIImage *storedImageFromMemory = [self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey];
     expect(storedImageFromMemory).to.equal(nil);
     
     NSString *cachePath = [self.sharedImageCache defaultCachePathForKey:kImageTestKey];

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -13,6 +13,7 @@
 #import <Expecta/Expecta.h>
 
 #import <SDWebImage/SDImageCache.h>
+#import <SDWebImage/UIImage+GIF.h>
 
 NSString *kImageTestKey = @"TestImageKey.jpg";
 
@@ -215,6 +216,23 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     }];
 }
 
+- (void)test41InsertionOfGif {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"storeImage forKey"];
+    
+    NSData *data = [self gifDataForTesting];
+    UIImage *image = [UIImage sd_animatedGIFWithData:data];
+    [self.sharedImageCache storeImage:image imageData:data forKey:kImageTestKey toDisk:YES completion:nil];
+    expect([self.sharedImageCache objectFromMemoryCacheForKey:kImageTestKey]).to.equal(data);
+    [self.sharedImageCache diskImageExistsWithKey:kImageTestKey completion:^(BOOL isInCache) {
+        if (isInCache) {
+            [expectation fulfill];
+        } else {
+            XCTFail(@"Gif should be in cache");
+        }
+    }];
+    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+}
+
 #pragma mark Helper methods
 
 - (void)clearAllCaches{
@@ -233,10 +251,23 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     return reusableImage;
 }
 
+- (NSData *)gifDataForTesting {
+    static NSData *reusableGifData = nil;
+    if (!reusableGifData) {
+        reusableGifData = [NSData dataWithContentsOfFile:[self testGifPath]];
+    }
+    return reusableGifData;
+}
+
 - (NSString *)testImagePath {
     
     NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
     return [testBundle pathForResource:@"TestImage" ofType:@"jpg"];
 }
 
+- (NSString *)testGifPath {
+    
+    NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
+    return [testBundle pathForResource:@"TestImage" ofType:@"gif"];
+}
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

When gif was loaded, it was not cached in memory. Instead library cached image with just one frame. This PR fixes that.