### PR TITLE
Add method for SDWebImageDownloaderOperation subclass to decrypt or decompress image data

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ community can help you solve it.
 ## Collaborators
 - [Konstantinos K.](https://github.com/mythodeia)
 - [Bogdan Poplauschi](https://github.com/bpoplauschi)
+- [Chester Liu](https://github.com/skyline75489)
 
 ## Licenses
 

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -119,6 +119,9 @@ extern NSString * _Nonnull const SDWebImageDownloadFinishNotification;
  */
 - (BOOL)cancel:(nullable id)token;
 
-- (UIImage *)imageWithData:(NSData *)data;
+/**
+ *  Converts downloaded image data to a UIImage object.
+ */
+- (nullable UIImage *)imageWithData:(nonnull NSData *)data forCacheKey:(nonnull NSString *)key;
 
 @end

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -97,7 +97,7 @@ extern NSString * _Nonnull const SDWebImageDownloadFinishNotification;
                                 options:(SDWebImageDownloaderOptions)options NS_DESIGNATED_INITIALIZER;
 
 /**
- *  Adds handlers for progress and completion. Returns a tokent that can be passed to -cancel: to cancel this set of
+ *  Adds handlers for progress and completion. Returns a token that can be passed to -cancel: to cancel this set of
  *  callbacks.
  *
  *  @param progressBlock  the block executed when a new chunk of data arrives.
@@ -119,6 +119,9 @@ extern NSString * _Nonnull const SDWebImageDownloadFinishNotification;
  */
 - (BOOL)cancel:(nullable id)token;
 
+/*
+ *  May be implemented by a subclass to prepare image data after download (e.g. decrypt, decompress)
+ */
 - (nullable NSData *)prepareImageData:(nonnull NSData *)data;
 
 @end

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -119,4 +119,6 @@ extern NSString * _Nonnull const SDWebImageDownloadFinishNotification;
  */
 - (BOOL)cancel:(nullable id)token;
 
+- (UIImage *)imageWithData:(NSData *)data;
+
 @end

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -119,9 +119,6 @@ extern NSString * _Nonnull const SDWebImageDownloadFinishNotification;
  */
 - (BOOL)cancel:(nullable id)token;
 
-/**
- *  Converts downloaded image data to a UIImage object.
- */
-- (nullable UIImage *)imageWithData:(nonnull NSData *)data forCacheKey:(nonnull NSString *)key;
+- (nullable NSData *)prepareImageData:(nonnull NSData *)data;
 
 @end

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -420,8 +420,8 @@ didReceiveResponse:(NSURLResponse *)response
              *  So we don't need to check the cache option here, since the system will obey the cache option
              */
             if (self.imageData) {
-                UIImage *image = [self imageWithData:self.imageData];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
+                UIImage *image = [self imageWithData:self.imageData forCacheKey:key];
                 image = [self scaledImageForKey:key image:image];
                 
                 // Do not force decoding animated GIFs
@@ -531,7 +531,7 @@ didReceiveResponse:(NSURLResponse *)response
     });
 }
 
-- (UIImage *)imageWithData:(NSData *)data {
+- (UIImage *)imageWithData:(NSData *)data forCacheKey:(NSString *)key {
     return [UIImage sd_imageWithData:data];
 }
 

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -420,7 +420,7 @@ didReceiveResponse:(NSURLResponse *)response
              *  So we don't need to check the cache option here, since the system will obey the cache option
              */
             if (self.imageData) {
-                UIImage *image = [UIImage sd_imageWithData:self.imageData];
+                UIImage *image = [self imageWithData:self.imageData];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                 image = [self scaledImageForKey:key image:image];
                 
@@ -529,6 +529,10 @@ didReceiveResponse:(NSURLResponse *)response
             completedBlock(image, imageData, error, finished);
         }
     });
+}
+
+- (UIImage *)imageWithData:(NSData *)data {
+    return [UIImage sd_imageWithData:data];
 }
 
 @end

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -420,8 +420,17 @@ didReceiveResponse:(NSURLResponse *)response
              *  So we don't need to check the cache option here, since the system will obey the cache option
              */
             if (self.imageData) {
+                NSData *preparedImageData = [self prepareImageData:self.imageData];
+                if (preparedImageData) {
+                    [self.imageData setData:preparedImageData]; 
+                } else {
+                    self.imageData = nil;
+                }
+            }
+
+            if (self.imageData) {
+                UIImage *image = [UIImage sd_imageWithData:self.imageData];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-                UIImage *image = [self imageWithData:self.imageData forCacheKey:key];
                 image = [self scaledImageForKey:key image:image];
                 
                 // Do not force decoding animated GIFs
@@ -531,8 +540,8 @@ didReceiveResponse:(NSURLResponse *)response
     });
 }
 
-- (UIImage *)imageWithData:(NSData *)data forCacheKey:(NSString *)key {
-    return [UIImage sd_imageWithData:data];
+- (NSData *)prepareImageData:(NSData *)data {
+    return data;
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: see below

### Pull Request Description

This adds a `prepareImageData` method to SDWebImageDownloaderOperation that is intended for subclasses to override if they need to do something special with the image data after it's downloaded but before it's cached or converted to a UIImage. I'm using it in my project for decryption but it could also be useful for custom decompression. Without this change, it's hard to implement these kinds of behaviors in a SDWebImageDownloaderOperation subclass.