### PR TITLE
Add ability to change NSURLSessionConfiguration used by SDWebImageDownloader

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -120,6 +120,15 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
 
 
 /**
+ * The configuration in use by the internal NSURLSession.
+ * Mutating this object directly has no effect.
+ *
+ * @see createNewSessionWithConfiguration:
+ */
+@property (readonly, nonatomic, nonnull) NSURLSessionConfiguration *sessionConfiguration;
+
+
+/**
  * Changes download operations execution order. Default value is `SDWebImageDownloaderFIFOExecutionOrder`.
  */
 @property (assign, nonatomic) SDWebImageDownloaderExecutionOrder executionOrder;
@@ -229,5 +238,15 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
  * Cancels all download operations in the queue
  */
 - (void)cancelAllDownloads;
+
+/**
+ * Forces SDWebImageDownloader to create and use a new NSURLSession that is
+ * initialized with the given configuration.
+ * *Note*: All existing download operations in the queue will be cancelled.
+ * *Note*: `timeoutIntervalForRequest` is going to be overwritten.
+ *
+ * @param sessionConfiguration The configuration to use for the new NSURLSession
+ */
+- (void)createNewSessionWithConfiguration:(nonnull NSURLSessionConfiguration *)sessionConfiguration;
 
 @end

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -84,18 +84,28 @@
         _barrierQueue = dispatch_queue_create("com.hackemist.SDWebImageDownloaderBarrierQueue", DISPATCH_QUEUE_CONCURRENT);
         _downloadTimeout = 15.0;
 
-        sessionConfiguration.timeoutIntervalForRequest = _downloadTimeout;
-
-        /**
-         *  Create the session for this task
-         *  We send nil as delegate queue so that the session creates a serial operation queue for performing all delegate
-         *  method calls and completion handler calls.
-         */
-        self.session = [NSURLSession sessionWithConfiguration:sessionConfiguration
-                                                     delegate:self
-                                                delegateQueue:nil];
+        [self createNewSessionWithConfiguration:sessionConfiguration];
     }
     return self;
+}
+
+- (void)createNewSessionWithConfiguration:(NSURLSessionConfiguration *)sessionConfiguration {
+    [self cancelAllDownloads];
+
+    if (self.session) {
+        [self.session invalidateAndCancel];
+    }
+
+    sessionConfiguration.timeoutIntervalForRequest = self.downloadTimeout;
+
+    /**
+     *  Create the session for this task
+     *  We send nil as delegate queue so that the session creates a serial operation queue for performing all delegate
+     *  method calls and completion handler calls.
+     */
+    self.session = [NSURLSession sessionWithConfiguration:sessionConfiguration
+                                                 delegate:self
+                                            delegateQueue:nil];
 }
 
 - (void)dealloc {
@@ -129,6 +139,10 @@
 
 - (NSInteger)maxConcurrentDownloads {
     return _downloadQueue.maxConcurrentOperationCount;
+}
+
+- (NSURLSessionConfiguration *)sessionConfiguration {
+    return self.session.configuration;
 }
 
 - (void)setOperationClass:(nullable Class)operationClass {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1870

### Pull Request Description

Fixes issue #1870

I realized that changing the NSURLSession would require cancelling everything in the download queue, which seemed like a bigger-than-acceptable side effect for a property setter, so I went with exposing a read-only sessionConfiguration property and a createNewSessionWithConfiguration: method for the public API.

