### PR TITLE
[bugfix] Added @autoreleasepool to SDImageCache.storeImage

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -217,14 +217,15 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     
     if (toDisk) {
         dispatch_async(self.ioQueue, ^{
-            NSData *data = imageData;
-            
-            if (!data && image) {
-                SDImageFormat imageFormatFromData = [NSData sd_imageFormatForImageData:data];
-                data = [image sd_imageDataAsFormat:imageFormatFromData];
+            @autoreleasepool {
+                NSData *data = imageData;
+                if (!data && image) {
+                    SDImageFormat imageFormatFromData = [NSData sd_imageFormatForImageData:data];
+                    data = [image sd_imageDataAsFormat:imageFormatFromData];
+                }                
+                [self storeImageDataToDisk:data forKey:key];
             }
             
-            [self storeImageDataToDisk:data forKey:key];
             if (completionBlock) {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     completionBlock();


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Added @autoreleasepool to SDImageCache.storeImage to prevent huge memory consumption when store a lot of images in series.
This what it look like when you try to store a lot of images in a loop:
![beforeadding](https://cloud.githubusercontent.com/assets/22085789/24577490/fc1bee94-16ce-11e7-948f-7cb65e4e6b56.png)
And that is what it look like after @autoreleasepool added:
![afteradding](https://cloud.githubusercontent.com/assets/22085789/24577489/fbee2dc4-16ce-11e7-9766-a114ba7346f9.png)

