### PR TITLE
fix user header search paths

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
     gif.dependency 'SDWebImage/Core'
     gif.dependency 'FLAnimatedImage', '~> 1.0'
     gif.xcconfig = {
-      'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/FLAnimatedImage/FLAnimatedImage'
+      'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/FLAnimatedImage/FLAnimatedImage'
     }
   end
 
@@ -55,11 +55,11 @@ Pod::Spec.new do |s|
     webp.source_files = 'SDWebImage/UIImage+WebP.{h,m}'
     webp.xcconfig = { 
       'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_WEBP=1',
-      'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
+      'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/libwebp/src'
     }
     webp.watchos.xcconfig = {
       'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_WEBP=1 WEBP_USE_INTRINSICS=1',
-      'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
+      'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/libwebp/src'
     }
     webp.dependency 'SDWebImage/Core'
     webp.dependency 'libwebp'


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues:

SDWebImage/GIF and SDWebImage/WebP have dependency FLAnimatedImage, libwebp.
The USER_HEADER_SEARCH_PATHS does not exist.

### Pull Request Description

The USER_HEADER_SEARCH_PATHS is set to use PODS_ROOT as the prefix when using CocoaPods.

