### PR TITLE
We found that URLOperations may modify in different threads at the sa…

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -230,11 +230,13 @@
 
             __weak SDWebImageDownloaderOperation *woperation = operation;
             operation.completionBlock = ^{
-              SDWebImageDownloaderOperation *soperation = woperation;
-              if (!soperation) return;
-              if (self.URLOperations[url] == soperation) {
-                  [self.URLOperations removeObjectForKey:url];
-              };
+              dispatch_barrier_async(self.barrierQueue, ^{
+                  SDWebImageDownloaderOperation *soperation = woperation;
+                  if (!soperation) return;
+                  if (self.URLOperations[url] == soperation) {
+                      [self.URLOperations removeObjectForKey:url];
+                  };
+              });
             };
         }
         id downloadOperationCancelToken = [operation addHandlersForProgress:progressBlock completed:completedBlock];


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

We found that URLOperations may modify in different threads at the same time when We try to cancel it.
![screen shot 2017-03-20 at 10 57 35](https://cloud.githubusercontent.com/assets/1539246/24087622/211287fc-0d5c-11e7-9af9-bba77d1c3a1d.png)

Let URLOperations being modified in single queue to solve crash https://github.com/rs/SDWebImage/issues/990

