### PR TITLE
Update cocoapods to manage the dependency

### DIFF
--- a/Examples/SDWebImage Demo.xcodeproj/project.pbxproj
+++ b/Examples/SDWebImage Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2106A94718E77EE39A2ADB35 /* libPods-SDWebImage Watch Demo Extension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 483FC15FF3CC643408F1B978 /* libPods-SDWebImage Watch Demo Extension.a */; };
 		3E75A9861742DBE700DA412D /* CustomPathImages in Resources */ = {isa = PBXBuildFile; fileRef = 3E75A9851742DBE700DA412D /* CustomPathImages */; };
 		4314D1AA1D0E1181004B36C9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4314D1A91D0E1181004B36C9 /* main.m */; };
 		4314D1AD1D0E1181004B36C9 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4314D1AC1D0E1181004B36C9 /* AppDelegate.m */; };
@@ -44,6 +45,10 @@
 		53A2B50E155B155A00B12423 /* placeholder@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 53A2B50C155B155A00B12423 /* placeholder@2x.png */; };
 		53EEC18916484553007601E1 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 53EEC18816484553007601E1 /* Default-568h@2x.png */; };
 		DA248D44195470FD00390AB0 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 537612E3155ABA3C005750A4 /* MapKit.framework */; };
+		DB69F226A083BE27F647BA46 /* libPods-SDWebImage TV Demo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E3EDCD7AE0E45EA5BA0F98 /* libPods-SDWebImage TV Demo.a */; };
+		DB87C1FE2C6ECAFF1A6ACB31 /* libPods-SDWebImage OSX Demo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FA6C0249C0C53FCB8FA5B94F /* libPods-SDWebImage OSX Demo.a */; };
+		EC3C937D7A601B1ED5EF907C /* libPods-SDWebImage iOS Demo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4485BED3FDD1308A222EF609 /* libPods-SDWebImage iOS Demo.a */; };
+		FD226F1CE4D78BCCE2DD3B90 /* libPods-SDWebImage Watch Demo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AD5FF238198C0C0D73BE256 /* libPods-SDWebImage Watch Demo.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -103,13 +108,6 @@
 			remoteGlobalIDString = 43A629F91D0E07600089D7DD;
 			remoteInfo = "SDWebImage Watch Demo Extension";
 		};
-		43A62A0D1D0E07600089D7DD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 5376128C155AB74D005750A4 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 43A629ED1D0E07600089D7DD;
-			remoteInfo = "SDWebImage Watch Demo";
-		};
 		43F04B3D1D9E467E003F9640 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DA248D6C1954841D00390AB0 /* SDWebImage.xcodeproj */;
@@ -123,6 +121,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 4A2CADFE1AB4BB5300B6BC39;
 			remoteInfo = "SDWebImage iOS";
+		};
+		AB977BE51EC9607E0007E443 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5376128C155AB74D005750A4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 43A629F91D0E07600089D7DD;
+			remoteInfo = "SDWebImage Watch Demo Extension";
+		};
+		AB977BFD1EC978E40007E443 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5376128C155AB74D005750A4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 43A629ED1D0E07600089D7DD;
+			remoteInfo = "SDWebImage Watch Demo";
 		};
 		DA248D731954841D00390AB0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -159,7 +171,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0767D250B8029571A1BBD44A /* Pods-SDWebImage OSX Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage OSX Demo.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage OSX Demo/Pods-SDWebImage OSX Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		1396B5166BDC8633059A1348 /* Pods-SDWebImage TV Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage TV Demo.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage TV Demo/Pods-SDWebImage TV Demo.release.xcconfig"; sourceTree = "<group>"; };
+		15E11CD68A1CB229CF82A2CF /* Pods_Base_SDWebImage_iOS_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Base_SDWebImage_iOS_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		20682178774759C10014CFF2 /* libPods-Demo-SDWebImage Watch Demo Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Demo-SDWebImage Watch Demo Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E75A9851742DBE700DA412D /* CustomPathImages */ = {isa = PBXFileReference; lastKnownFileType = folder; path = CustomPathImages; sourceTree = SOURCE_ROOT; };
+		43127645969A3CF2D637B16C /* Pods-SDWebImage Watch Demo Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage Watch Demo Extension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage Watch Demo Extension/Pods-SDWebImage Watch Demo Extension.release.xcconfig"; sourceTree = "<group>"; };
 		4314D1A61D0E1181004B36C9 /* SDWebImage TV Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SDWebImage TV Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4314D1A91D0E1181004B36C9 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		4314D1AB1D0E1181004B36C9 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -192,6 +209,9 @@
 		43A62A081D0E07600089D7DD /* NotificationController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NotificationController.m; sourceTree = "<group>"; };
 		43A62A0A1D0E07600089D7DD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		43A62A0C1D0E07600089D7DD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4485BED3FDD1308A222EF609 /* libPods-SDWebImage iOS Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SDWebImage iOS Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		483FC15FF3CC643408F1B978 /* libPods-SDWebImage Watch Demo Extension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SDWebImage Watch Demo Extension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4AD7E37386E6BDA0829F533A /* Pods-SDWebImage TV Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage TV Demo.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage TV Demo/Pods-SDWebImage TV Demo.debug.xcconfig"; sourceTree = "<group>"; };
 		53761295155AB74D005750A4 /* SDWebImage iOS Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SDWebImage iOS Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		53761299155AB74D005750A4 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		5376129B155AB74D005750A4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -212,7 +232,24 @@
 		53A2B50B155B155A00B12423 /* placeholder.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = placeholder.png; sourceTree = "<group>"; };
 		53A2B50C155B155A00B12423 /* placeholder@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "placeholder@2x.png"; sourceTree = "<group>"; };
 		53EEC18816484553007601E1 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "../Default-568h@2x.png"; sourceTree = "<group>"; };
+		5AD5FF238198C0C0D73BE256 /* libPods-SDWebImage Watch Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SDWebImage Watch Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BE79B1E30E750C521F61BC4 /* libPods-Demo-SDWebImage OSX Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Demo-SDWebImage OSX Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FAA202E873CA98C30EE86F9 /* Pods-SDWebImage Watch Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage Watch Demo.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage Watch Demo/Pods-SDWebImage Watch Demo.release.xcconfig"; sourceTree = "<group>"; };
+		624883D0A8DB88BBE1EC3F8F /* Pods-SDWebImage iOS Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage iOS Demo.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage iOS Demo/Pods-SDWebImage iOS Demo.release.xcconfig"; sourceTree = "<group>"; };
+		6521BF9508A8146DE6CC92DA /* Pods-SDWebImage OSX Demo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage OSX Demo.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage OSX Demo/Pods-SDWebImage OSX Demo.release.xcconfig"; sourceTree = "<group>"; };
+		872939276848EB72AC46533E /* libPods-Demo-SDWebImage TV Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Demo-SDWebImage TV Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		939D310966EA630EB7A1FE42 /* Pods-SDWebImage iOS Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage iOS Demo.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage iOS Demo/Pods-SDWebImage iOS Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		B427688E683E99F11291403A /* Pods_Base_SDWebImage_Watch_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Base_SDWebImage_Watch_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C1E3EDCD7AE0E45EA5BA0F98 /* libPods-SDWebImage TV Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SDWebImage TV Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7FD9BD795AD14B10DE11C90 /* Pods-SDWebImage Watch Demo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage Watch Demo.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage Watch Demo/Pods-SDWebImage Watch Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		CBF8AC5EA0AE6C12BC9DE1D8 /* Pods-SDWebImage Watch Demo Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage Watch Demo Extension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage Watch Demo Extension/Pods-SDWebImage Watch Demo Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		DA248D6C1954841D00390AB0 /* SDWebImage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDWebImage.xcodeproj; path = ../SDWebImage.xcodeproj; sourceTree = "<group>"; };
+		E57FD16CDD2075B2E831ED3D /* Pods_Base_SDWebImage_Watch_Demo_Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Base_SDWebImage_Watch_Demo_Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5FE31A05575EAF97EC2878A /* Pods_Base_SDWebImage_TV_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Base_SDWebImage_TV_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EE9261E6243EB1429EE1CF65 /* Pods_Base_SDWebImage_OSX_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Base_SDWebImage_OSX_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F3C19723212A071831A4BF76 /* libPods-Demo-SDWebImage Watch Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Demo-SDWebImage Watch Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F785386DB12CBE9EB1F60625 /* libPods-Demo-SDWebImage iOS Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Demo-SDWebImage iOS Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA6C0249C0C53FCB8FA5B94F /* libPods-SDWebImage OSX Demo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SDWebImage OSX Demo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -221,6 +258,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4314D1BC1D0E11A8004B36C9 /* SDWebImage.framework in Frameworks */,
+				DB69F226A083BE27F647BA46 /* libPods-SDWebImage TV Demo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -229,6 +267,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				43A629EB1D0DFDD40089D7DD /* SDWebImage.framework in Frameworks */,
+				DB87C1FE2C6ECAFF1A6ACB31 /* libPods-SDWebImage OSX Demo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -237,6 +276,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				43F04B3F1D9E468D003F9640 /* SDWebImage.framework in Frameworks */,
+				2106A94718E77EE39A2ADB35 /* libPods-SDWebImage Watch Demo Extension.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -250,6 +290,15 @@
 				5376129A155AB74D005750A4 /* UIKit.framework in Frameworks */,
 				5376129C155AB74D005750A4 /* Foundation.framework in Frameworks */,
 				5376129E155AB74D005750A4 /* CoreGraphics.framework in Frameworks */,
+				EC3C937D7A601B1ED5EF907C /* libPods-SDWebImage iOS Demo.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D08D3E086D8625372EE42D3A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD226F1CE4D78BCCE2DD3B90 /* libPods-SDWebImage Watch Demo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -347,6 +396,7 @@
 				4314D1A71D0E1181004B36C9 /* SDWebImage TV Demo */,
 				53761298155AB74D005750A4 /* Frameworks */,
 				53761296155AB74D005750A4 /* Products */,
+				8799EE2F567E2CEB8BDCA1D9 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -370,6 +420,21 @@
 				53761299155AB74D005750A4 /* UIKit.framework */,
 				5376129B155AB74D005750A4 /* Foundation.framework */,
 				5376129D155AB74D005750A4 /* CoreGraphics.framework */,
+				EE9261E6243EB1429EE1CF65 /* Pods_Base_SDWebImage_OSX_Demo.framework */,
+				E5FE31A05575EAF97EC2878A /* Pods_Base_SDWebImage_TV_Demo.framework */,
+				B427688E683E99F11291403A /* Pods_Base_SDWebImage_Watch_Demo.framework */,
+				E57FD16CDD2075B2E831ED3D /* Pods_Base_SDWebImage_Watch_Demo_Extension.framework */,
+				15E11CD68A1CB229CF82A2CF /* Pods_Base_SDWebImage_iOS_Demo.framework */,
+				5BE79B1E30E750C521F61BC4 /* libPods-Demo-SDWebImage OSX Demo.a */,
+				872939276848EB72AC46533E /* libPods-Demo-SDWebImage TV Demo.a */,
+				F3C19723212A071831A4BF76 /* libPods-Demo-SDWebImage Watch Demo.a */,
+				20682178774759C10014CFF2 /* libPods-Demo-SDWebImage Watch Demo Extension.a */,
+				F785386DB12CBE9EB1F60625 /* libPods-Demo-SDWebImage iOS Demo.a */,
+				FA6C0249C0C53FCB8FA5B94F /* libPods-SDWebImage OSX Demo.a */,
+				C1E3EDCD7AE0E45EA5BA0F98 /* libPods-SDWebImage TV Demo.a */,
+				483FC15FF3CC643408F1B978 /* libPods-SDWebImage Watch Demo Extension.a */,
+				5AD5FF238198C0C0D73BE256 /* libPods-SDWebImage Watch Demo.a */,
+				4485BED3FDD1308A222EF609 /* libPods-SDWebImage iOS Demo.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -404,6 +469,23 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		8799EE2F567E2CEB8BDCA1D9 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				0767D250B8029571A1BBD44A /* Pods-SDWebImage OSX Demo.debug.xcconfig */,
+				6521BF9508A8146DE6CC92DA /* Pods-SDWebImage OSX Demo.release.xcconfig */,
+				4AD7E37386E6BDA0829F533A /* Pods-SDWebImage TV Demo.debug.xcconfig */,
+				1396B5166BDC8633059A1348 /* Pods-SDWebImage TV Demo.release.xcconfig */,
+				CBF8AC5EA0AE6C12BC9DE1D8 /* Pods-SDWebImage Watch Demo Extension.debug.xcconfig */,
+				43127645969A3CF2D637B16C /* Pods-SDWebImage Watch Demo Extension.release.xcconfig */,
+				C7FD9BD795AD14B10DE11C90 /* Pods-SDWebImage Watch Demo.debug.xcconfig */,
+				5FAA202E873CA98C30EE86F9 /* Pods-SDWebImage Watch Demo.release.xcconfig */,
+				939D310966EA630EB7A1FE42 /* Pods-SDWebImage iOS Demo.debug.xcconfig */,
+				624883D0A8DB88BBE1EC3F8F /* Pods-SDWebImage iOS Demo.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		DA248D6D1954841D00390AB0 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -424,9 +506,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4314D1B71D0E1182004B36C9 /* Build configuration list for PBXNativeTarget "SDWebImage TV Demo" */;
 			buildPhases = (
+				A60B2B6E9981FF7B6A00A9D0 /* [CP] Check Pods Manifest.lock */,
 				4314D1A21D0E1181004B36C9 /* Sources */,
 				4314D1A31D0E1181004B36C9 /* Frameworks */,
 				4314D1A41D0E1181004B36C9 /* Resources */,
+				0294DCD1BEDA703B9FFB62A4 /* [CP] Embed Pods Frameworks */,
+				BA0DC9E09AF89CC2F7116B7F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -442,9 +527,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 43A629E81D0DFD000089D7DD /* Build configuration list for PBXNativeTarget "SDWebImage OSX Demo" */;
 			buildPhases = (
+				8443B4E1F944670663046429 /* [CP] Check Pods Manifest.lock */,
 				43A629CB1D0DFD000089D7DD /* Sources */,
 				43A629CC1D0DFD000089D7DD /* Frameworks */,
 				43A629CD1D0DFD000089D7DD /* Resources */,
+				706C92A2367154B758464CB8 /* [CP] Embed Pods Frameworks */,
+				661D009030A20334E93A29CF /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -460,8 +548,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 43A62A141D0E07600089D7DD /* Build configuration list for PBXNativeTarget "SDWebImage Watch Demo" */;
 			buildPhases = (
+				61E7FD26528EF7061F6ADB55 /* [CP] Check Pods Manifest.lock */,
 				43A629EC1D0E07600089D7DD /* Resources */,
 				43A62A131D0E07600089D7DD /* Embed App Extensions */,
+				D08D3E086D8625372EE42D3A /* Frameworks */,
+				55EF6283C1CE70B85554128D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -477,9 +568,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 43A62A101D0E07600089D7DD /* Build configuration list for PBXNativeTarget "SDWebImage Watch Demo Extension" */;
 			buildPhases = (
+				F4CF655A1773AC0A006E49F2 /* [CP] Check Pods Manifest.lock */,
 				43A629F61D0E07600089D7DD /* Sources */,
 				43A629F71D0E07600089D7DD /* Frameworks */,
 				43A629F81D0E07600089D7DD /* Resources */,
+				49093D65608A4B672EC45CED /* [CP] Embed Pods Frameworks */,
+				294DC3442C4B7B15FA41B6E9 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -495,16 +589,20 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 537612B9155AB74D005750A4 /* Build configuration list for PBXNativeTarget "SDWebImage iOS Demo" */;
 			buildPhases = (
+				90869FFE7BB11B565D8EF830 /* [CP] Check Pods Manifest.lock */,
 				53761291155AB74D005750A4 /* Sources */,
 				53761292155AB74D005750A4 /* Frameworks */,
 				53761293155AB74D005750A4 /* Resources */,
 				43A62A171D0E07600089D7DD /* Embed Watch Content */,
+				0535F4B5D9BE13E074935FB6 /* [CP] Embed Pods Frameworks */,
+				5AF8566DA0303D98D5DCF97C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				AB977BFE1EC978E40007E443 /* PBXTargetDependency */,
+				AB977BE61EC9607E0007E443 /* PBXTargetDependency */,
 				43F100171D9EE17C00F6E0CE /* PBXTargetDependency */,
-				43A62A0E1D0E07600089D7DD /* PBXTargetDependency */,
 			);
 			name = "SDWebImage iOS Demo";
 			productName = "SDWebImage Demo";
@@ -517,7 +615,7 @@
 		5376128C155AB74D005750A4 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = Dailymotion;
 				TargetAttributes = {
 					4314D1A51D0E1181004B36C9 = {
@@ -658,6 +756,219 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		0294DCD1BEDA703B9FFB62A4 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SDWebImage TV Demo/Pods-SDWebImage TV Demo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		0535F4B5D9BE13E074935FB6 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SDWebImage iOS Demo/Pods-SDWebImage iOS Demo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		294DC3442C4B7B15FA41B6E9 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SDWebImage Watch Demo Extension/Pods-SDWebImage Watch Demo Extension-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		49093D65608A4B672EC45CED /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SDWebImage Watch Demo Extension/Pods-SDWebImage Watch Demo Extension-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		55EF6283C1CE70B85554128D /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SDWebImage Watch Demo/Pods-SDWebImage Watch Demo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		5AF8566DA0303D98D5DCF97C /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SDWebImage iOS Demo/Pods-SDWebImage iOS Demo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		61E7FD26528EF7061F6ADB55 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		661D009030A20334E93A29CF /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SDWebImage OSX Demo/Pods-SDWebImage OSX Demo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		706C92A2367154B758464CB8 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SDWebImage OSX Demo/Pods-SDWebImage OSX Demo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8443B4E1F944670663046429 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		90869FFE7BB11B565D8EF830 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		A60B2B6E9981FF7B6A00A9D0 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		BA0DC9E09AF89CC2F7116B7F /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-SDWebImage TV Demo/Pods-SDWebImage TV Demo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F4CF655A1773AC0A006E49F2 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		4314D1A21D0E1181004B36C9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -718,11 +1029,6 @@
 			target = 43A629F91D0E07600089D7DD /* SDWebImage Watch Demo Extension */;
 			targetProxy = 43A629FC1D0E07600089D7DD /* PBXContainerItemProxy */;
 		};
-		43A62A0E1D0E07600089D7DD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 43A629ED1D0E07600089D7DD /* SDWebImage Watch Demo */;
-			targetProxy = 43A62A0D1D0E07600089D7DD /* PBXContainerItemProxy */;
-		};
 		43F04B3E1D9E467E003F9640 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "SDWebImage watchOS";
@@ -732,6 +1038,16 @@
 			isa = PBXTargetDependency;
 			name = "SDWebImage iOS";
 			targetProxy = 43F100161D9EE17C00F6E0CE /* PBXContainerItemProxy */;
+		};
+		AB977BE61EC9607E0007E443 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 43A629F91D0E07600089D7DD /* SDWebImage Watch Demo Extension */;
+			targetProxy = AB977BE51EC9607E0007E443 /* PBXContainerItemProxy */;
+		};
+		AB977BFE1EC978E40007E443 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 43A629ED1D0E07600089D7DD /* SDWebImage Watch Demo */;
+			targetProxy = AB977BFD1EC978E40007E443 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -781,6 +1097,7 @@
 /* Begin XCBuildConfiguration section */
 		4314D1B81D0E1182004B36C9 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4AD7E37386E6BDA0829F533A /* Pods-SDWebImage TV Demo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -809,6 +1126,7 @@
 				INFOPLIST_FILE = "SDWebImage TV Demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.SDWebImage-TV-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -819,6 +1137,7 @@
 		};
 		4314D1B91D0E1182004B36C9 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1396B5166BDC8633059A1348 /* Pods-SDWebImage TV Demo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -849,6 +1168,7 @@
 				INFOPLIST_FILE = "SDWebImage TV Demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.SDWebImage-TV-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -859,6 +1179,7 @@
 		};
 		43A629E01D0DFD000089D7DD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0767D250B8029571A1BBD44A /* Pods-SDWebImage OSX Demo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -889,6 +1210,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.SDWebImage-OSX-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -897,6 +1219,7 @@
 		};
 		43A629E11D0DFD000089D7DD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6521BF9508A8146DE6CC92DA /* Pods-SDWebImage OSX Demo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -929,6 +1252,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.SDWebImage-OSX-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -937,6 +1261,7 @@
 		};
 		43A62A111D0E07600089D7DD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CBF8AC5EA0AE6C12BC9DE1D8 /* Pods-SDWebImage Watch Demo Extension.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -963,6 +1288,7 @@
 				INFOPLIST_FILE = "SDWebImage Watch Demo Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.SDWebImage-iOS-Demo.watchkitapp.watchkitextension";
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
@@ -974,6 +1300,7 @@
 		};
 		43A62A121D0E07600089D7DD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 43127645969A3CF2D637B16C /* Pods-SDWebImage Watch Demo Extension.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1002,6 +1329,7 @@
 				INFOPLIST_FILE = "SDWebImage Watch Demo Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.SDWebImage-iOS-Demo.watchkitapp.watchkitextension";
 				PRODUCT_NAME = "${TARGET_NAME}";
 				SDKROOT = watchos;
@@ -1013,6 +1341,7 @@
 		};
 		43A62A151D0E07600089D7DD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C7FD9BD795AD14B10DE11C90 /* Pods-SDWebImage Watch Demo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1040,6 +1369,7 @@
 				IBSC_MODULE = SDWebImage_Watch_Demo_Extension;
 				INFOPLIST_FILE = "SDWebImage Watch Demo/Info.plist";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.SDWebImage-iOS-Demo.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1051,6 +1381,7 @@
 		};
 		43A62A161D0E07600089D7DD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5FAA202E873CA98C30EE86F9 /* Pods-SDWebImage Watch Demo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1080,6 +1411,7 @@
 				IBSC_MODULE = SDWebImage_Watch_Demo_Extension;
 				INFOPLIST_FILE = "SDWebImage Watch Demo/Info.plist";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.SDWebImage-iOS-Demo.watchkitapp";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1094,11 +1426,22 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -1106,8 +1449,11 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_VERSION = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 			};
@@ -1118,12 +1464,26 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_VERSION = "";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				VALIDATE_PRODUCT = YES;
@@ -1132,6 +1492,7 @@
 		};
 		537612BA155AB74D005750A4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 939D310966EA630EB7A1FE42 /* Pods-SDWebImage iOS Demo.debug.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1139,15 +1500,15 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SDWebImage Demo/SDWebImage Demo-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
-				HEADER_SEARCH_PATHS = (
-					"\"$(OBJROOT)/UninstalledProducts/include\"",
-					"\"$(TARGET_BUILD_DIR)/usr/local/lib/include\"",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "SDWebImage Demo/SDWebImage Demo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				OTHER_CFLAGS = "";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1157,6 +1518,7 @@
 		};
 		537612BB155AB74D005750A4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 624883D0A8DB88BBE1EC3F8F /* Pods-SDWebImage iOS Demo.release.xcconfig */;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1164,14 +1526,15 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SDWebImage Demo/SDWebImage Demo-Prefix.pch";
-				GCC_PREPROCESSOR_DEFINITIONS = "";
-				HEADER_SEARCH_PATHS = (
-					"\"$(OBJROOT)/UninstalledProducts/include\"",
-					"\"$(TARGET_BUILD_DIR)/usr/local/lib/include\"",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "SDWebImage Demo/SDWebImage Demo-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/Demo OSX.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/Demo OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "53761294155AB74D005750A4"
-               BuildableName = "SDWebImage iOS Demo.app"
-               BlueprintName = "SDWebImage iOS Demo"
-               ReferencedContainer = "container:Examples/SDWebImage Demo.xcodeproj">
+               BlueprintIdentifier = "43A629CE1D0DFD000089D7DD"
+               BuildableName = "SDWebImage OSX Demo.app"
+               BlueprintName = "SDWebImage OSX Demo"
+               ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -32,10 +32,10 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "53761294155AB74D005750A4"
-            BuildableName = "SDWebImage iOS Demo.app"
-            BlueprintName = "SDWebImage iOS Demo"
-            ReferencedContainer = "container:Examples/SDWebImage Demo.xcodeproj">
+            BlueprintIdentifier = "43A629CE1D0DFD000089D7DD"
+            BuildableName = "SDWebImage OSX Demo.app"
+            BlueprintName = "SDWebImage OSX Demo"
+            ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
@@ -55,10 +55,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "53761294155AB74D005750A4"
-            BuildableName = "SDWebImage iOS Demo.app"
-            BlueprintName = "SDWebImage iOS Demo"
-            ReferencedContainer = "container:Examples/SDWebImage Demo.xcodeproj">
+            BlueprintIdentifier = "43A629CE1D0DFD000089D7DD"
+            BuildableName = "SDWebImage OSX Demo.app"
+            BlueprintName = "SDWebImage OSX Demo"
+            ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <EnvironmentVariables>
@@ -81,10 +81,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "53761294155AB74D005750A4"
-            BuildableName = "SDWebImage iOS Demo.app"
-            BlueprintName = "SDWebImage iOS Demo"
-            ReferencedContainer = "container:Examples/SDWebImage Demo.xcodeproj">
+            BlueprintIdentifier = "43A629CE1D0DFD000089D7DD"
+            BuildableName = "SDWebImage OSX Demo.app"
+            BlueprintName = "SDWebImage OSX Demo"
+            ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/Demo TV.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/Demo TV.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/Demo Watch.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/Demo Watch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/SDWebImage Demo/MasterViewController.m
+++ b/Examples/SDWebImage Demo/MasterViewController.m
@@ -9,7 +9,7 @@
 #import "MasterViewController.h"
 #import <SDWebImage/UIImageView+WebCache.h>
 #import "DetailViewController.h"
-#import <SDWebImage/FLAnimatedImageView.h>
+#import <FLAnimatedImage/FLAnimatedImageView.h>
 #import <SDWebImage/FLAnimatedImageView+WebCache.h>
 #import <SDWebImage/UIView+WebCache.h>
 

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,56 @@
+
+# there is not a podspec in the libwebp project, 
+# so I will copy a podspec to the project folder,
+# and will remove the podspec after pod install.
+require 'fileutils'
+FileUtils.cp('vendors/libwebp.podspec.json', 'vendors/libwebp/')
+post_install do |installer|
+  FileUtils.rm('vendors/libwebp/libwebp.podspec.json')
+end
+
+# use_frameworks!
+
+workspace 'SDWebImage'
+
+################################ Demo ################################
+target 'SDWebImage iOS Demo' do
+  project 'Examples/SDWebImage Demo'
+  platform :ios, '8.0'
+  pod 'FLAnimatedImage', :path=>'vendors/FLAnimatedImage'
+  pod 'libwebp', :path=>'vendors/libwebp'
+end
+
+target 'SDWebImage OSX Demo' do
+  project 'Examples/SDWebImage Demo'
+  platform :osx
+  pod 'libwebp', :path=>'vendors/libwebp'
+end
+
+target 'SDWebImage Watch Demo' do
+  project 'Examples/SDWebImage Demo'
+  platform :watchos
+  pod 'libwebp', :path=>'vendors/libwebp'
+end
+  
+target 'SDWebImage Watch Demo Extension' do
+  project 'Examples/SDWebImage Demo'
+  platform :watchos
+  pod 'libwebp', :path=>'vendors/libwebp'
+end
+
+target 'SDWebImage TV Demo' do
+  project 'Examples/SDWebImage Demo'
+  platform :tvos
+  pod 'libwebp', :path=>'vendors/libwebp'
+end
+
+################################ Tests ################################
+target 'Tests' do
+  project 'Tests/SDWebImage Tests'
+  platform :ios, '8.0'
+  pod 'Expecta'
+  pod 'SDWebImage', :path=>'SDWebImage.podspec'
+  pod 'SDWebImage/WebP', :path=>'SDWebImage.podspec'
+  pod 'SDWebImage/MapKit', :path=>'SDWebImage.podspec'
+  pod 'SDWebImage/GIF', :path=>'SDWebImage.podspec'
+end

--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -54,12 +54,10 @@ Pod::Spec.new do |s|
   s.subspec 'WebP' do |webp|
     webp.source_files = 'SDWebImage/UIImage+WebP.{h,m}'
     webp.xcconfig = { 
-      'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_WEBP=1',
-      'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
+      'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_WEBP=1'
     }
     webp.watchos.xcconfig = {
-      'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_WEBP=1 WEBP_USE_INTRINSICS=1',
-      'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
+      'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_WEBP=1 WEBP_USE_INTRINSICS=1'
     }
     webp.dependency 'SDWebImage/Core'
     webp.dependency 'libwebp'

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -39,232 +39,40 @@
 		00733A711BC4880E00A5A117 /* UIImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D95148C56230056699D /* UIImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00733A721BC4880E00A5A117 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00733A731BC4880E00A5A117 /* SDWebImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A2CAE031AB4BB5400B6BC39 /* SDWebImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4314D11E1D0E0E3B004B36C9 /* huffman.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB21998E60B007367ED /* huffman.c */; };
-		4314D11F1D0E0E3B004B36C9 /* quant_levels.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB71998E60B007367ED /* quant_levels.c */; };
-		4314D1201D0E0E3B004B36C9 /* idec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D601998E6B2007367ED /* idec.c */; };
-		4314D1211D0E0E3B004B36C9 /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBB1998E60B007367ED /* random.c */; };
 		4314D1231D0E0E3B004B36C9 /* SDImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D86148C56230056699D /* SDImageCache.m */; };
 		4314D1241D0E0E3B004B36C9 /* SDWebImageDecoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8A148C56230056699D /* SDWebImageDecoder.m */; };
-		4314D1271D0E0E3B004B36C9 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBD1998E60B007367ED /* rescaler.c */; };
-		4314D12A1D0E0E3B004B36C9 /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D631998E6B2007367ED /* quant.c */; };
-		4314D12F1D0E0E3B004B36C9 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBF1998E60B007367ED /* thread.c */; };
 		4314D1311D0E0E3B004B36C9 /* SDWebImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8C148C56230056699D /* SDWebImageDownloader.m */; };
-		4314D1321D0E0E3B004B36C9 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB01998E60B007367ED /* filters.c */; };
 		4314D1341D0E0E3B004B36C9 /* UIImage+WebP.m in Sources */ = {isa = PBXBuildFile; fileRef = 53EDFB921762547C00698166 /* UIImage+WebP.m */; };
-		4314D1351D0E0E3B004B36C9 /* tree.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D641998E6B2007367ED /* tree.c */; };
 		4314D1361D0E0E3B004B36C9 /* SDWebImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8F148C56230056699D /* SDWebImageManager.m */; };
 		4314D1371D0E0E3B004B36C9 /* SDWebImagePrefetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D92148C56230056699D /* SDWebImagePrefetcher.m */; };
-		4314D1391D0E0E3B004B36C9 /* color_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAD1998E60B007367ED /* color_cache.c */; };
 		4314D13B1D0E0E3B004B36C9 /* UIButton+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D94148C56230056699D /* UIButton+WebCache.m */; };
-		4314D13D1D0E0E3B004B36C9 /* quant_levels_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB91998E60B007367ED /* quant_levels_dec.c */; };
-		4314D13E1D0E0E3B004B36C9 /* vp8l.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D671998E6B2007367ED /* vp8l.c */; };
 		4314D1401D0E0E3B004B36C9 /* UIImageView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D96148C56230056699D /* UIImageView+WebCache.m */; };
 		4314D1411D0E0E3B004B36C9 /* SDWebImageDownloaderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 530E49E416460AE2002868E7 /* SDWebImageDownloaderOperation.m */; };
-		4314D1421D0E0E3B004B36C9 /* webp.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D691998E6B2007367ED /* webp.c */; };
-		4314D1441D0E0E3B004B36C9 /* bit_writer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAB1998E60B007367ED /* bit_writer.c */; };
-		4314D1451D0E0E3B004B36C9 /* vp8.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D651998E6B2007367ED /* vp8.c */; };
 		4314D14B1D0E0E3B004B36C9 /* SDWebImageCompat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5340674F167780C40042B59E /* SDWebImageCompat.m */; };
-		4314D14C1D0E0E3B004B36C9 /* huffman_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB41998E60B007367ED /* huffman_encode.c */; };
 		4314D14D1D0E0E3B004B36C9 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
-		4314D14F1D0E0E3B004B36C9 /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D611998E6B2007367ED /* io.c */; };
 		4314D1501D0E0E3B004B36C9 /* UIView+WebCacheOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = AB615302192DA24600A2D8E9 /* UIView+WebCacheOperation.m */; };
-		4314D1511D0E0E3B004B36C9 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5D1998E6B2007367ED /* buffer.c */; };
 		4314D1521D0E0E3B004B36C9 /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
 		4314D1531D0E0E3B004B36C9 /* UIImage+MultiFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 53EDFB8917623F7C00698166 /* UIImage+MultiFormat.m */; };
 		4314D1551D0E0E3B004B36C9 /* UIImageView+HighlightedWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = ABBE71A618C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m */; };
-		4314D1571D0E0E3B004B36C9 /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5F1998E6B2007367ED /* frame.c */; };
-		4314D1581D0E0E3B004B36C9 /* bit_reader.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CA81998E60B007367ED /* bit_reader.c */; };
-		4314D15A1D0E0E3B004B36C9 /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5B1998E6B2007367ED /* alpha.c */; };
-		4314D15C1D0E0E3B004B36C9 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CC11998E60B007367ED /* utils.c */; };
 		4314D15E1D0E0E3B004B36C9 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53FB894814D35E9E0020B787 /* UIKit.framework */; };
 		4314D15F1D0E0E3B004B36C9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53922D72148C55820056699D /* Foundation.framework */; };
 		4314D1601D0E0E3B004B36C9 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 53FB893F14D35D1A0020B787 /* CoreGraphics.framework */; };
-		4314D1621D0E0E3B004B36C9 /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC91998E60B007367ED /* mux_types.h */; };
-		4314D1631D0E0E3B004B36C9 /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC51998E60B007367ED /* demux.h */; };
-		4314D1651D0E0E3B004B36C9 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC21998E60B007367ED /* utils.h */; };
-		4314D1661D0E0E3B004B36C9 /* quant_levels_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBA1998E60B007367ED /* quant_levels_dec.h */; };
-		4314D1671D0E0E3B004B36C9 /* bit_reader_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAA1998E60B007367ED /* bit_reader_inl.h */; };
-		4314D1691D0E0E3B004B36C9 /* color_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAE1998E60B007367ED /* color_cache.h */; };
-		4314D16A1D0E0E3B004B36C9 /* webpi.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D6A1998E6B2007367ED /* webpi.h */; };
-		4314D16B1D0E0E3B004B36C9 /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC61998E60B007367ED /* encode.h */; };
-		4314D16C1D0E0E3B004B36C9 /* bit_reader.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CA91998E60B007367ED /* bit_reader.h */; };
 		4314D16D1D0E0E3B004B36C9 /* SDImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D85148C56230056699D /* SDImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4314D16E1D0E0E3B004B36C9 /* quant_levels.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB81998E60B007367ED /* quant_levels.h */; };
 		4314D16F1D0E0E3B004B36C9 /* NSData+ImageContentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D5B9140188EE8DD006D06BD /* NSData+ImageContentType.h */; };
-		4314D1701D0E0E3B004B36C9 /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC81998E60B007367ED /* mux.h */; };
-		4314D1711D0E0E3B004B36C9 /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB31998E60B007367ED /* huffman.h */; };
 		4314D1721D0E0E3B004B36C9 /* SDWebImageCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D88148C56230056699D /* SDWebImageCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4314D1731D0E0E3B004B36C9 /* vp8li.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D681998E6B2007367ED /* vp8li.h */; };
-		4314D1741D0E0E3B004B36C9 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CCA1998E60B007367ED /* types.h */; };
-		4314D1761D0E0E3B004B36C9 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC41998E60B007367ED /* decode.h */; };
 		4314D1771D0E0E3B004B36C9 /* SDWebImageDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D89148C56230056699D /* SDWebImageDecoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4314D1781D0E0E3B004B36C9 /* SDWebImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8B148C56230056699D /* SDWebImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4314D1791D0E0E3B004B36C9 /* SDWebImageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8E148C56230056699D /* SDWebImageManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4314D17B1D0E0E3B004B36C9 /* huffman_encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB51998E60B007367ED /* huffman_encode.h */; };
 		4314D17C1D0E0E3B004B36C9 /* UIImage+WebP.h in Headers */ = {isa = PBXBuildFile; fileRef = 53EDFB911762547C00698166 /* UIImage+WebP.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4314D17D1D0E0E3B004B36C9 /* SDWebImagePrefetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D91148C56230056699D /* SDWebImagePrefetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4314D17E1D0E0E3B004B36C9 /* bit_writer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAC1998E60B007367ED /* bit_writer.h */; };
 		4314D17F1D0E0E3B004B36C9 /* UIButton+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D93148C56230056699D /* UIButton+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4314D1801D0E0E3B004B36C9 /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC01998E60B007367ED /* thread.h */; };
 		4314D1811D0E0E3B004B36C9 /* UIImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D95148C56230056699D /* UIImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4314D1821D0E0E3B004B36C9 /* endian_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAF1998E60B007367ED /* endian_inl.h */; };
 		4314D1841D0E0E3B004B36C9 /* SDWebImageOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E71646388E002868E7 /* SDWebImageOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4314D1851D0E0E3B004B36C9 /* SDWebImageDownloaderOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E316460AE2002868E7 /* SDWebImageDownloaderOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4314D1861D0E0E3B004B36C9 /* UIImageView+HighlightedWebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = ABBE71A518C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4314D1871D0E0E3B004B36C9 /* alphai.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5C1998E6B2007367ED /* alphai.h */; };
-		4314D1881D0E0E3B004B36C9 /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC71998E60B007367ED /* format_constants.h */; };
-		4314D1891D0E0E3B004B36C9 /* rescaler.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBE1998E60B007367ED /* rescaler.h */; };
-		4314D18E1D0E0E3B004B36C9 /* vp8i.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D661998E6B2007367ED /* vp8i.h */; };
 		4314D18F1D0E0E3B004B36C9 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4314D1901D0E0E3B004B36C9 /* UIImage+GIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A18A6CC5172DC28500419892 /* UIImage+GIF.h */; };
-		4314D1911D0E0E3B004B36C9 /* filters.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB11998E60B007367ED /* filters.h */; };
 		4314D1921D0E0E3B004B36C9 /* UIImage+MultiFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53EDFB8817623F7C00698166 /* UIImage+MultiFormat.h */; };
-		4314D1931D0E0E3B004B36C9 /* decode_vp8.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5E1998E6B2007367ED /* decode_vp8.h */; };
-		4314D1941D0E0E3B004B36C9 /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBC1998E60B007367ED /* random.h */; };
-		431738781CDFC2580008FEB9 /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5B1998E6B2007367ED /* alpha.c */; };
-		431738791CDFC2580008FEB9 /* alphai.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5C1998E6B2007367ED /* alphai.h */; };
-		4317387A1CDFC2580008FEB9 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5D1998E6B2007367ED /* buffer.c */; };
-		4317387B1CDFC2580008FEB9 /* decode_vp8.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5E1998E6B2007367ED /* decode_vp8.h */; };
-		4317387C1CDFC2580008FEB9 /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5F1998E6B2007367ED /* frame.c */; };
-		4317387D1CDFC2580008FEB9 /* idec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D601998E6B2007367ED /* idec.c */; };
-		4317387E1CDFC2580008FEB9 /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D611998E6B2007367ED /* io.c */; };
-		4317387F1CDFC2580008FEB9 /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D631998E6B2007367ED /* quant.c */; };
-		431738801CDFC2580008FEB9 /* tree.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D641998E6B2007367ED /* tree.c */; };
-		431738811CDFC2580008FEB9 /* vp8.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D651998E6B2007367ED /* vp8.c */; };
-		431738821CDFC2580008FEB9 /* vp8i.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D661998E6B2007367ED /* vp8i.h */; };
-		431738831CDFC2580008FEB9 /* vp8l.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D671998E6B2007367ED /* vp8l.c */; };
-		431738841CDFC2580008FEB9 /* vp8li.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D681998E6B2007367ED /* vp8li.h */; };
-		431738851CDFC2580008FEB9 /* webp.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D691998E6B2007367ED /* webp.c */; };
-		431738861CDFC2580008FEB9 /* webpi.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D6A1998E6B2007367ED /* webpi.h */; };
-		431738A31CDFC2630008FEB9 /* bit_reader.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CA81998E60B007367ED /* bit_reader.c */; };
-		431738A41CDFC2630008FEB9 /* bit_reader.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CA91998E60B007367ED /* bit_reader.h */; };
-		431738A51CDFC2630008FEB9 /* bit_reader_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAA1998E60B007367ED /* bit_reader_inl.h */; };
-		431738A61CDFC2630008FEB9 /* bit_writer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAB1998E60B007367ED /* bit_writer.c */; };
-		431738A71CDFC2630008FEB9 /* bit_writer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAC1998E60B007367ED /* bit_writer.h */; };
-		431738A81CDFC2630008FEB9 /* color_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAD1998E60B007367ED /* color_cache.c */; };
-		431738A91CDFC2630008FEB9 /* color_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAE1998E60B007367ED /* color_cache.h */; };
-		431738AA1CDFC2630008FEB9 /* endian_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAF1998E60B007367ED /* endian_inl.h */; };
-		431738AB1CDFC2630008FEB9 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB01998E60B007367ED /* filters.c */; };
-		431738AC1CDFC2630008FEB9 /* filters.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB11998E60B007367ED /* filters.h */; };
-		431738AD1CDFC2630008FEB9 /* huffman.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB21998E60B007367ED /* huffman.c */; };
-		431738AE1CDFC2630008FEB9 /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB31998E60B007367ED /* huffman.h */; };
-		431738AF1CDFC2630008FEB9 /* huffman_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB41998E60B007367ED /* huffman_encode.c */; };
-		431738B01CDFC2630008FEB9 /* huffman_encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB51998E60B007367ED /* huffman_encode.h */; };
-		431738B11CDFC2630008FEB9 /* quant_levels.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB71998E60B007367ED /* quant_levels.c */; };
-		431738B21CDFC2630008FEB9 /* quant_levels.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB81998E60B007367ED /* quant_levels.h */; };
-		431738B31CDFC2630008FEB9 /* quant_levels_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB91998E60B007367ED /* quant_levels_dec.c */; };
-		431738B41CDFC2630008FEB9 /* quant_levels_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBA1998E60B007367ED /* quant_levels_dec.h */; };
-		431738B51CDFC2630008FEB9 /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBB1998E60B007367ED /* random.c */; };
-		431738B61CDFC2630008FEB9 /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBC1998E60B007367ED /* random.h */; };
-		431738B71CDFC2630008FEB9 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBD1998E60B007367ED /* rescaler.c */; };
-		431738B81CDFC2630008FEB9 /* rescaler.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBE1998E60B007367ED /* rescaler.h */; };
-		431738B91CDFC2630008FEB9 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBF1998E60B007367ED /* thread.c */; };
-		431738BA1CDFC2630008FEB9 /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC01998E60B007367ED /* thread.h */; };
-		431738BB1CDFC2630008FEB9 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CC11998E60B007367ED /* utils.c */; };
-		431738BC1CDFC2630008FEB9 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC21998E60B007367ED /* utils.h */; };
-		431738BD1CDFC2660008FEB9 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC41998E60B007367ED /* decode.h */; };
-		431738BE1CDFC2660008FEB9 /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC51998E60B007367ED /* demux.h */; };
-		431738BF1CDFC2660008FEB9 /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC61998E60B007367ED /* encode.h */; };
-		431738C01CDFC2660008FEB9 /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC71998E60B007367ED /* format_constants.h */; };
-		431738C11CDFC2660008FEB9 /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC81998E60B007367ED /* mux.h */; };
-		431738C21CDFC2660008FEB9 /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC91998E60B007367ED /* mux_types.h */; };
-		431738C31CDFC2660008FEB9 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CCA1998E60B007367ED /* types.h */; };
-		431738C41CDFC8A30008FEB9 /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5B1998E6B2007367ED /* alpha.c */; };
-		431738C51CDFC8A30008FEB9 /* alphai.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5C1998E6B2007367ED /* alphai.h */; };
-		431738C61CDFC8A30008FEB9 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5D1998E6B2007367ED /* buffer.c */; };
-		431738C71CDFC8A30008FEB9 /* decode_vp8.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5E1998E6B2007367ED /* decode_vp8.h */; };
-		431738C81CDFC8A30008FEB9 /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5F1998E6B2007367ED /* frame.c */; };
-		431738C91CDFC8A30008FEB9 /* idec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D601998E6B2007367ED /* idec.c */; };
-		431738CA1CDFC8A30008FEB9 /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D611998E6B2007367ED /* io.c */; };
-		431738CB1CDFC8A30008FEB9 /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D631998E6B2007367ED /* quant.c */; };
-		431738CC1CDFC8A30008FEB9 /* tree.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D641998E6B2007367ED /* tree.c */; };
-		431738CD1CDFC8A30008FEB9 /* vp8.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D651998E6B2007367ED /* vp8.c */; };
-		431738CE1CDFC8A30008FEB9 /* vp8i.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D661998E6B2007367ED /* vp8i.h */; };
-		431738CF1CDFC8A30008FEB9 /* vp8l.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D671998E6B2007367ED /* vp8l.c */; };
-		431738D01CDFC8A30008FEB9 /* vp8li.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D681998E6B2007367ED /* vp8li.h */; };
-		431738D11CDFC8A30008FEB9 /* webp.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D691998E6B2007367ED /* webp.c */; };
-		431738D21CDFC8A30008FEB9 /* webpi.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D6A1998E6B2007367ED /* webpi.h */; };
-		431738D31CDFC8A40008FEB9 /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5B1998E6B2007367ED /* alpha.c */; };
-		431738D41CDFC8A40008FEB9 /* alphai.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5C1998E6B2007367ED /* alphai.h */; };
-		431738D51CDFC8A40008FEB9 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5D1998E6B2007367ED /* buffer.c */; };
-		431738D61CDFC8A40008FEB9 /* decode_vp8.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5E1998E6B2007367ED /* decode_vp8.h */; };
-		431738D71CDFC8A40008FEB9 /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5F1998E6B2007367ED /* frame.c */; };
-		431738D81CDFC8A40008FEB9 /* idec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D601998E6B2007367ED /* idec.c */; };
-		431738D91CDFC8A40008FEB9 /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D611998E6B2007367ED /* io.c */; };
-		431738DA1CDFC8A40008FEB9 /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D631998E6B2007367ED /* quant.c */; };
-		431738DB1CDFC8A40008FEB9 /* tree.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D641998E6B2007367ED /* tree.c */; };
-		431738DC1CDFC8A40008FEB9 /* vp8.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D651998E6B2007367ED /* vp8.c */; };
-		431738DD1CDFC8A40008FEB9 /* vp8i.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D661998E6B2007367ED /* vp8i.h */; };
-		431738DE1CDFC8A40008FEB9 /* vp8l.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D671998E6B2007367ED /* vp8l.c */; };
-		431738DF1CDFC8A40008FEB9 /* vp8li.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D681998E6B2007367ED /* vp8li.h */; };
-		431738E01CDFC8A40008FEB9 /* webp.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D691998E6B2007367ED /* webp.c */; };
-		431738E11CDFC8A40008FEB9 /* webpi.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D6A1998E6B2007367ED /* webpi.h */; };
-		4317391A1CDFC8B20008FEB9 /* bit_reader.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CA81998E60B007367ED /* bit_reader.c */; };
-		4317391B1CDFC8B20008FEB9 /* bit_reader.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CA91998E60B007367ED /* bit_reader.h */; };
-		4317391C1CDFC8B20008FEB9 /* bit_reader_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAA1998E60B007367ED /* bit_reader_inl.h */; };
-		4317391D1CDFC8B20008FEB9 /* bit_writer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAB1998E60B007367ED /* bit_writer.c */; };
-		4317391E1CDFC8B20008FEB9 /* bit_writer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAC1998E60B007367ED /* bit_writer.h */; };
-		4317391F1CDFC8B20008FEB9 /* color_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAD1998E60B007367ED /* color_cache.c */; };
-		431739201CDFC8B20008FEB9 /* color_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAE1998E60B007367ED /* color_cache.h */; };
-		431739211CDFC8B20008FEB9 /* endian_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAF1998E60B007367ED /* endian_inl.h */; };
-		431739221CDFC8B20008FEB9 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB01998E60B007367ED /* filters.c */; };
-		431739231CDFC8B20008FEB9 /* filters.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB11998E60B007367ED /* filters.h */; };
-		431739241CDFC8B20008FEB9 /* huffman.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB21998E60B007367ED /* huffman.c */; };
-		431739251CDFC8B20008FEB9 /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB31998E60B007367ED /* huffman.h */; };
-		431739261CDFC8B20008FEB9 /* huffman_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB41998E60B007367ED /* huffman_encode.c */; };
-		431739271CDFC8B20008FEB9 /* huffman_encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB51998E60B007367ED /* huffman_encode.h */; };
-		431739281CDFC8B20008FEB9 /* quant_levels.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB71998E60B007367ED /* quant_levels.c */; };
-		431739291CDFC8B20008FEB9 /* quant_levels.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB81998E60B007367ED /* quant_levels.h */; };
-		4317392A1CDFC8B20008FEB9 /* quant_levels_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB91998E60B007367ED /* quant_levels_dec.c */; };
-		4317392B1CDFC8B20008FEB9 /* quant_levels_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBA1998E60B007367ED /* quant_levels_dec.h */; };
-		4317392C1CDFC8B20008FEB9 /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBB1998E60B007367ED /* random.c */; };
-		4317392D1CDFC8B20008FEB9 /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBC1998E60B007367ED /* random.h */; };
-		4317392E1CDFC8B20008FEB9 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBD1998E60B007367ED /* rescaler.c */; };
-		4317392F1CDFC8B20008FEB9 /* rescaler.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBE1998E60B007367ED /* rescaler.h */; };
-		431739301CDFC8B20008FEB9 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBF1998E60B007367ED /* thread.c */; };
-		431739311CDFC8B20008FEB9 /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC01998E60B007367ED /* thread.h */; };
-		431739321CDFC8B20008FEB9 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CC11998E60B007367ED /* utils.c */; };
-		431739331CDFC8B20008FEB9 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC21998E60B007367ED /* utils.h */; };
-		431739341CDFC8B20008FEB9 /* bit_reader.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CA81998E60B007367ED /* bit_reader.c */; };
-		431739351CDFC8B20008FEB9 /* bit_reader.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CA91998E60B007367ED /* bit_reader.h */; };
-		431739361CDFC8B20008FEB9 /* bit_reader_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAA1998E60B007367ED /* bit_reader_inl.h */; };
-		431739371CDFC8B20008FEB9 /* bit_writer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAB1998E60B007367ED /* bit_writer.c */; };
-		431739381CDFC8B20008FEB9 /* bit_writer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAC1998E60B007367ED /* bit_writer.h */; };
-		431739391CDFC8B20008FEB9 /* color_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAD1998E60B007367ED /* color_cache.c */; };
-		4317393A1CDFC8B20008FEB9 /* color_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAE1998E60B007367ED /* color_cache.h */; };
-		4317393B1CDFC8B20008FEB9 /* endian_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAF1998E60B007367ED /* endian_inl.h */; };
-		4317393C1CDFC8B20008FEB9 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB01998E60B007367ED /* filters.c */; };
-		4317393D1CDFC8B20008FEB9 /* filters.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB11998E60B007367ED /* filters.h */; };
-		4317393E1CDFC8B20008FEB9 /* huffman.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB21998E60B007367ED /* huffman.c */; };
-		4317393F1CDFC8B20008FEB9 /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB31998E60B007367ED /* huffman.h */; };
-		431739401CDFC8B20008FEB9 /* huffman_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB41998E60B007367ED /* huffman_encode.c */; };
-		431739411CDFC8B20008FEB9 /* huffman_encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB51998E60B007367ED /* huffman_encode.h */; };
-		431739421CDFC8B20008FEB9 /* quant_levels.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB71998E60B007367ED /* quant_levels.c */; };
-		431739431CDFC8B20008FEB9 /* quant_levels.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB81998E60B007367ED /* quant_levels.h */; };
-		431739441CDFC8B20008FEB9 /* quant_levels_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB91998E60B007367ED /* quant_levels_dec.c */; };
-		431739451CDFC8B20008FEB9 /* quant_levels_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBA1998E60B007367ED /* quant_levels_dec.h */; };
-		431739461CDFC8B20008FEB9 /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBB1998E60B007367ED /* random.c */; };
-		431739471CDFC8B20008FEB9 /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBC1998E60B007367ED /* random.h */; };
-		431739481CDFC8B20008FEB9 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBD1998E60B007367ED /* rescaler.c */; };
-		431739491CDFC8B20008FEB9 /* rescaler.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBE1998E60B007367ED /* rescaler.h */; };
-		4317394A1CDFC8B20008FEB9 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBF1998E60B007367ED /* thread.c */; };
-		4317394B1CDFC8B20008FEB9 /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC01998E60B007367ED /* thread.h */; };
-		4317394C1CDFC8B20008FEB9 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CC11998E60B007367ED /* utils.c */; };
-		4317394D1CDFC8B20008FEB9 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC21998E60B007367ED /* utils.h */; };
-		4317394E1CDFC8B70008FEB9 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC41998E60B007367ED /* decode.h */; };
-		4317394F1CDFC8B70008FEB9 /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC51998E60B007367ED /* demux.h */; };
-		431739501CDFC8B70008FEB9 /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC61998E60B007367ED /* encode.h */; };
-		431739511CDFC8B70008FEB9 /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC71998E60B007367ED /* format_constants.h */; };
-		431739521CDFC8B70008FEB9 /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC81998E60B007367ED /* mux.h */; };
-		431739531CDFC8B70008FEB9 /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC91998E60B007367ED /* mux_types.h */; };
-		431739541CDFC8B70008FEB9 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CCA1998E60B007367ED /* types.h */; };
-		431739551CDFC8B70008FEB9 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC41998E60B007367ED /* decode.h */; };
-		431739561CDFC8B70008FEB9 /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC51998E60B007367ED /* demux.h */; };
-		431739571CDFC8B70008FEB9 /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC61998E60B007367ED /* encode.h */; };
-		431739581CDFC8B70008FEB9 /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC71998E60B007367ED /* format_constants.h */; };
-		431739591CDFC8B70008FEB9 /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC81998E60B007367ED /* mux.h */; };
-		4317395A1CDFC8B70008FEB9 /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC91998E60B007367ED /* mux_types.h */; };
-		4317395B1CDFC8B70008FEB9 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CCA1998E60B007367ED /* types.h */; };
 		431BB68C1D06D2C1006A3455 /* SDWebImageDownloaderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 530E49E416460AE2002868E7 /* SDWebImageDownloaderOperation.m */; };
 		431BB68E1D06D2C1006A3455 /* SDWebImagePrefetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D92148C56230056699D /* SDWebImagePrefetcher.m */; };
 		431BB6921D06D2C1006A3455 /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
@@ -313,140 +121,44 @@
 		438096731CDFC08F00DC626B /* MKAnnotationView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 535699B515113E7300A4C397 /* MKAnnotationView+WebCache.m */; };
 		438096741CDFC09C00DC626B /* UIImage+WebP.h in Headers */ = {isa = PBXBuildFile; fileRef = 53EDFB911762547C00698166 /* UIImage+WebP.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		438096751CDFC0A100DC626B /* UIImage+WebP.m in Sources */ = {isa = PBXBuildFile; fileRef = 53EDFB921762547C00698166 /* UIImage+WebP.m */; };
-		4397D2791D0DDD8C00BB2784 /* huffman.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB21998E60B007367ED /* huffman.c */; };
-		4397D27A1D0DDD8C00BB2784 /* quant_levels.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB71998E60B007367ED /* quant_levels.c */; };
-		4397D27B1D0DDD8C00BB2784 /* idec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D601998E6B2007367ED /* idec.c */; };
-		4397D27C1D0DDD8C00BB2784 /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBB1998E60B007367ED /* random.c */; };
 		4397D27E1D0DDD8C00BB2784 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
 		4397D27F1D0DDD8C00BB2784 /* UIImage+WebP.m in Sources */ = {isa = PBXBuildFile; fileRef = 53EDFB921762547C00698166 /* UIImage+WebP.m */; };
-		4397D2821D0DDD8C00BB2784 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBD1998E60B007367ED /* rescaler.c */; };
-		4397D2851D0DDD8C00BB2784 /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D631998E6B2007367ED /* quant.c */; };
-		4397D28A1D0DDD8C00BB2784 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBF1998E60B007367ED /* thread.c */; };
 		4397D28C1D0DDD8C00BB2784 /* UIImageView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D96148C56230056699D /* UIImageView+WebCache.m */; };
-		4397D28D1D0DDD8C00BB2784 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB01998E60B007367ED /* filters.c */; };
 		4397D28F1D0DDD8C00BB2784 /* SDWebImageDownloaderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 530E49E416460AE2002868E7 /* SDWebImageDownloaderOperation.m */; };
-		4397D2901D0DDD8C00BB2784 /* tree.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D641998E6B2007367ED /* tree.c */; };
 		4397D2911D0DDD8C00BB2784 /* MKAnnotationView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 535699B515113E7300A4C397 /* MKAnnotationView+WebCache.m */; };
 		4397D2921D0DDD8C00BB2784 /* SDWebImagePrefetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D92148C56230056699D /* SDWebImagePrefetcher.m */; };
-		4397D2941D0DDD8C00BB2784 /* color_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAD1998E60B007367ED /* color_cache.c */; };
 		4397D2961D0DDD8C00BB2784 /* UIImage+MultiFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 53EDFB8917623F7C00698166 /* UIImage+MultiFormat.m */; };
-		4397D2981D0DDD8C00BB2784 /* quant_levels_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB91998E60B007367ED /* quant_levels_dec.c */; };
-		4397D2991D0DDD8C00BB2784 /* vp8l.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D671998E6B2007367ED /* vp8l.c */; };
 		4397D29B1D0DDD8C00BB2784 /* SDWebImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8C148C56230056699D /* SDWebImageDownloader.m */; };
 		4397D29C1D0DDD8C00BB2784 /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
-		4397D29D1D0DDD8C00BB2784 /* webp.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D691998E6B2007367ED /* webp.c */; };
-		4397D29F1D0DDD8C00BB2784 /* bit_writer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAB1998E60B007367ED /* bit_writer.c */; };
-		4397D2A01D0DDD8C00BB2784 /* vp8.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D651998E6B2007367ED /* vp8.c */; };
 		4397D2A11D0DDD8C00BB2784 /* SDWebImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8F148C56230056699D /* SDWebImageManager.m */; };
 		4397D2A61D0DDD8C00BB2784 /* SDWebImageCompat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5340674F167780C40042B59E /* SDWebImageCompat.m */; };
-		4397D2A71D0DDD8C00BB2784 /* huffman_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB41998E60B007367ED /* huffman_encode.c */; };
 		4397D2A81D0DDD8C00BB2784 /* UIButton+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D94148C56230056699D /* UIButton+WebCache.m */; };
-		4397D2AA1D0DDD8C00BB2784 /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D611998E6B2007367ED /* io.c */; };
 		4397D2AB1D0DDD8C00BB2784 /* UIView+WebCacheOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = AB615302192DA24600A2D8E9 /* UIView+WebCacheOperation.m */; };
-		4397D2AC1D0DDD8C00BB2784 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5D1998E6B2007367ED /* buffer.c */; };
 		4397D2AD1D0DDD8C00BB2784 /* SDWebImageDecoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8A148C56230056699D /* SDWebImageDecoder.m */; };
 		4397D2AE1D0DDD8C00BB2784 /* UIImageView+HighlightedWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = ABBE71A618C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m */; };
 		4397D2B01D0DDD8C00BB2784 /* SDImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D86148C56230056699D /* SDImageCache.m */; };
-		4397D2B21D0DDD8C00BB2784 /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5F1998E6B2007367ED /* frame.c */; };
-		4397D2B31D0DDD8C00BB2784 /* bit_reader.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CA81998E60B007367ED /* bit_reader.c */; };
-		4397D2B51D0DDD8C00BB2784 /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5B1998E6B2007367ED /* alpha.c */; };
-		4397D2B71D0DDD8C00BB2784 /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CC11998E60B007367ED /* utils.c */; };
-		4397D2BA1D0DDD8C00BB2784 /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC51998E60B007367ED /* demux.h */; };
-		4397D2BB1D0DDD8C00BB2784 /* endian_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAF1998E60B007367ED /* endian_inl.h */; };
-		4397D2BD1D0DDD8C00BB2784 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CCA1998E60B007367ED /* types.h */; };
-		4397D2BF1D0DDD8C00BB2784 /* alphai.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5C1998E6B2007367ED /* alphai.h */; };
 		4397D2C01D0DDD8C00BB2784 /* SDWebImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A2CAE031AB4BB5400B6BC39 /* SDWebImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4397D2C11D0DDD8C00BB2784 /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC71998E60B007367ED /* format_constants.h */; };
-		4397D2C21D0DDD8C00BB2784 /* filters.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB11998E60B007367ED /* filters.h */; };
 		4397D2C31D0DDD8C00BB2784 /* SDWebImageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8E148C56230056699D /* SDWebImageManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2C41D0DDD8C00BB2784 /* SDImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D85148C56230056699D /* SDImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2C51D0DDD8C00BB2784 /* UIImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D95148C56230056699D /* UIImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4397D2C61D0DDD8C00BB2784 /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBC1998E60B007367ED /* random.h */; };
-		4397D2C71D0DDD8C00BB2784 /* rescaler.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBE1998E60B007367ED /* rescaler.h */; };
 		4397D2C81D0DDD8C00BB2784 /* SDWebImageCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D88148C56230056699D /* SDWebImageCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4397D2C91D0DDD8C00BB2784 /* bit_reader.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CA91998E60B007367ED /* bit_reader.h */; };
 		4397D2CB1D0DDD8C00BB2784 /* UIImageView+HighlightedWebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = ABBE71A518C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4397D2CC1D0DDD8C00BB2784 /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC81998E60B007367ED /* mux.h */; };
-		4397D2CE1D0DDD8C00BB2784 /* huffman_encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB51998E60B007367ED /* huffman_encode.h */; };
 		4397D2D01D0DDD8C00BB2784 /* SDWebImageDownloaderOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E316460AE2002868E7 /* SDWebImageDownloaderOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4397D2D11D0DDD8C00BB2784 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC41998E60B007367ED /* decode.h */; };
-		4397D2D21D0DDD8C00BB2784 /* webpi.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D6A1998E6B2007367ED /* webpi.h */; };
-		4397D2D31D0DDD8C00BB2784 /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC01998E60B007367ED /* thread.h */; };
-		4397D2D41D0DDD8C00BB2784 /* quant_levels.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB81998E60B007367ED /* quant_levels.h */; };
-		4397D2D51D0DDD8C00BB2784 /* bit_reader_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAA1998E60B007367ED /* bit_reader_inl.h */; };
-		4397D2D61D0DDD8C00BB2784 /* quant_levels_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBA1998E60B007367ED /* quant_levels_dec.h */; };
 		4397D2D81D0DDD8C00BB2784 /* UIButton+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D93148C56230056699D /* UIButton+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2D91D0DDD8C00BB2784 /* SDWebImagePrefetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D91148C56230056699D /* SDWebImagePrefetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2DA1D0DDD8C00BB2784 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2DB1D0DDD8C00BB2784 /* UIImage+MultiFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53EDFB8817623F7C00698166 /* UIImage+MultiFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2DC1D0DDD8C00BB2784 /* SDWebImageOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E71646388E002868E7 /* SDWebImageOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4397D2DD1D0DDD8C00BB2784 /* vp8i.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D661998E6B2007367ED /* vp8i.h */; };
-		4397D2DE1D0DDD8C00BB2784 /* vp8li.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D681998E6B2007367ED /* vp8li.h */; };
-		4397D2DF1D0DDD8C00BB2784 /* color_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAE1998E60B007367ED /* color_cache.h */; };
-		4397D2E01D0DDD8C00BB2784 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC21998E60B007367ED /* utils.h */; };
 		4397D2E11D0DDD8C00BB2784 /* SDWebImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8B148C56230056699D /* SDWebImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4397D2E21D0DDD8C00BB2784 /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB31998E60B007367ED /* huffman.h */; };
 		4397D2E31D0DDD8C00BB2784 /* MKAnnotationView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 535699B415113E7300A4C397 /* MKAnnotationView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4397D2E51D0DDD8C00BB2784 /* bit_writer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAC1998E60B007367ED /* bit_writer.h */; };
-		4397D2E61D0DDD8C00BB2784 /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC61998E60B007367ED /* encode.h */; };
 		4397D2E81D0DDD8C00BB2784 /* SDWebImageDecoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D89148C56230056699D /* SDWebImageDecoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2E91D0DDD8C00BB2784 /* UIImage+WebP.h in Headers */ = {isa = PBXBuildFile; fileRef = 53EDFB911762547C00698166 /* UIImage+WebP.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2EA1D0DDD8C00BB2784 /* UIImage+GIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A18A6CC5172DC28500419892 /* UIImage+GIF.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2EB1D0DDD8C00BB2784 /* NSData+ImageContentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D5B9140188EE8DD006D06BD /* NSData+ImageContentType.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4397D2EC1D0DDD8C00BB2784 /* decode_vp8.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5E1998E6B2007367ED /* decode_vp8.h */; };
-		4397D2ED1D0DDD8C00BB2784 /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC91998E60B007367ED /* mux_types.h */; };
 		4397D2F61D0DE2DF00BB2784 /* NSImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4397D2F41D0DE2DF00BB2784 /* NSImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2F71D0DE2DF00BB2784 /* NSImage+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4397D2F51D0DE2DF00BB2784 /* NSImage+WebCache.m */; };
 		4397D2F81D0DF44200BB2784 /* MKAnnotationView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 535699B415113E7300A4C397 /* MKAnnotationView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4397D2F91D0DF44A00BB2784 /* MKAnnotationView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 535699B515113E7300A4C397 /* MKAnnotationView+WebCache.m */; };
-		43A62A1B1D0E0A800089D7DD /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC41998E60B007367ED /* decode.h */; };
-		43A62A1C1D0E0A800089D7DD /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC51998E60B007367ED /* demux.h */; };
-		43A62A1D1D0E0A800089D7DD /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC61998E60B007367ED /* encode.h */; };
-		43A62A1E1D0E0A800089D7DD /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC71998E60B007367ED /* format_constants.h */; };
-		43A62A1F1D0E0A800089D7DD /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC81998E60B007367ED /* mux.h */; };
-		43A62A201D0E0A800089D7DD /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC91998E60B007367ED /* mux_types.h */; };
-		43A62A211D0E0A800089D7DD /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CCA1998E60B007367ED /* types.h */; };
-		43A62A221D0E0A860089D7DD /* bit_reader.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CA81998E60B007367ED /* bit_reader.c */; };
-		43A62A231D0E0A860089D7DD /* bit_reader.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CA91998E60B007367ED /* bit_reader.h */; };
-		43A62A241D0E0A860089D7DD /* bit_reader_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAA1998E60B007367ED /* bit_reader_inl.h */; };
-		43A62A251D0E0A860089D7DD /* bit_writer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAB1998E60B007367ED /* bit_writer.c */; };
-		43A62A261D0E0A860089D7DD /* bit_writer.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAC1998E60B007367ED /* bit_writer.h */; };
-		43A62A271D0E0A860089D7DD /* color_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CAD1998E60B007367ED /* color_cache.c */; };
-		43A62A281D0E0A860089D7DD /* color_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAE1998E60B007367ED /* color_cache.h */; };
-		43A62A291D0E0A860089D7DD /* endian_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CAF1998E60B007367ED /* endian_inl.h */; };
-		43A62A2A1D0E0A860089D7DD /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB01998E60B007367ED /* filters.c */; };
-		43A62A2B1D0E0A860089D7DD /* filters.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB11998E60B007367ED /* filters.h */; };
-		43A62A2C1D0E0A860089D7DD /* huffman.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB21998E60B007367ED /* huffman.c */; };
-		43A62A2D1D0E0A860089D7DD /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB31998E60B007367ED /* huffman.h */; };
-		43A62A2E1D0E0A860089D7DD /* huffman_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB41998E60B007367ED /* huffman_encode.c */; };
-		43A62A2F1D0E0A860089D7DD /* huffman_encode.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB51998E60B007367ED /* huffman_encode.h */; };
-		43A62A301D0E0A860089D7DD /* quant_levels.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB71998E60B007367ED /* quant_levels.c */; };
-		43A62A311D0E0A860089D7DD /* quant_levels.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CB81998E60B007367ED /* quant_levels.h */; };
-		43A62A321D0E0A860089D7DD /* quant_levels_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CB91998E60B007367ED /* quant_levels_dec.c */; };
-		43A62A331D0E0A860089D7DD /* quant_levels_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBA1998E60B007367ED /* quant_levels_dec.h */; };
-		43A62A341D0E0A860089D7DD /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBB1998E60B007367ED /* random.c */; };
-		43A62A351D0E0A860089D7DD /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBC1998E60B007367ED /* random.h */; };
-		43A62A361D0E0A860089D7DD /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBD1998E60B007367ED /* rescaler.c */; };
-		43A62A371D0E0A860089D7DD /* rescaler.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CBE1998E60B007367ED /* rescaler.h */; };
-		43A62A381D0E0A860089D7DD /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CBF1998E60B007367ED /* thread.c */; };
-		43A62A391D0E0A860089D7DD /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC01998E60B007367ED /* thread.h */; };
-		43A62A3A1D0E0A860089D7DD /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577CC11998E60B007367ED /* utils.c */; };
-		43A62A3B1D0E0A860089D7DD /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577CC21998E60B007367ED /* utils.h */; };
-		43A62A581D0E0A8F0089D7DD /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5B1998E6B2007367ED /* alpha.c */; };
-		43A62A591D0E0A8F0089D7DD /* alphai.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5C1998E6B2007367ED /* alphai.h */; };
-		43A62A5A1D0E0A8F0089D7DD /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5D1998E6B2007367ED /* buffer.c */; };
-		43A62A5B1D0E0A8F0089D7DD /* decode_vp8.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D5E1998E6B2007367ED /* decode_vp8.h */; };
-		43A62A5C1D0E0A8F0089D7DD /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D5F1998E6B2007367ED /* frame.c */; };
-		43A62A5D1D0E0A8F0089D7DD /* idec.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D601998E6B2007367ED /* idec.c */; };
-		43A62A5E1D0E0A8F0089D7DD /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D611998E6B2007367ED /* io.c */; };
-		43A62A5F1D0E0A8F0089D7DD /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D631998E6B2007367ED /* quant.c */; };
-		43A62A601D0E0A8F0089D7DD /* tree.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D641998E6B2007367ED /* tree.c */; };
-		43A62A611D0E0A8F0089D7DD /* vp8.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D651998E6B2007367ED /* vp8.c */; };
-		43A62A621D0E0A8F0089D7DD /* vp8i.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D661998E6B2007367ED /* vp8i.h */; };
-		43A62A631D0E0A8F0089D7DD /* vp8l.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D671998E6B2007367ED /* vp8l.c */; };
-		43A62A641D0E0A8F0089D7DD /* vp8li.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D681998E6B2007367ED /* vp8li.h */; };
-		43A62A651D0E0A8F0089D7DD /* webp.c in Sources */ = {isa = PBXBuildFile; fileRef = DA577D691998E6B2007367ED /* webp.c */; };
-		43A62A661D0E0A8F0089D7DD /* webpi.h in Headers */ = {isa = PBXBuildFile; fileRef = DA577D6A1998E6B2007367ED /* webpi.h */; };
 		43A918641D8308FE00B3925F /* SDImageCacheConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 43A918621D8308FE00B3925F /* SDImageCacheConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43A918651D8308FE00B3925F /* SDImageCacheConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 43A918621D8308FE00B3925F /* SDImageCacheConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43A918661D8308FE00B3925F /* SDImageCacheConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 43A918621D8308FE00B3925F /* SDImageCacheConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -459,408 +171,12 @@
 		43A9186E1D8308FE00B3925F /* SDImageCacheConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A918631D8308FE00B3925F /* SDImageCacheConfig.m */; };
 		43A9186F1D8308FE00B3925F /* SDImageCacheConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A918631D8308FE00B3925F /* SDImageCacheConfig.m */; };
 		43A918701D8308FE00B3925F /* SDImageCacheConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A918631D8308FE00B3925F /* SDImageCacheConfig.m */; };
-		43C892851D9D62B60022038D /* common_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892821D9D62B60022038D /* common_sse2.h */; };
-		43C892861D9D62B60022038D /* dec_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892831D9D62B60022038D /* dec_msa.c */; };
-		43C892871D9D62B60022038D /* msa_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892841D9D62B60022038D /* msa_macro.h */; };
-		43C892881D9D62C50022038D /* common_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892821D9D62B60022038D /* common_sse2.h */; };
-		43C892891D9D62C60022038D /* common_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892821D9D62B60022038D /* common_sse2.h */; };
-		43C8928A1D9D62C60022038D /* common_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892821D9D62B60022038D /* common_sse2.h */; };
-		43C8928B1D9D62C70022038D /* common_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892821D9D62B60022038D /* common_sse2.h */; };
-		43C8928C1D9D62C70022038D /* common_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892821D9D62B60022038D /* common_sse2.h */; };
-		43C8928D1D9D62CF0022038D /* dec_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892831D9D62B60022038D /* dec_msa.c */; };
-		43C8928E1D9D62D00022038D /* dec_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892831D9D62B60022038D /* dec_msa.c */; };
-		43C8928F1D9D62D00022038D /* dec_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892831D9D62B60022038D /* dec_msa.c */; };
-		43C892901D9D62D10022038D /* dec_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892831D9D62B60022038D /* dec_msa.c */; };
-		43C892911D9D62D10022038D /* dec_msa.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892831D9D62B60022038D /* dec_msa.c */; };
-		43C892921D9D62D30022038D /* msa_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892841D9D62B60022038D /* msa_macro.h */; };
-		43C892931D9D62D40022038D /* msa_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892841D9D62B60022038D /* msa_macro.h */; };
-		43C892941D9D62D40022038D /* msa_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892841D9D62B60022038D /* msa_macro.h */; };
-		43C892951D9D62D40022038D /* msa_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892841D9D62B60022038D /* msa_macro.h */; };
-		43C892961D9D62D40022038D /* msa_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43C892841D9D62B60022038D /* msa_macro.h */; };
-		43C8929A1D9D6DD70022038D /* anim_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892981D9D6DD70022038D /* anim_decode.c */; };
-		43C8929B1D9D6DD70022038D /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892991D9D6DD70022038D /* demux.c */; };
-		43C8929C1D9D6DD90022038D /* anim_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892981D9D6DD70022038D /* anim_decode.c */; };
-		43C8929D1D9D6DD90022038D /* anim_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892981D9D6DD70022038D /* anim_decode.c */; };
-		43C8929E1D9D6DDA0022038D /* anim_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892981D9D6DD70022038D /* anim_decode.c */; };
-		43C8929F1D9D6DDA0022038D /* anim_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892981D9D6DD70022038D /* anim_decode.c */; };
-		43C892A01D9D6DDA0022038D /* anim_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892981D9D6DD70022038D /* anim_decode.c */; };
-		43C892A11D9D6DDC0022038D /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892991D9D6DD70022038D /* demux.c */; };
-		43C892A21D9D6DDD0022038D /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892991D9D6DD70022038D /* demux.c */; };
-		43C892A31D9D6DDD0022038D /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892991D9D6DD70022038D /* demux.c */; };
-		43C892A41D9D6DDD0022038D /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892991D9D6DD70022038D /* demux.c */; };
-		43C892A51D9D6DDE0022038D /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = 43C892991D9D6DD70022038D /* demux.c */; };
-		43CE75761CFE9427006C64D0 /* FLAnimatedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CE75491CFE9427006C64D0 /* FLAnimatedImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43CE75771CFE9427006C64D0 /* FLAnimatedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CE75491CFE9427006C64D0 /* FLAnimatedImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43CE75781CFE9427006C64D0 /* FLAnimatedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CE75491CFE9427006C64D0 /* FLAnimatedImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43CE75791CFE9427006C64D0 /* FLAnimatedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 43CE754A1CFE9427006C64D0 /* FLAnimatedImage.m */; };
-		43CE757A1CFE9427006C64D0 /* FLAnimatedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 43CE754A1CFE9427006C64D0 /* FLAnimatedImage.m */; };
-		43CE757B1CFE9427006C64D0 /* FLAnimatedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 43CE754A1CFE9427006C64D0 /* FLAnimatedImage.m */; };
-		43CE757C1CFE9427006C64D0 /* FLAnimatedImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CE754B1CFE9427006C64D0 /* FLAnimatedImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43CE757D1CFE9427006C64D0 /* FLAnimatedImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CE754B1CFE9427006C64D0 /* FLAnimatedImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43CE757E1CFE9427006C64D0 /* FLAnimatedImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CE754B1CFE9427006C64D0 /* FLAnimatedImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43CE757F1CFE9427006C64D0 /* FLAnimatedImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 43CE754C1CFE9427006C64D0 /* FLAnimatedImageView.m */; };
-		43CE75801CFE9427006C64D0 /* FLAnimatedImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 43CE754C1CFE9427006C64D0 /* FLAnimatedImageView.m */; };
-		43CE75811CFE9427006C64D0 /* FLAnimatedImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 43CE754C1CFE9427006C64D0 /* FLAnimatedImageView.m */; };
 		43CE75D01CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CE75CE1CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43CE75D11CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CE75CE1CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43CE75D21CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 43CE75CE1CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43CE75D31CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 43CE75CF1CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m */; };
 		43CE75D41CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 43CE75CF1CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m */; };
 		43CE75D51CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 43CE75CF1CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m */; };
-		43DA7C161D1086000028BE58 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C151D1086000028BE58 /* common.h */; };
-		43DA7C171D1086100028BE58 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C151D1086000028BE58 /* common.h */; };
-		43DA7C181D1086110028BE58 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C151D1086000028BE58 /* common.h */; };
-		43DA7C191D1086120028BE58 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C151D1086000028BE58 /* common.h */; };
-		43DA7C1A1D1086120028BE58 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C151D1086000028BE58 /* common.h */; };
-		43DA7C1B1D1086130028BE58 /* common.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C151D1086000028BE58 /* common.h */; };
-		43DA7C911D1086570028BE58 /* alpha_processing_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5A1D1086570028BE58 /* alpha_processing_sse41.c */; };
-		43DA7C921D1086570028BE58 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5B1D1086570028BE58 /* alpha_processing.c */; };
-		43DA7C931D1086570028BE58 /* argb_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5C1D1086570028BE58 /* argb_mips_dsp_r2.c */; };
-		43DA7C941D1086570028BE58 /* argb_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5D1D1086570028BE58 /* argb_sse2.c */; };
-		43DA7C951D1086570028BE58 /* argb.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5E1D1086570028BE58 /* argb.c */; };
-		43DA7C961D1086570028BE58 /* cost_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5F1D1086570028BE58 /* cost_mips_dsp_r2.c */; };
-		43DA7C971D1086570028BE58 /* cost_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C601D1086570028BE58 /* cost_mips32.c */; };
-		43DA7C981D1086570028BE58 /* cost_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C611D1086570028BE58 /* cost_sse2.c */; };
-		43DA7C991D1086570028BE58 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C621D1086570028BE58 /* cost.c */; };
-		43DA7C9A1D1086570028BE58 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C631D1086570028BE58 /* cpu.c */; };
-		43DA7C9B1D1086570028BE58 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C641D1086570028BE58 /* dec_clip_tables.c */; };
-		43DA7C9C1D1086570028BE58 /* dec_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C651D1086570028BE58 /* dec_mips_dsp_r2.c */; };
-		43DA7C9D1D1086570028BE58 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C661D1086570028BE58 /* dec_mips32.c */; };
-		43DA7C9E1D1086570028BE58 /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C671D1086570028BE58 /* dec_neon.c */; };
-		43DA7C9F1D1086570028BE58 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C681D1086570028BE58 /* dec_sse2.c */; };
-		43DA7CA01D1086570028BE58 /* dec_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C691D1086570028BE58 /* dec_sse41.c */; };
-		43DA7CA11D1086570028BE58 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6A1D1086570028BE58 /* dec.c */; };
-		43DA7CA21D1086570028BE58 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C6B1D1086570028BE58 /* dsp.h */; };
-		43DA7CA31D1086570028BE58 /* enc_avx2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6C1D1086570028BE58 /* enc_avx2.c */; };
-		43DA7CA41D1086570028BE58 /* enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6D1D1086570028BE58 /* enc_mips_dsp_r2.c */; };
-		43DA7CA51D1086570028BE58 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6E1D1086570028BE58 /* enc_mips32.c */; };
-		43DA7CA61D1086570028BE58 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6F1D1086570028BE58 /* enc_neon.c */; };
-		43DA7CA71D1086570028BE58 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C701D1086570028BE58 /* enc_sse2.c */; };
-		43DA7CA81D1086570028BE58 /* enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C711D1086570028BE58 /* enc_sse41.c */; };
-		43DA7CA91D1086570028BE58 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C721D1086570028BE58 /* enc.c */; };
-		43DA7CAA1D1086570028BE58 /* filters_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C731D1086570028BE58 /* filters_mips_dsp_r2.c */; };
-		43DA7CAB1D1086570028BE58 /* filters_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C741D1086570028BE58 /* filters_sse2.c */; };
-		43DA7CAC1D1086570028BE58 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C751D1086570028BE58 /* filters.c */; };
-		43DA7CAD1D1086570028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C761D1086570028BE58 /* lossless_enc_mips_dsp_r2.c */; };
-		43DA7CAE1D1086570028BE58 /* lossless_enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C771D1086570028BE58 /* lossless_enc_mips32.c */; };
-		43DA7CAF1D1086570028BE58 /* lossless_enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C781D1086570028BE58 /* lossless_enc_neon.c */; };
-		43DA7CB01D1086570028BE58 /* lossless_enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C791D1086570028BE58 /* lossless_enc_sse2.c */; };
-		43DA7CB11D1086570028BE58 /* lossless_enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7A1D1086570028BE58 /* lossless_enc_sse41.c */; };
-		43DA7CB21D1086570028BE58 /* lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7B1D1086570028BE58 /* lossless_enc.c */; };
-		43DA7CB31D1086570028BE58 /* lossless_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7C1D1086570028BE58 /* lossless_mips_dsp_r2.c */; };
-		43DA7CB41D1086570028BE58 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7D1D1086570028BE58 /* lossless_neon.c */; };
-		43DA7CB51D1086570028BE58 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7E1D1086570028BE58 /* lossless_sse2.c */; };
-		43DA7CB61D1086570028BE58 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7F1D1086570028BE58 /* lossless.c */; };
-		43DA7CB71D1086570028BE58 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C801D1086570028BE58 /* lossless.h */; };
-		43DA7CB81D1086570028BE58 /* mips_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C811D1086570028BE58 /* mips_macro.h */; };
-		43DA7CB91D1086570028BE58 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C821D1086570028BE58 /* neon.h */; };
-		43DA7CBA1D1086570028BE58 /* rescaler_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C831D1086570028BE58 /* rescaler_mips_dsp_r2.c */; };
-		43DA7CBB1D1086570028BE58 /* rescaler_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C841D1086570028BE58 /* rescaler_mips32.c */; };
-		43DA7CBC1D1086570028BE58 /* rescaler_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C851D1086570028BE58 /* rescaler_neon.c */; };
-		43DA7CBD1D1086570028BE58 /* rescaler_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C861D1086570028BE58 /* rescaler_sse2.c */; };
-		43DA7CBE1D1086570028BE58 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C871D1086570028BE58 /* rescaler.c */; };
-		43DA7CBF1D1086570028BE58 /* upsampling_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C881D1086570028BE58 /* upsampling_mips_dsp_r2.c */; };
-		43DA7CC01D1086570028BE58 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C891D1086570028BE58 /* upsampling_neon.c */; };
-		43DA7CC11D1086570028BE58 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8A1D1086570028BE58 /* upsampling_sse2.c */; };
-		43DA7CC21D1086570028BE58 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8B1D1086570028BE58 /* upsampling.c */; };
-		43DA7CC31D1086570028BE58 /* yuv_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8C1D1086570028BE58 /* yuv_mips_dsp_r2.c */; };
-		43DA7CC41D1086570028BE58 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8D1D1086570028BE58 /* yuv_mips32.c */; };
-		43DA7CC51D1086570028BE58 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8E1D1086570028BE58 /* yuv_sse2.c */; };
-		43DA7CC61D1086570028BE58 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8F1D1086570028BE58 /* yuv.c */; };
-		43DA7CC71D1086570028BE58 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C901D1086570028BE58 /* yuv.h */; };
-		43DA7CC81D10865E0028BE58 /* alpha_processing_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5A1D1086570028BE58 /* alpha_processing_sse41.c */; };
-		43DA7CC91D10865E0028BE58 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5B1D1086570028BE58 /* alpha_processing.c */; };
-		43DA7CCA1D10865E0028BE58 /* argb_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5C1D1086570028BE58 /* argb_mips_dsp_r2.c */; };
-		43DA7CCB1D10865E0028BE58 /* argb_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5D1D1086570028BE58 /* argb_sse2.c */; };
-		43DA7CCC1D10865E0028BE58 /* argb.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5E1D1086570028BE58 /* argb.c */; };
-		43DA7CCD1D10865E0028BE58 /* cost_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5F1D1086570028BE58 /* cost_mips_dsp_r2.c */; };
-		43DA7CCE1D10865E0028BE58 /* cost_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C601D1086570028BE58 /* cost_mips32.c */; };
-		43DA7CCF1D10865E0028BE58 /* cost_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C611D1086570028BE58 /* cost_sse2.c */; };
-		43DA7CD01D10865E0028BE58 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C621D1086570028BE58 /* cost.c */; };
-		43DA7CD11D10865E0028BE58 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C631D1086570028BE58 /* cpu.c */; };
-		43DA7CD21D10865E0028BE58 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C641D1086570028BE58 /* dec_clip_tables.c */; };
-		43DA7CD31D10865E0028BE58 /* dec_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C651D1086570028BE58 /* dec_mips_dsp_r2.c */; };
-		43DA7CD41D10865E0028BE58 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C661D1086570028BE58 /* dec_mips32.c */; };
-		43DA7CD51D10865E0028BE58 /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C671D1086570028BE58 /* dec_neon.c */; };
-		43DA7CD61D10865E0028BE58 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C681D1086570028BE58 /* dec_sse2.c */; };
-		43DA7CD71D10865E0028BE58 /* dec_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C691D1086570028BE58 /* dec_sse41.c */; };
-		43DA7CD81D10865E0028BE58 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6A1D1086570028BE58 /* dec.c */; };
-		43DA7CD91D10865E0028BE58 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C6B1D1086570028BE58 /* dsp.h */; };
-		43DA7CDA1D10865E0028BE58 /* enc_avx2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6C1D1086570028BE58 /* enc_avx2.c */; };
-		43DA7CDB1D10865E0028BE58 /* enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6D1D1086570028BE58 /* enc_mips_dsp_r2.c */; };
-		43DA7CDC1D10865E0028BE58 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6E1D1086570028BE58 /* enc_mips32.c */; };
-		43DA7CDD1D10865E0028BE58 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6F1D1086570028BE58 /* enc_neon.c */; };
-		43DA7CDE1D10865E0028BE58 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C701D1086570028BE58 /* enc_sse2.c */; };
-		43DA7CDF1D10865E0028BE58 /* enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C711D1086570028BE58 /* enc_sse41.c */; };
-		43DA7CE01D10865E0028BE58 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C721D1086570028BE58 /* enc.c */; };
-		43DA7CE11D10865E0028BE58 /* filters_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C731D1086570028BE58 /* filters_mips_dsp_r2.c */; };
-		43DA7CE21D10865E0028BE58 /* filters_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C741D1086570028BE58 /* filters_sse2.c */; };
-		43DA7CE31D10865E0028BE58 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C751D1086570028BE58 /* filters.c */; };
-		43DA7CE41D10865E0028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C761D1086570028BE58 /* lossless_enc_mips_dsp_r2.c */; };
-		43DA7CE51D10865E0028BE58 /* lossless_enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C771D1086570028BE58 /* lossless_enc_mips32.c */; };
-		43DA7CE61D10865E0028BE58 /* lossless_enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C781D1086570028BE58 /* lossless_enc_neon.c */; };
-		43DA7CE71D10865E0028BE58 /* lossless_enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C791D1086570028BE58 /* lossless_enc_sse2.c */; };
-		43DA7CE81D10865E0028BE58 /* lossless_enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7A1D1086570028BE58 /* lossless_enc_sse41.c */; };
-		43DA7CE91D10865E0028BE58 /* lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7B1D1086570028BE58 /* lossless_enc.c */; };
-		43DA7CEA1D10865E0028BE58 /* lossless_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7C1D1086570028BE58 /* lossless_mips_dsp_r2.c */; };
-		43DA7CEB1D10865E0028BE58 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7D1D1086570028BE58 /* lossless_neon.c */; };
-		43DA7CEC1D10865E0028BE58 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7E1D1086570028BE58 /* lossless_sse2.c */; };
-		43DA7CED1D10865E0028BE58 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7F1D1086570028BE58 /* lossless.c */; };
-		43DA7CEE1D10865E0028BE58 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C801D1086570028BE58 /* lossless.h */; };
-		43DA7CEF1D10865E0028BE58 /* mips_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C811D1086570028BE58 /* mips_macro.h */; };
-		43DA7CF01D10865E0028BE58 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C821D1086570028BE58 /* neon.h */; };
-		43DA7CF11D10865E0028BE58 /* rescaler_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C831D1086570028BE58 /* rescaler_mips_dsp_r2.c */; };
-		43DA7CF21D10865E0028BE58 /* rescaler_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C841D1086570028BE58 /* rescaler_mips32.c */; };
-		43DA7CF31D10865E0028BE58 /* rescaler_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C851D1086570028BE58 /* rescaler_neon.c */; };
-		43DA7CF41D10865E0028BE58 /* rescaler_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C861D1086570028BE58 /* rescaler_sse2.c */; };
-		43DA7CF51D10865E0028BE58 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C871D1086570028BE58 /* rescaler.c */; };
-		43DA7CF61D10865E0028BE58 /* upsampling_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C881D1086570028BE58 /* upsampling_mips_dsp_r2.c */; };
-		43DA7CF71D10865E0028BE58 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C891D1086570028BE58 /* upsampling_neon.c */; };
-		43DA7CF81D10865E0028BE58 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8A1D1086570028BE58 /* upsampling_sse2.c */; };
-		43DA7CF91D10865E0028BE58 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8B1D1086570028BE58 /* upsampling.c */; };
-		43DA7CFA1D10865E0028BE58 /* yuv_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8C1D1086570028BE58 /* yuv_mips_dsp_r2.c */; };
-		43DA7CFB1D10865E0028BE58 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8D1D1086570028BE58 /* yuv_mips32.c */; };
-		43DA7CFC1D10865E0028BE58 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8E1D1086570028BE58 /* yuv_sse2.c */; };
-		43DA7CFD1D10865E0028BE58 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8F1D1086570028BE58 /* yuv.c */; };
-		43DA7CFE1D10865E0028BE58 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C901D1086570028BE58 /* yuv.h */; };
-		43DA7CFF1D10865F0028BE58 /* alpha_processing_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5A1D1086570028BE58 /* alpha_processing_sse41.c */; };
-		43DA7D001D10865F0028BE58 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5B1D1086570028BE58 /* alpha_processing.c */; };
-		43DA7D011D10865F0028BE58 /* argb_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5C1D1086570028BE58 /* argb_mips_dsp_r2.c */; };
-		43DA7D021D10865F0028BE58 /* argb_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5D1D1086570028BE58 /* argb_sse2.c */; };
-		43DA7D031D10865F0028BE58 /* argb.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5E1D1086570028BE58 /* argb.c */; };
-		43DA7D041D10865F0028BE58 /* cost_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5F1D1086570028BE58 /* cost_mips_dsp_r2.c */; };
-		43DA7D051D10865F0028BE58 /* cost_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C601D1086570028BE58 /* cost_mips32.c */; };
-		43DA7D061D10865F0028BE58 /* cost_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C611D1086570028BE58 /* cost_sse2.c */; };
-		43DA7D071D10865F0028BE58 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C621D1086570028BE58 /* cost.c */; };
-		43DA7D081D10865F0028BE58 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C631D1086570028BE58 /* cpu.c */; };
-		43DA7D091D10865F0028BE58 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C641D1086570028BE58 /* dec_clip_tables.c */; };
-		43DA7D0A1D10865F0028BE58 /* dec_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C651D1086570028BE58 /* dec_mips_dsp_r2.c */; };
-		43DA7D0B1D10865F0028BE58 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C661D1086570028BE58 /* dec_mips32.c */; };
-		43DA7D0C1D10865F0028BE58 /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C671D1086570028BE58 /* dec_neon.c */; };
-		43DA7D0D1D10865F0028BE58 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C681D1086570028BE58 /* dec_sse2.c */; };
-		43DA7D0E1D10865F0028BE58 /* dec_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C691D1086570028BE58 /* dec_sse41.c */; };
-		43DA7D0F1D10865F0028BE58 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6A1D1086570028BE58 /* dec.c */; };
-		43DA7D101D10865F0028BE58 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C6B1D1086570028BE58 /* dsp.h */; };
-		43DA7D111D10865F0028BE58 /* enc_avx2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6C1D1086570028BE58 /* enc_avx2.c */; };
-		43DA7D121D10865F0028BE58 /* enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6D1D1086570028BE58 /* enc_mips_dsp_r2.c */; };
-		43DA7D131D10865F0028BE58 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6E1D1086570028BE58 /* enc_mips32.c */; };
-		43DA7D141D10865F0028BE58 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6F1D1086570028BE58 /* enc_neon.c */; };
-		43DA7D151D10865F0028BE58 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C701D1086570028BE58 /* enc_sse2.c */; };
-		43DA7D161D10865F0028BE58 /* enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C711D1086570028BE58 /* enc_sse41.c */; };
-		43DA7D171D10865F0028BE58 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C721D1086570028BE58 /* enc.c */; };
-		43DA7D181D10865F0028BE58 /* filters_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C731D1086570028BE58 /* filters_mips_dsp_r2.c */; };
-		43DA7D191D10865F0028BE58 /* filters_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C741D1086570028BE58 /* filters_sse2.c */; };
-		43DA7D1A1D10865F0028BE58 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C751D1086570028BE58 /* filters.c */; };
-		43DA7D1B1D10865F0028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C761D1086570028BE58 /* lossless_enc_mips_dsp_r2.c */; };
-		43DA7D1C1D10865F0028BE58 /* lossless_enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C771D1086570028BE58 /* lossless_enc_mips32.c */; };
-		43DA7D1D1D10865F0028BE58 /* lossless_enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C781D1086570028BE58 /* lossless_enc_neon.c */; };
-		43DA7D1E1D10865F0028BE58 /* lossless_enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C791D1086570028BE58 /* lossless_enc_sse2.c */; };
-		43DA7D1F1D10865F0028BE58 /* lossless_enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7A1D1086570028BE58 /* lossless_enc_sse41.c */; };
-		43DA7D201D10865F0028BE58 /* lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7B1D1086570028BE58 /* lossless_enc.c */; };
-		43DA7D211D10865F0028BE58 /* lossless_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7C1D1086570028BE58 /* lossless_mips_dsp_r2.c */; };
-		43DA7D221D10865F0028BE58 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7D1D1086570028BE58 /* lossless_neon.c */; };
-		43DA7D231D10865F0028BE58 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7E1D1086570028BE58 /* lossless_sse2.c */; };
-		43DA7D241D10865F0028BE58 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7F1D1086570028BE58 /* lossless.c */; };
-		43DA7D251D10865F0028BE58 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C801D1086570028BE58 /* lossless.h */; };
-		43DA7D261D10865F0028BE58 /* mips_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C811D1086570028BE58 /* mips_macro.h */; };
-		43DA7D271D10865F0028BE58 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C821D1086570028BE58 /* neon.h */; };
-		43DA7D281D10865F0028BE58 /* rescaler_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C831D1086570028BE58 /* rescaler_mips_dsp_r2.c */; };
-		43DA7D291D10865F0028BE58 /* rescaler_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C841D1086570028BE58 /* rescaler_mips32.c */; };
-		43DA7D2A1D10865F0028BE58 /* rescaler_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C851D1086570028BE58 /* rescaler_neon.c */; };
-		43DA7D2B1D10865F0028BE58 /* rescaler_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C861D1086570028BE58 /* rescaler_sse2.c */; };
-		43DA7D2C1D10865F0028BE58 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C871D1086570028BE58 /* rescaler.c */; };
-		43DA7D2D1D10865F0028BE58 /* upsampling_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C881D1086570028BE58 /* upsampling_mips_dsp_r2.c */; };
-		43DA7D2E1D10865F0028BE58 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C891D1086570028BE58 /* upsampling_neon.c */; };
-		43DA7D2F1D10865F0028BE58 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8A1D1086570028BE58 /* upsampling_sse2.c */; };
-		43DA7D301D10865F0028BE58 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8B1D1086570028BE58 /* upsampling.c */; };
-		43DA7D311D10865F0028BE58 /* yuv_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8C1D1086570028BE58 /* yuv_mips_dsp_r2.c */; };
-		43DA7D321D10865F0028BE58 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8D1D1086570028BE58 /* yuv_mips32.c */; };
-		43DA7D331D10865F0028BE58 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8E1D1086570028BE58 /* yuv_sse2.c */; };
-		43DA7D341D10865F0028BE58 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8F1D1086570028BE58 /* yuv.c */; };
-		43DA7D351D10865F0028BE58 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C901D1086570028BE58 /* yuv.h */; };
-		43DA7D361D1086600028BE58 /* alpha_processing_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5A1D1086570028BE58 /* alpha_processing_sse41.c */; };
-		43DA7D371D1086600028BE58 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5B1D1086570028BE58 /* alpha_processing.c */; };
-		43DA7D381D1086600028BE58 /* argb_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5C1D1086570028BE58 /* argb_mips_dsp_r2.c */; };
-		43DA7D391D1086600028BE58 /* argb_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5D1D1086570028BE58 /* argb_sse2.c */; };
-		43DA7D3A1D1086600028BE58 /* argb.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5E1D1086570028BE58 /* argb.c */; };
-		43DA7D3B1D1086600028BE58 /* cost_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5F1D1086570028BE58 /* cost_mips_dsp_r2.c */; };
-		43DA7D3C1D1086600028BE58 /* cost_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C601D1086570028BE58 /* cost_mips32.c */; };
-		43DA7D3D1D1086600028BE58 /* cost_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C611D1086570028BE58 /* cost_sse2.c */; };
-		43DA7D3E1D1086600028BE58 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C621D1086570028BE58 /* cost.c */; };
-		43DA7D3F1D1086600028BE58 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C631D1086570028BE58 /* cpu.c */; };
-		43DA7D401D1086600028BE58 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C641D1086570028BE58 /* dec_clip_tables.c */; };
-		43DA7D411D1086600028BE58 /* dec_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C651D1086570028BE58 /* dec_mips_dsp_r2.c */; };
-		43DA7D421D1086600028BE58 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C661D1086570028BE58 /* dec_mips32.c */; };
-		43DA7D431D1086600028BE58 /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C671D1086570028BE58 /* dec_neon.c */; };
-		43DA7D441D1086600028BE58 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C681D1086570028BE58 /* dec_sse2.c */; };
-		43DA7D451D1086600028BE58 /* dec_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C691D1086570028BE58 /* dec_sse41.c */; };
-		43DA7D461D1086600028BE58 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6A1D1086570028BE58 /* dec.c */; };
-		43DA7D471D1086600028BE58 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C6B1D1086570028BE58 /* dsp.h */; };
-		43DA7D481D1086600028BE58 /* enc_avx2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6C1D1086570028BE58 /* enc_avx2.c */; };
-		43DA7D491D1086600028BE58 /* enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6D1D1086570028BE58 /* enc_mips_dsp_r2.c */; };
-		43DA7D4A1D1086600028BE58 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6E1D1086570028BE58 /* enc_mips32.c */; };
-		43DA7D4B1D1086600028BE58 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6F1D1086570028BE58 /* enc_neon.c */; };
-		43DA7D4C1D1086600028BE58 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C701D1086570028BE58 /* enc_sse2.c */; };
-		43DA7D4D1D1086600028BE58 /* enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C711D1086570028BE58 /* enc_sse41.c */; };
-		43DA7D4E1D1086600028BE58 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C721D1086570028BE58 /* enc.c */; };
-		43DA7D4F1D1086600028BE58 /* filters_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C731D1086570028BE58 /* filters_mips_dsp_r2.c */; };
-		43DA7D501D1086600028BE58 /* filters_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C741D1086570028BE58 /* filters_sse2.c */; };
-		43DA7D511D1086600028BE58 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C751D1086570028BE58 /* filters.c */; };
-		43DA7D521D1086600028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C761D1086570028BE58 /* lossless_enc_mips_dsp_r2.c */; };
-		43DA7D531D1086600028BE58 /* lossless_enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C771D1086570028BE58 /* lossless_enc_mips32.c */; };
-		43DA7D541D1086600028BE58 /* lossless_enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C781D1086570028BE58 /* lossless_enc_neon.c */; };
-		43DA7D551D1086600028BE58 /* lossless_enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C791D1086570028BE58 /* lossless_enc_sse2.c */; };
-		43DA7D561D1086600028BE58 /* lossless_enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7A1D1086570028BE58 /* lossless_enc_sse41.c */; };
-		43DA7D571D1086600028BE58 /* lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7B1D1086570028BE58 /* lossless_enc.c */; };
-		43DA7D581D1086600028BE58 /* lossless_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7C1D1086570028BE58 /* lossless_mips_dsp_r2.c */; };
-		43DA7D591D1086600028BE58 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7D1D1086570028BE58 /* lossless_neon.c */; };
-		43DA7D5A1D1086600028BE58 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7E1D1086570028BE58 /* lossless_sse2.c */; };
-		43DA7D5B1D1086600028BE58 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7F1D1086570028BE58 /* lossless.c */; };
-		43DA7D5C1D1086600028BE58 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C801D1086570028BE58 /* lossless.h */; };
-		43DA7D5D1D1086600028BE58 /* mips_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C811D1086570028BE58 /* mips_macro.h */; };
-		43DA7D5E1D1086600028BE58 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C821D1086570028BE58 /* neon.h */; };
-		43DA7D5F1D1086600028BE58 /* rescaler_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C831D1086570028BE58 /* rescaler_mips_dsp_r2.c */; };
-		43DA7D601D1086600028BE58 /* rescaler_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C841D1086570028BE58 /* rescaler_mips32.c */; };
-		43DA7D611D1086600028BE58 /* rescaler_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C851D1086570028BE58 /* rescaler_neon.c */; };
-		43DA7D621D1086600028BE58 /* rescaler_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C861D1086570028BE58 /* rescaler_sse2.c */; };
-		43DA7D631D1086600028BE58 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C871D1086570028BE58 /* rescaler.c */; };
-		43DA7D641D1086600028BE58 /* upsampling_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C881D1086570028BE58 /* upsampling_mips_dsp_r2.c */; };
-		43DA7D651D1086600028BE58 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C891D1086570028BE58 /* upsampling_neon.c */; };
-		43DA7D661D1086600028BE58 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8A1D1086570028BE58 /* upsampling_sse2.c */; };
-		43DA7D671D1086600028BE58 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8B1D1086570028BE58 /* upsampling.c */; };
-		43DA7D681D1086600028BE58 /* yuv_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8C1D1086570028BE58 /* yuv_mips_dsp_r2.c */; };
-		43DA7D691D1086600028BE58 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8D1D1086570028BE58 /* yuv_mips32.c */; };
-		43DA7D6A1D1086600028BE58 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8E1D1086570028BE58 /* yuv_sse2.c */; };
-		43DA7D6B1D1086600028BE58 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8F1D1086570028BE58 /* yuv.c */; };
-		43DA7D6C1D1086600028BE58 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C901D1086570028BE58 /* yuv.h */; };
-		43DA7D6D1D1086600028BE58 /* alpha_processing_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5A1D1086570028BE58 /* alpha_processing_sse41.c */; };
-		43DA7D6E1D1086600028BE58 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5B1D1086570028BE58 /* alpha_processing.c */; };
-		43DA7D6F1D1086600028BE58 /* argb_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5C1D1086570028BE58 /* argb_mips_dsp_r2.c */; };
-		43DA7D701D1086600028BE58 /* argb_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5D1D1086570028BE58 /* argb_sse2.c */; };
-		43DA7D711D1086600028BE58 /* argb.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5E1D1086570028BE58 /* argb.c */; };
-		43DA7D721D1086600028BE58 /* cost_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5F1D1086570028BE58 /* cost_mips_dsp_r2.c */; };
-		43DA7D731D1086600028BE58 /* cost_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C601D1086570028BE58 /* cost_mips32.c */; };
-		43DA7D741D1086600028BE58 /* cost_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C611D1086570028BE58 /* cost_sse2.c */; };
-		43DA7D751D1086600028BE58 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C621D1086570028BE58 /* cost.c */; };
-		43DA7D761D1086600028BE58 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C631D1086570028BE58 /* cpu.c */; };
-		43DA7D771D1086600028BE58 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C641D1086570028BE58 /* dec_clip_tables.c */; };
-		43DA7D781D1086600028BE58 /* dec_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C651D1086570028BE58 /* dec_mips_dsp_r2.c */; };
-		43DA7D791D1086600028BE58 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C661D1086570028BE58 /* dec_mips32.c */; };
-		43DA7D7A1D1086600028BE58 /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C671D1086570028BE58 /* dec_neon.c */; };
-		43DA7D7B1D1086600028BE58 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C681D1086570028BE58 /* dec_sse2.c */; };
-		43DA7D7C1D1086600028BE58 /* dec_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C691D1086570028BE58 /* dec_sse41.c */; };
-		43DA7D7D1D1086600028BE58 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6A1D1086570028BE58 /* dec.c */; };
-		43DA7D7E1D1086600028BE58 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C6B1D1086570028BE58 /* dsp.h */; };
-		43DA7D7F1D1086600028BE58 /* enc_avx2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6C1D1086570028BE58 /* enc_avx2.c */; };
-		43DA7D801D1086600028BE58 /* enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6D1D1086570028BE58 /* enc_mips_dsp_r2.c */; };
-		43DA7D811D1086600028BE58 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6E1D1086570028BE58 /* enc_mips32.c */; };
-		43DA7D821D1086600028BE58 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6F1D1086570028BE58 /* enc_neon.c */; };
-		43DA7D831D1086600028BE58 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C701D1086570028BE58 /* enc_sse2.c */; };
-		43DA7D841D1086600028BE58 /* enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C711D1086570028BE58 /* enc_sse41.c */; };
-		43DA7D851D1086600028BE58 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C721D1086570028BE58 /* enc.c */; };
-		43DA7D861D1086600028BE58 /* filters_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C731D1086570028BE58 /* filters_mips_dsp_r2.c */; };
-		43DA7D871D1086600028BE58 /* filters_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C741D1086570028BE58 /* filters_sse2.c */; };
-		43DA7D881D1086600028BE58 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C751D1086570028BE58 /* filters.c */; };
-		43DA7D891D1086600028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C761D1086570028BE58 /* lossless_enc_mips_dsp_r2.c */; };
-		43DA7D8A1D1086600028BE58 /* lossless_enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C771D1086570028BE58 /* lossless_enc_mips32.c */; };
-		43DA7D8B1D1086600028BE58 /* lossless_enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C781D1086570028BE58 /* lossless_enc_neon.c */; };
-		43DA7D8C1D1086600028BE58 /* lossless_enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C791D1086570028BE58 /* lossless_enc_sse2.c */; };
-		43DA7D8D1D1086600028BE58 /* lossless_enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7A1D1086570028BE58 /* lossless_enc_sse41.c */; };
-		43DA7D8E1D1086600028BE58 /* lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7B1D1086570028BE58 /* lossless_enc.c */; };
-		43DA7D8F1D1086600028BE58 /* lossless_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7C1D1086570028BE58 /* lossless_mips_dsp_r2.c */; };
-		43DA7D901D1086600028BE58 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7D1D1086570028BE58 /* lossless_neon.c */; };
-		43DA7D911D1086600028BE58 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7E1D1086570028BE58 /* lossless_sse2.c */; };
-		43DA7D921D1086600028BE58 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7F1D1086570028BE58 /* lossless.c */; };
-		43DA7D931D1086600028BE58 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C801D1086570028BE58 /* lossless.h */; };
-		43DA7D941D1086600028BE58 /* mips_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C811D1086570028BE58 /* mips_macro.h */; };
-		43DA7D951D1086600028BE58 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C821D1086570028BE58 /* neon.h */; };
-		43DA7D961D1086600028BE58 /* rescaler_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C831D1086570028BE58 /* rescaler_mips_dsp_r2.c */; };
-		43DA7D971D1086600028BE58 /* rescaler_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C841D1086570028BE58 /* rescaler_mips32.c */; };
-		43DA7D981D1086600028BE58 /* rescaler_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C851D1086570028BE58 /* rescaler_neon.c */; };
-		43DA7D991D1086600028BE58 /* rescaler_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C861D1086570028BE58 /* rescaler_sse2.c */; };
-		43DA7D9A1D1086600028BE58 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C871D1086570028BE58 /* rescaler.c */; };
-		43DA7D9B1D1086600028BE58 /* upsampling_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C881D1086570028BE58 /* upsampling_mips_dsp_r2.c */; };
-		43DA7D9C1D1086600028BE58 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C891D1086570028BE58 /* upsampling_neon.c */; };
-		43DA7D9D1D1086600028BE58 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8A1D1086570028BE58 /* upsampling_sse2.c */; };
-		43DA7D9E1D1086600028BE58 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8B1D1086570028BE58 /* upsampling.c */; };
-		43DA7D9F1D1086600028BE58 /* yuv_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8C1D1086570028BE58 /* yuv_mips_dsp_r2.c */; };
-		43DA7DA01D1086600028BE58 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8D1D1086570028BE58 /* yuv_mips32.c */; };
-		43DA7DA11D1086600028BE58 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8E1D1086570028BE58 /* yuv_sse2.c */; };
-		43DA7DA21D1086600028BE58 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8F1D1086570028BE58 /* yuv.c */; };
-		43DA7DA31D1086600028BE58 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C901D1086570028BE58 /* yuv.h */; };
-		43DA7DA41D1086610028BE58 /* alpha_processing_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5A1D1086570028BE58 /* alpha_processing_sse41.c */; };
-		43DA7DA51D1086610028BE58 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5B1D1086570028BE58 /* alpha_processing.c */; };
-		43DA7DA61D1086610028BE58 /* argb_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5C1D1086570028BE58 /* argb_mips_dsp_r2.c */; };
-		43DA7DA71D1086610028BE58 /* argb_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5D1D1086570028BE58 /* argb_sse2.c */; };
-		43DA7DA81D1086610028BE58 /* argb.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5E1D1086570028BE58 /* argb.c */; };
-		43DA7DA91D1086610028BE58 /* cost_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C5F1D1086570028BE58 /* cost_mips_dsp_r2.c */; };
-		43DA7DAA1D1086610028BE58 /* cost_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C601D1086570028BE58 /* cost_mips32.c */; };
-		43DA7DAB1D1086610028BE58 /* cost_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C611D1086570028BE58 /* cost_sse2.c */; };
-		43DA7DAC1D1086610028BE58 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C621D1086570028BE58 /* cost.c */; };
-		43DA7DAD1D1086610028BE58 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C631D1086570028BE58 /* cpu.c */; };
-		43DA7DAE1D1086610028BE58 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C641D1086570028BE58 /* dec_clip_tables.c */; };
-		43DA7DAF1D1086610028BE58 /* dec_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C651D1086570028BE58 /* dec_mips_dsp_r2.c */; };
-		43DA7DB01D1086610028BE58 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C661D1086570028BE58 /* dec_mips32.c */; };
-		43DA7DB11D1086610028BE58 /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C671D1086570028BE58 /* dec_neon.c */; };
-		43DA7DB21D1086610028BE58 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C681D1086570028BE58 /* dec_sse2.c */; };
-		43DA7DB31D1086610028BE58 /* dec_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C691D1086570028BE58 /* dec_sse41.c */; };
-		43DA7DB41D1086610028BE58 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6A1D1086570028BE58 /* dec.c */; };
-		43DA7DB51D1086610028BE58 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C6B1D1086570028BE58 /* dsp.h */; };
-		43DA7DB61D1086610028BE58 /* enc_avx2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6C1D1086570028BE58 /* enc_avx2.c */; };
-		43DA7DB71D1086610028BE58 /* enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6D1D1086570028BE58 /* enc_mips_dsp_r2.c */; };
-		43DA7DB81D1086610028BE58 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6E1D1086570028BE58 /* enc_mips32.c */; };
-		43DA7DB91D1086610028BE58 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C6F1D1086570028BE58 /* enc_neon.c */; };
-		43DA7DBA1D1086610028BE58 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C701D1086570028BE58 /* enc_sse2.c */; };
-		43DA7DBB1D1086610028BE58 /* enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C711D1086570028BE58 /* enc_sse41.c */; };
-		43DA7DBC1D1086610028BE58 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C721D1086570028BE58 /* enc.c */; };
-		43DA7DBD1D1086610028BE58 /* filters_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C731D1086570028BE58 /* filters_mips_dsp_r2.c */; };
-		43DA7DBE1D1086610028BE58 /* filters_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C741D1086570028BE58 /* filters_sse2.c */; };
-		43DA7DBF1D1086610028BE58 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C751D1086570028BE58 /* filters.c */; };
-		43DA7DC01D1086610028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C761D1086570028BE58 /* lossless_enc_mips_dsp_r2.c */; };
-		43DA7DC11D1086610028BE58 /* lossless_enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C771D1086570028BE58 /* lossless_enc_mips32.c */; };
-		43DA7DC21D1086610028BE58 /* lossless_enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C781D1086570028BE58 /* lossless_enc_neon.c */; };
-		43DA7DC31D1086610028BE58 /* lossless_enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C791D1086570028BE58 /* lossless_enc_sse2.c */; };
-		43DA7DC41D1086610028BE58 /* lossless_enc_sse41.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7A1D1086570028BE58 /* lossless_enc_sse41.c */; };
-		43DA7DC51D1086610028BE58 /* lossless_enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7B1D1086570028BE58 /* lossless_enc.c */; };
-		43DA7DC61D1086610028BE58 /* lossless_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7C1D1086570028BE58 /* lossless_mips_dsp_r2.c */; };
-		43DA7DC71D1086610028BE58 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7D1D1086570028BE58 /* lossless_neon.c */; };
-		43DA7DC81D1086610028BE58 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7E1D1086570028BE58 /* lossless_sse2.c */; };
-		43DA7DC91D1086610028BE58 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C7F1D1086570028BE58 /* lossless.c */; };
-		43DA7DCA1D1086610028BE58 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C801D1086570028BE58 /* lossless.h */; };
-		43DA7DCB1D1086610028BE58 /* mips_macro.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C811D1086570028BE58 /* mips_macro.h */; };
-		43DA7DCC1D1086610028BE58 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C821D1086570028BE58 /* neon.h */; };
-		43DA7DCD1D1086610028BE58 /* rescaler_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C831D1086570028BE58 /* rescaler_mips_dsp_r2.c */; };
-		43DA7DCE1D1086610028BE58 /* rescaler_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C841D1086570028BE58 /* rescaler_mips32.c */; };
-		43DA7DCF1D1086610028BE58 /* rescaler_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C851D1086570028BE58 /* rescaler_neon.c */; };
-		43DA7DD01D1086610028BE58 /* rescaler_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C861D1086570028BE58 /* rescaler_sse2.c */; };
-		43DA7DD11D1086610028BE58 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C871D1086570028BE58 /* rescaler.c */; };
-		43DA7DD21D1086610028BE58 /* upsampling_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C881D1086570028BE58 /* upsampling_mips_dsp_r2.c */; };
-		43DA7DD31D1086610028BE58 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C891D1086570028BE58 /* upsampling_neon.c */; };
-		43DA7DD41D1086610028BE58 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8A1D1086570028BE58 /* upsampling_sse2.c */; };
-		43DA7DD51D1086610028BE58 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8B1D1086570028BE58 /* upsampling.c */; };
-		43DA7DD61D1086610028BE58 /* yuv_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8C1D1086570028BE58 /* yuv_mips_dsp_r2.c */; };
-		43DA7DD71D1086610028BE58 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8D1D1086570028BE58 /* yuv_mips32.c */; };
-		43DA7DD81D1086610028BE58 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8E1D1086570028BE58 /* yuv_sse2.c */; };
-		43DA7DD91D1086610028BE58 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7C8F1D1086570028BE58 /* yuv.c */; };
-		43DA7DDA1D1086610028BE58 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7C901D1086570028BE58 /* yuv.h */; };
-		43DA7DDC1D1086740028BE58 /* extras.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7DDB1D1086740028BE58 /* extras.h */; };
-		43DA7DDD1D10867A0028BE58 /* extras.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7DDB1D1086740028BE58 /* extras.h */; };
-		43DA7DDE1D10867B0028BE58 /* extras.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7DDB1D1086740028BE58 /* extras.h */; };
-		43DA7DDF1D10867B0028BE58 /* extras.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7DDB1D1086740028BE58 /* extras.h */; };
-		43DA7DE01D10867C0028BE58 /* extras.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7DDB1D1086740028BE58 /* extras.h */; };
-		43DA7DE11D10867D0028BE58 /* extras.h in Headers */ = {isa = PBXBuildFile; fileRef = 43DA7DDB1D1086740028BE58 /* extras.h */; };
-		43DA7DE41D109B160028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE21D109B160028BE58 /* alpha_processing_mips_dsp_r2.c */; };
-		43DA7DE51D109B160028BE58 /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE31D109B160028BE58 /* alpha_processing_sse2.c */; };
-		43DA7DE61D109B980028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE21D109B160028BE58 /* alpha_processing_mips_dsp_r2.c */; };
-		43DA7DE71D109B980028BE58 /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE31D109B160028BE58 /* alpha_processing_sse2.c */; };
-		43DA7DE81D109B990028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE21D109B160028BE58 /* alpha_processing_mips_dsp_r2.c */; };
-		43DA7DE91D109B990028BE58 /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE31D109B160028BE58 /* alpha_processing_sse2.c */; };
-		43DA7DEA1D109B9A0028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE21D109B160028BE58 /* alpha_processing_mips_dsp_r2.c */; };
-		43DA7DEB1D109B9A0028BE58 /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE31D109B160028BE58 /* alpha_processing_sse2.c */; };
-		43DA7DEC1D109B9B0028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE21D109B160028BE58 /* alpha_processing_mips_dsp_r2.c */; };
-		43DA7DED1D109B9B0028BE58 /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE31D109B160028BE58 /* alpha_processing_sse2.c */; };
-		43DA7DEE1D109B9B0028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE21D109B160028BE58 /* alpha_processing_mips_dsp_r2.c */; };
-		43DA7DEF1D109B9B0028BE58 /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 43DA7DE31D109B160028BE58 /* alpha_processing_sse2.c */; };
 		4A2CAE041AB4BB5400B6BC39 /* SDWebImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A2CAE031AB4BB5400B6BC39 /* SDWebImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4A2CAE181AB4BB6400B6BC39 /* SDWebImageCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D88148C56230056699D /* SDWebImageCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4A2CAE191AB4BB6400B6BC39 /* SDWebImageCompat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5340674F167780C40042B59E /* SDWebImageCompat.m */; };
@@ -925,6 +241,10 @@
 		A18A6CC9172DC28500419892 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
 		AB615303192DA24600A2D8E9 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AB615306192DA24600A2D8E9 /* UIView+WebCacheOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = AB615302192DA24600A2D8E9 /* UIView+WebCacheOperation.m */; };
+		AB977BF61EC977BB0007E443 /* liblibwebp-watchOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AB977BF51EC977BB0007E443 /* liblibwebp-watchOS.a */; };
+		AB977BF81EC977C90007E443 /* liblibwebp-OSX.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AB977BF71EC977C90007E443 /* liblibwebp-OSX.a */; };
+		AB977BFA1EC977D10007E443 /* liblibwebp-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AB977BF91EC977D10007E443 /* liblibwebp-tvOS.a */; };
+		AB977BFC1EC977DB0007E443 /* liblibwebp-iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AB977BFB1EC977DB0007E443 /* liblibwebp-iOS.a */; };
 		ABBE71A718C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = ABBE71A518C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		ABBE71A818C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = ABBE71A618C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m */; };
 /* End PBXBuildFile section */
@@ -940,76 +260,8 @@
 		4397D2F51D0DE2DF00BB2784 /* NSImage+WebCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSImage+WebCache.m"; path = "SDWebImage/NSImage+WebCache.m"; sourceTree = "<group>"; };
 		43A918621D8308FE00B3925F /* SDImageCacheConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDImageCacheConfig.h; sourceTree = "<group>"; };
 		43A918631D8308FE00B3925F /* SDImageCacheConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDImageCacheConfig.m; sourceTree = "<group>"; };
-		43C892821D9D62B60022038D /* common_sse2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common_sse2.h; sourceTree = "<group>"; };
-		43C892831D9D62B60022038D /* dec_msa.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_msa.c; sourceTree = "<group>"; };
-		43C892841D9D62B60022038D /* msa_macro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = msa_macro.h; sourceTree = "<group>"; };
-		43C892981D9D6DD70022038D /* anim_decode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = anim_decode.c; sourceTree = "<group>"; };
-		43C892991D9D6DD70022038D /* demux.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = demux.c; sourceTree = "<group>"; };
-		43CE75491CFE9427006C64D0 /* FLAnimatedImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLAnimatedImage.h; sourceTree = "<group>"; };
-		43CE754A1CFE9427006C64D0 /* FLAnimatedImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLAnimatedImage.m; sourceTree = "<group>"; };
-		43CE754B1CFE9427006C64D0 /* FLAnimatedImageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FLAnimatedImageView.h; sourceTree = "<group>"; };
-		43CE754C1CFE9427006C64D0 /* FLAnimatedImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FLAnimatedImageView.m; sourceTree = "<group>"; };
 		43CE75CE1CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FLAnimatedImageView+WebCache.h"; sourceTree = "<group>"; };
 		43CE75CF1CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "FLAnimatedImageView+WebCache.m"; sourceTree = "<group>"; };
-		43DA7C151D1086000028BE58 /* common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.h; sourceTree = "<group>"; };
-		43DA7C5A1D1086570028BE58 /* alpha_processing_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_processing_sse41.c; sourceTree = "<group>"; };
-		43DA7C5B1D1086570028BE58 /* alpha_processing.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_processing.c; sourceTree = "<group>"; };
-		43DA7C5C1D1086570028BE58 /* argb_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = argb_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7C5D1D1086570028BE58 /* argb_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = argb_sse2.c; sourceTree = "<group>"; };
-		43DA7C5E1D1086570028BE58 /* argb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = argb.c; sourceTree = "<group>"; };
-		43DA7C5F1D1086570028BE58 /* cost_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cost_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7C601D1086570028BE58 /* cost_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cost_mips32.c; sourceTree = "<group>"; };
-		43DA7C611D1086570028BE58 /* cost_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cost_sse2.c; sourceTree = "<group>"; };
-		43DA7C621D1086570028BE58 /* cost.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cost.c; sourceTree = "<group>"; };
-		43DA7C631D1086570028BE58 /* cpu.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cpu.c; sourceTree = "<group>"; };
-		43DA7C641D1086570028BE58 /* dec_clip_tables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_clip_tables.c; sourceTree = "<group>"; };
-		43DA7C651D1086570028BE58 /* dec_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7C661D1086570028BE58 /* dec_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_mips32.c; sourceTree = "<group>"; };
-		43DA7C671D1086570028BE58 /* dec_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_neon.c; sourceTree = "<group>"; };
-		43DA7C681D1086570028BE58 /* dec_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_sse2.c; sourceTree = "<group>"; };
-		43DA7C691D1086570028BE58 /* dec_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec_sse41.c; sourceTree = "<group>"; };
-		43DA7C6A1D1086570028BE58 /* dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = dec.c; sourceTree = "<group>"; };
-		43DA7C6B1D1086570028BE58 /* dsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dsp.h; sourceTree = "<group>"; };
-		43DA7C6C1D1086570028BE58 /* enc_avx2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_avx2.c; sourceTree = "<group>"; };
-		43DA7C6D1D1086570028BE58 /* enc_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7C6E1D1086570028BE58 /* enc_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_mips32.c; sourceTree = "<group>"; };
-		43DA7C6F1D1086570028BE58 /* enc_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_neon.c; sourceTree = "<group>"; };
-		43DA7C701D1086570028BE58 /* enc_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_sse2.c; sourceTree = "<group>"; };
-		43DA7C711D1086570028BE58 /* enc_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc_sse41.c; sourceTree = "<group>"; };
-		43DA7C721D1086570028BE58 /* enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = enc.c; sourceTree = "<group>"; };
-		43DA7C731D1086570028BE58 /* filters_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7C741D1086570028BE58 /* filters_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters_sse2.c; sourceTree = "<group>"; };
-		43DA7C751D1086570028BE58 /* filters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters.c; sourceTree = "<group>"; };
-		43DA7C761D1086570028BE58 /* lossless_enc_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7C771D1086570028BE58 /* lossless_enc_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_mips32.c; sourceTree = "<group>"; };
-		43DA7C781D1086570028BE58 /* lossless_enc_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_neon.c; sourceTree = "<group>"; };
-		43DA7C791D1086570028BE58 /* lossless_enc_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_sse2.c; sourceTree = "<group>"; };
-		43DA7C7A1D1086570028BE58 /* lossless_enc_sse41.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc_sse41.c; sourceTree = "<group>"; };
-		43DA7C7B1D1086570028BE58 /* lossless_enc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_enc.c; sourceTree = "<group>"; };
-		43DA7C7C1D1086570028BE58 /* lossless_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7C7D1D1086570028BE58 /* lossless_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_neon.c; sourceTree = "<group>"; };
-		43DA7C7E1D1086570028BE58 /* lossless_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless_sse2.c; sourceTree = "<group>"; };
-		43DA7C7F1D1086570028BE58 /* lossless.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = lossless.c; sourceTree = "<group>"; };
-		43DA7C801D1086570028BE58 /* lossless.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = lossless.h; sourceTree = "<group>"; };
-		43DA7C811D1086570028BE58 /* mips_macro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mips_macro.h; sourceTree = "<group>"; };
-		43DA7C821D1086570028BE58 /* neon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = neon.h; sourceTree = "<group>"; };
-		43DA7C831D1086570028BE58 /* rescaler_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7C841D1086570028BE58 /* rescaler_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler_mips32.c; sourceTree = "<group>"; };
-		43DA7C851D1086570028BE58 /* rescaler_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler_neon.c; sourceTree = "<group>"; };
-		43DA7C861D1086570028BE58 /* rescaler_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler_sse2.c; sourceTree = "<group>"; };
-		43DA7C871D1086570028BE58 /* rescaler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler.c; sourceTree = "<group>"; };
-		43DA7C881D1086570028BE58 /* upsampling_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upsampling_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7C891D1086570028BE58 /* upsampling_neon.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upsampling_neon.c; sourceTree = "<group>"; };
-		43DA7C8A1D1086570028BE58 /* upsampling_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upsampling_sse2.c; sourceTree = "<group>"; };
-		43DA7C8B1D1086570028BE58 /* upsampling.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = upsampling.c; sourceTree = "<group>"; };
-		43DA7C8C1D1086570028BE58 /* yuv_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yuv_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7C8D1D1086570028BE58 /* yuv_mips32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yuv_mips32.c; sourceTree = "<group>"; };
-		43DA7C8E1D1086570028BE58 /* yuv_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yuv_sse2.c; sourceTree = "<group>"; };
-		43DA7C8F1D1086570028BE58 /* yuv.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = yuv.c; sourceTree = "<group>"; };
-		43DA7C901D1086570028BE58 /* yuv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = yuv.h; sourceTree = "<group>"; };
-		43DA7DDB1D1086740028BE58 /* extras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = extras.h; sourceTree = "<group>"; };
-		43DA7DE21D109B160028BE58 /* alpha_processing_mips_dsp_r2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_processing_mips_dsp_r2.c; sourceTree = "<group>"; };
-		43DA7DE31D109B160028BE58 /* alpha_processing_sse2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha_processing_sse2.c; sourceTree = "<group>"; };
 		4A2CADFF1AB4BB5300B6BC39 /* SDWebImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A2CAE021AB4BB5400B6BC39 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4A2CAE031AB4BB5400B6BC39 /* SDWebImage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImage.h; sourceTree = "<group>"; };
@@ -1048,56 +300,22 @@
 		A18A6CC6172DC28500419892 /* UIImage+GIF.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+GIF.m"; sourceTree = "<group>"; };
 		AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+WebCacheOperation.h"; sourceTree = "<group>"; };
 		AB615302192DA24600A2D8E9 /* UIView+WebCacheOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+WebCacheOperation.m"; sourceTree = "<group>"; };
+		AB977BEA1EC961E40007E443 /* Pods-SDWebImage OSX Demo.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage OSX Demo.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage OSX Demo/Pods-SDWebImage OSX Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		AB977BEB1EC961E40007E443 /* Pods-SDWebImage OSX Demo.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage OSX Demo.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage OSX Demo/Pods-SDWebImage OSX Demo.release.xcconfig"; sourceTree = "<group>"; };
+		AB977BEC1EC961E40007E443 /* Pods-SDWebImage TV Demo.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage TV Demo.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage TV Demo/Pods-SDWebImage TV Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		AB977BED1EC961E40007E443 /* Pods-SDWebImage TV Demo.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage TV Demo.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage TV Demo/Pods-SDWebImage TV Demo.release.xcconfig"; sourceTree = "<group>"; };
+		AB977BEE1EC961E40007E443 /* Pods-SDWebImage Watch Demo Extension.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage Watch Demo Extension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage Watch Demo Extension/Pods-SDWebImage Watch Demo Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		AB977BEF1EC961E40007E443 /* Pods-SDWebImage Watch Demo Extension.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage Watch Demo Extension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage Watch Demo Extension/Pods-SDWebImage Watch Demo Extension.release.xcconfig"; sourceTree = "<group>"; };
+		AB977BF01EC961E40007E443 /* Pods-SDWebImage Watch Demo.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage Watch Demo.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage Watch Demo/Pods-SDWebImage Watch Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		AB977BF11EC961E40007E443 /* Pods-SDWebImage Watch Demo.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage Watch Demo.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage Watch Demo/Pods-SDWebImage Watch Demo.release.xcconfig"; sourceTree = "<group>"; };
+		AB977BF21EC961E40007E443 /* Pods-SDWebImage iOS Demo.debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage iOS Demo.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage iOS Demo/Pods-SDWebImage iOS Demo.debug.xcconfig"; sourceTree = "<group>"; };
+		AB977BF31EC961E40007E443 /* Pods-SDWebImage iOS Demo.release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Pods-SDWebImage iOS Demo.release.xcconfig"; path = "../Pods/Target Support Files/Pods-SDWebImage iOS Demo/Pods-SDWebImage iOS Demo.release.xcconfig"; sourceTree = "<group>"; };
+		AB977BF51EC977BB0007E443 /* liblibwebp-watchOS.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "liblibwebp-watchOS.a"; path = "Pods/../build/Debug-watchos/libwebp-watchOS/liblibwebp-watchOS.a"; sourceTree = "<group>"; };
+		AB977BF71EC977C90007E443 /* liblibwebp-OSX.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "liblibwebp-OSX.a"; path = "../../../../../Volumes/”ramdisk”/SDWebImage-gsmrenfknaepxaapzlbubibgwvmw/Build/Products/Debug/libwebp-OSX/liblibwebp-OSX.a"; sourceTree = "<group>"; };
+		AB977BF91EC977D10007E443 /* liblibwebp-tvOS.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "liblibwebp-tvOS.a"; path = "../../../../../Volumes/”ramdisk”/SDWebImage-gsmrenfknaepxaapzlbubibgwvmw/Build/Products/Debug-appletvsimulator/libwebp-tvOS/liblibwebp-tvOS.a"; sourceTree = "<group>"; };
+		AB977BFB1EC977DB0007E443 /* liblibwebp-iOS.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "liblibwebp-iOS.a"; path = "../../../../../Volumes/”ramdisk”/SDWebImage-gsmrenfknaepxaapzlbubibgwvmw/Build/Products/Debug-iphonesimulator/libwebp-iOS/liblibwebp-iOS.a"; sourceTree = "<group>"; };
 		ABBE71A518C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImageView+HighlightedWebCache.h"; path = "SDWebImage/UIImageView+HighlightedWebCache.h"; sourceTree = "<group>"; };
 		ABBE71A618C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+HighlightedWebCache.m"; path = "SDWebImage/UIImageView+HighlightedWebCache.m"; sourceTree = "<group>"; };
-		DA577CA81998E60B007367ED /* bit_reader.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bit_reader.c; sourceTree = "<group>"; };
-		DA577CA91998E60B007367ED /* bit_reader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_reader.h; sourceTree = "<group>"; };
-		DA577CAA1998E60B007367ED /* bit_reader_inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_reader_inl.h; sourceTree = "<group>"; };
-		DA577CAB1998E60B007367ED /* bit_writer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bit_writer.c; sourceTree = "<group>"; };
-		DA577CAC1998E60B007367ED /* bit_writer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_writer.h; sourceTree = "<group>"; };
-		DA577CAD1998E60B007367ED /* color_cache.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = color_cache.c; sourceTree = "<group>"; };
-		DA577CAE1998E60B007367ED /* color_cache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = color_cache.h; sourceTree = "<group>"; };
-		DA577CAF1998E60B007367ED /* endian_inl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = endian_inl.h; sourceTree = "<group>"; };
-		DA577CB01998E60B007367ED /* filters.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = filters.c; sourceTree = "<group>"; };
-		DA577CB11998E60B007367ED /* filters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = filters.h; sourceTree = "<group>"; };
-		DA577CB21998E60B007367ED /* huffman.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = huffman.c; sourceTree = "<group>"; };
-		DA577CB31998E60B007367ED /* huffman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = huffman.h; sourceTree = "<group>"; };
-		DA577CB41998E60B007367ED /* huffman_encode.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = huffman_encode.c; sourceTree = "<group>"; };
-		DA577CB51998E60B007367ED /* huffman_encode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = huffman_encode.h; sourceTree = "<group>"; };
-		DA577CB71998E60B007367ED /* quant_levels.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quant_levels.c; sourceTree = "<group>"; };
-		DA577CB81998E60B007367ED /* quant_levels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quant_levels.h; sourceTree = "<group>"; };
-		DA577CB91998E60B007367ED /* quant_levels_dec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quant_levels_dec.c; sourceTree = "<group>"; };
-		DA577CBA1998E60B007367ED /* quant_levels_dec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = quant_levels_dec.h; sourceTree = "<group>"; };
-		DA577CBB1998E60B007367ED /* random.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = random.c; sourceTree = "<group>"; };
-		DA577CBC1998E60B007367ED /* random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = random.h; sourceTree = "<group>"; };
-		DA577CBD1998E60B007367ED /* rescaler.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rescaler.c; sourceTree = "<group>"; };
-		DA577CBE1998E60B007367ED /* rescaler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rescaler.h; sourceTree = "<group>"; };
-		DA577CBF1998E60B007367ED /* thread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = thread.c; sourceTree = "<group>"; };
-		DA577CC01998E60B007367ED /* thread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread.h; sourceTree = "<group>"; };
-		DA577CC11998E60B007367ED /* utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utils.c; sourceTree = "<group>"; };
-		DA577CC21998E60B007367ED /* utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utils.h; sourceTree = "<group>"; };
-		DA577CC41998E60B007367ED /* decode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decode.h; sourceTree = "<group>"; };
-		DA577CC51998E60B007367ED /* demux.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = demux.h; sourceTree = "<group>"; };
-		DA577CC61998E60B007367ED /* encode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encode.h; sourceTree = "<group>"; };
-		DA577CC71998E60B007367ED /* format_constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = format_constants.h; sourceTree = "<group>"; };
-		DA577CC81998E60B007367ED /* mux.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mux.h; sourceTree = "<group>"; };
-		DA577CC91998E60B007367ED /* mux_types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mux_types.h; sourceTree = "<group>"; };
-		DA577CCA1998E60B007367ED /* types.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = types.h; sourceTree = "<group>"; };
-		DA577D5B1998E6B2007367ED /* alpha.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alpha.c; sourceTree = "<group>"; };
-		DA577D5C1998E6B2007367ED /* alphai.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alphai.h; sourceTree = "<group>"; };
-		DA577D5D1998E6B2007367ED /* buffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = buffer.c; sourceTree = "<group>"; };
-		DA577D5E1998E6B2007367ED /* decode_vp8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decode_vp8.h; sourceTree = "<group>"; };
-		DA577D5F1998E6B2007367ED /* frame.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = frame.c; sourceTree = "<group>"; };
-		DA577D601998E6B2007367ED /* idec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = idec.c; sourceTree = "<group>"; };
-		DA577D611998E6B2007367ED /* io.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = io.c; sourceTree = "<group>"; };
-		DA577D631998E6B2007367ED /* quant.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = quant.c; sourceTree = "<group>"; };
-		DA577D641998E6B2007367ED /* tree.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tree.c; sourceTree = "<group>"; };
-		DA577D651998E6B2007367ED /* vp8.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp8.c; sourceTree = "<group>"; };
-		DA577D661998E6B2007367ED /* vp8i.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8i.h; sourceTree = "<group>"; };
-		DA577D671998E6B2007367ED /* vp8l.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = vp8l.c; sourceTree = "<group>"; };
-		DA577D681998E6B2007367ED /* vp8li.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = vp8li.h; sourceTree = "<group>"; };
-		DA577D691998E6B2007367ED /* webp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = webp.c; sourceTree = "<group>"; };
-		DA577D6A1998E6B2007367ED /* webpi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = webpi.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1105,6 +323,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB977BFA1EC977D10007E443 /* liblibwebp-tvOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1122,6 +341,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB977BF61EC977BB0007E443 /* liblibwebp-watchOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1129,6 +349,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB977BF81EC977C90007E443 /* liblibwebp-OSX.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1136,6 +357,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB977BFC1EC977DB0007E443 /* liblibwebp-iOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1172,35 +394,6 @@
 			path = ..;
 			sourceTree = "<group>";
 		};
-		43C892971D9D6DBB0022038D /* demux */ = {
-			isa = PBXGroup;
-			children = (
-				43C892981D9D6DD70022038D /* anim_decode.c */,
-				43C892991D9D6DD70022038D /* demux.c */,
-			);
-			path = demux;
-			sourceTree = "<group>";
-		};
-		43CE75451CFE9427006C64D0 /* FLAnimatedImage */ = {
-			isa = PBXGroup;
-			children = (
-				43CE75481CFE9427006C64D0 /* FLAnimatedImage */,
-			);
-			name = FLAnimatedImage;
-			path = Vendors/FLAnimatedImage;
-			sourceTree = "<group>";
-		};
-		43CE75481CFE9427006C64D0 /* FLAnimatedImage */ = {
-			isa = PBXGroup;
-			children = (
-				43CE75491CFE9427006C64D0 /* FLAnimatedImage.h */,
-				43CE754A1CFE9427006C64D0 /* FLAnimatedImage.m */,
-				43CE754B1CFE9427006C64D0 /* FLAnimatedImageView.h */,
-				43CE754C1CFE9427006C64D0 /* FLAnimatedImageView.m */,
-			);
-			path = FLAnimatedImage;
-			sourceTree = "<group>";
-		};
 		43CE75CD1CFE98B3006C64D0 /* FLAnimatedImage */ = {
 			isa = PBXGroup;
 			children = (
@@ -1234,6 +427,7 @@
 				4A2CAE001AB4BB5300B6BC39 /* WebImage */,
 				53922D71148C55820056699D /* Frameworks */,
 				53922D70148C55820056699D /* Products */,
+				AB977BF41EC961E40007E443 /* Pods */,
 			);
 			sourceTree = "<group>";
 			usesTabs = 0;
@@ -1254,8 +448,10 @@
 		53922D71148C55820056699D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				43CE75451CFE9427006C64D0 /* FLAnimatedImage */,
-				DA577C121998E60B007367ED /* libwebp */,
+				AB977BFB1EC977DB0007E443 /* liblibwebp-iOS.a */,
+				AB977BF91EC977D10007E443 /* liblibwebp-tvOS.a */,
+				AB977BF71EC977C90007E443 /* liblibwebp-OSX.a */,
+				AB977BF51EC977BB0007E443 /* liblibwebp-watchOS.a */,
 				53FB893F14D35D1A0020B787 /* CoreGraphics.framework */,
 				53922D72148C55820056699D /* Foundation.framework */,
 				53FB894814D35E9E0020B787 /* UIKit.framework */,
@@ -1331,163 +527,22 @@
 			name = Utils;
 			sourceTree = "<group>";
 		};
-		DA577C121998E60B007367ED /* libwebp */ = {
+		AB977BF41EC961E40007E443 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				DA577C4F1998E60B007367ED /* src */,
+				AB977BEA1EC961E40007E443 /* Pods-SDWebImage OSX Demo.debug.xcconfig */,
+				AB977BEB1EC961E40007E443 /* Pods-SDWebImage OSX Demo.release.xcconfig */,
+				AB977BEC1EC961E40007E443 /* Pods-SDWebImage TV Demo.debug.xcconfig */,
+				AB977BED1EC961E40007E443 /* Pods-SDWebImage TV Demo.release.xcconfig */,
+				AB977BEE1EC961E40007E443 /* Pods-SDWebImage Watch Demo Extension.debug.xcconfig */,
+				AB977BEF1EC961E40007E443 /* Pods-SDWebImage Watch Demo Extension.release.xcconfig */,
+				AB977BF01EC961E40007E443 /* Pods-SDWebImage Watch Demo.debug.xcconfig */,
+				AB977BF11EC961E40007E443 /* Pods-SDWebImage Watch Demo.release.xcconfig */,
+				AB977BF21EC961E40007E443 /* Pods-SDWebImage iOS Demo.debug.xcconfig */,
+				AB977BF31EC961E40007E443 /* Pods-SDWebImage iOS Demo.release.xcconfig */,
 			);
-			name = libwebp;
-			path = Vendors/libwebp;
-			sourceTree = "<group>";
-		};
-		DA577C4F1998E60B007367ED /* src */ = {
-			isa = PBXGroup;
-			children = (
-				DA577D5A1998E6B2007367ED /* dec */,
-				43C892971D9D6DBB0022038D /* demux */,
-				DA577C651998E60B007367ED /* dsp */,
-				DA577CA71998E60B007367ED /* utils */,
-				DA577CC31998E60B007367ED /* webp */,
-			);
-			path = src;
-			sourceTree = "<group>";
-		};
-		DA577C651998E60B007367ED /* dsp */ = {
-			isa = PBXGroup;
-			children = (
-				43DA7DE21D109B160028BE58 /* alpha_processing_mips_dsp_r2.c */,
-				43DA7DE31D109B160028BE58 /* alpha_processing_sse2.c */,
-				43DA7C5A1D1086570028BE58 /* alpha_processing_sse41.c */,
-				43DA7C5B1D1086570028BE58 /* alpha_processing.c */,
-				43DA7C5C1D1086570028BE58 /* argb_mips_dsp_r2.c */,
-				43DA7C5D1D1086570028BE58 /* argb_sse2.c */,
-				43DA7C5E1D1086570028BE58 /* argb.c */,
-				43C892821D9D62B60022038D /* common_sse2.h */,
-				43DA7C5F1D1086570028BE58 /* cost_mips_dsp_r2.c */,
-				43DA7C601D1086570028BE58 /* cost_mips32.c */,
-				43DA7C611D1086570028BE58 /* cost_sse2.c */,
-				43DA7C621D1086570028BE58 /* cost.c */,
-				43DA7C631D1086570028BE58 /* cpu.c */,
-				43DA7C641D1086570028BE58 /* dec_clip_tables.c */,
-				43DA7C651D1086570028BE58 /* dec_mips_dsp_r2.c */,
-				43DA7C661D1086570028BE58 /* dec_mips32.c */,
-				43C892831D9D62B60022038D /* dec_msa.c */,
-				43DA7C671D1086570028BE58 /* dec_neon.c */,
-				43DA7C681D1086570028BE58 /* dec_sse2.c */,
-				43DA7C691D1086570028BE58 /* dec_sse41.c */,
-				43DA7C6A1D1086570028BE58 /* dec.c */,
-				43DA7C6B1D1086570028BE58 /* dsp.h */,
-				43DA7C6C1D1086570028BE58 /* enc_avx2.c */,
-				43DA7C6D1D1086570028BE58 /* enc_mips_dsp_r2.c */,
-				43DA7C6E1D1086570028BE58 /* enc_mips32.c */,
-				43DA7C6F1D1086570028BE58 /* enc_neon.c */,
-				43DA7C701D1086570028BE58 /* enc_sse2.c */,
-				43DA7C711D1086570028BE58 /* enc_sse41.c */,
-				43DA7C721D1086570028BE58 /* enc.c */,
-				43DA7C731D1086570028BE58 /* filters_mips_dsp_r2.c */,
-				43DA7C741D1086570028BE58 /* filters_sse2.c */,
-				43DA7C751D1086570028BE58 /* filters.c */,
-				43DA7C761D1086570028BE58 /* lossless_enc_mips_dsp_r2.c */,
-				43DA7C771D1086570028BE58 /* lossless_enc_mips32.c */,
-				43DA7C781D1086570028BE58 /* lossless_enc_neon.c */,
-				43DA7C791D1086570028BE58 /* lossless_enc_sse2.c */,
-				43DA7C7A1D1086570028BE58 /* lossless_enc_sse41.c */,
-				43DA7C7B1D1086570028BE58 /* lossless_enc.c */,
-				43DA7C7C1D1086570028BE58 /* lossless_mips_dsp_r2.c */,
-				43DA7C7D1D1086570028BE58 /* lossless_neon.c */,
-				43DA7C7E1D1086570028BE58 /* lossless_sse2.c */,
-				43DA7C7F1D1086570028BE58 /* lossless.c */,
-				43DA7C801D1086570028BE58 /* lossless.h */,
-				43DA7C811D1086570028BE58 /* mips_macro.h */,
-				43C892841D9D62B60022038D /* msa_macro.h */,
-				43DA7C821D1086570028BE58 /* neon.h */,
-				43DA7C831D1086570028BE58 /* rescaler_mips_dsp_r2.c */,
-				43DA7C841D1086570028BE58 /* rescaler_mips32.c */,
-				43DA7C851D1086570028BE58 /* rescaler_neon.c */,
-				43DA7C861D1086570028BE58 /* rescaler_sse2.c */,
-				43DA7C871D1086570028BE58 /* rescaler.c */,
-				43DA7C881D1086570028BE58 /* upsampling_mips_dsp_r2.c */,
-				43DA7C891D1086570028BE58 /* upsampling_neon.c */,
-				43DA7C8A1D1086570028BE58 /* upsampling_sse2.c */,
-				43DA7C8B1D1086570028BE58 /* upsampling.c */,
-				43DA7C8C1D1086570028BE58 /* yuv_mips_dsp_r2.c */,
-				43DA7C8D1D1086570028BE58 /* yuv_mips32.c */,
-				43DA7C8E1D1086570028BE58 /* yuv_sse2.c */,
-				43DA7C8F1D1086570028BE58 /* yuv.c */,
-				43DA7C901D1086570028BE58 /* yuv.h */,
-			);
-			path = dsp;
-			sourceTree = "<group>";
-		};
-		DA577CA71998E60B007367ED /* utils */ = {
-			isa = PBXGroup;
-			children = (
-				DA577CA81998E60B007367ED /* bit_reader.c */,
-				DA577CA91998E60B007367ED /* bit_reader.h */,
-				DA577CAA1998E60B007367ED /* bit_reader_inl.h */,
-				DA577CAB1998E60B007367ED /* bit_writer.c */,
-				DA577CAC1998E60B007367ED /* bit_writer.h */,
-				DA577CAD1998E60B007367ED /* color_cache.c */,
-				DA577CAE1998E60B007367ED /* color_cache.h */,
-				DA577CAF1998E60B007367ED /* endian_inl.h */,
-				DA577CB01998E60B007367ED /* filters.c */,
-				DA577CB11998E60B007367ED /* filters.h */,
-				DA577CB21998E60B007367ED /* huffman.c */,
-				DA577CB31998E60B007367ED /* huffman.h */,
-				DA577CB41998E60B007367ED /* huffman_encode.c */,
-				DA577CB51998E60B007367ED /* huffman_encode.h */,
-				DA577CB71998E60B007367ED /* quant_levels.c */,
-				DA577CB81998E60B007367ED /* quant_levels.h */,
-				DA577CB91998E60B007367ED /* quant_levels_dec.c */,
-				DA577CBA1998E60B007367ED /* quant_levels_dec.h */,
-				DA577CBB1998E60B007367ED /* random.c */,
-				DA577CBC1998E60B007367ED /* random.h */,
-				DA577CBD1998E60B007367ED /* rescaler.c */,
-				DA577CBE1998E60B007367ED /* rescaler.h */,
-				DA577CBF1998E60B007367ED /* thread.c */,
-				DA577CC01998E60B007367ED /* thread.h */,
-				DA577CC11998E60B007367ED /* utils.c */,
-				DA577CC21998E60B007367ED /* utils.h */,
-			);
-			path = utils;
-			sourceTree = "<group>";
-		};
-		DA577CC31998E60B007367ED /* webp */ = {
-			isa = PBXGroup;
-			children = (
-				DA577CC41998E60B007367ED /* decode.h */,
-				DA577CC51998E60B007367ED /* demux.h */,
-				DA577CC61998E60B007367ED /* encode.h */,
-				43DA7DDB1D1086740028BE58 /* extras.h */,
-				DA577CC71998E60B007367ED /* format_constants.h */,
-				DA577CC81998E60B007367ED /* mux.h */,
-				DA577CC91998E60B007367ED /* mux_types.h */,
-				DA577CCA1998E60B007367ED /* types.h */,
-			);
-			path = webp;
-			sourceTree = "<group>";
-		};
-		DA577D5A1998E6B2007367ED /* dec */ = {
-			isa = PBXGroup;
-			children = (
-				DA577D5B1998E6B2007367ED /* alpha.c */,
-				DA577D5C1998E6B2007367ED /* alphai.h */,
-				DA577D5D1998E6B2007367ED /* buffer.c */,
-				43DA7C151D1086000028BE58 /* common.h */,
-				DA577D5E1998E6B2007367ED /* decode_vp8.h */,
-				DA577D5F1998E6B2007367ED /* frame.c */,
-				DA577D601998E6B2007367ED /* idec.c */,
-				DA577D611998E6B2007367ED /* io.c */,
-				DA577D631998E6B2007367ED /* quant.c */,
-				DA577D641998E6B2007367ED /* tree.c */,
-				DA577D651998E6B2007367ED /* vp8.c */,
-				DA577D661998E6B2007367ED /* vp8i.h */,
-				DA577D671998E6B2007367ED /* vp8l.c */,
-				DA577D681998E6B2007367ED /* vp8li.h */,
-				DA577D691998E6B2007367ED /* webp.c */,
-				DA577D6A1998E6B2007367ED /* webpi.h */,
-			);
-			path = dec;
+			name = Pods;
+			path = Examples;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1497,64 +552,27 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43DA7D5E1D1086600028BE58 /* neon.h in Headers */,
-				4317395A1CDFC8B70008FEB9 /* mux_types.h in Headers */,
-				431739561CDFC8B70008FEB9 /* demux.h in Headers */,
-				4317394D1CDFC8B20008FEB9 /* utils.h in Headers */,
 				4397D2F81D0DF44200BB2784 /* MKAnnotationView+WebCache.h in Headers */,
 				4369C27A1D9807EC007E863A /* UIView+WebCache.h in Headers */,
-				431739451CDFC8B20008FEB9 /* quant_levels_dec.h in Headers */,
-				431739361CDFC8B20008FEB9 /* bit_reader_inl.h in Headers */,
-				4317393A1CDFC8B20008FEB9 /* color_cache.h in Headers */,
-				431738E11CDFC8A40008FEB9 /* webpi.h in Headers */,
 				43A918671D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
-				431739571CDFC8B70008FEB9 /* encode.h in Headers */,
-				431739351CDFC8B20008FEB9 /* bit_reader.h in Headers */,
-				43DA7D5D1D1086600028BE58 /* mips_macro.h in Headers */,
 				00733A6F1BC4880E00A5A117 /* UIImage+WebP.h in Headers */,
-				43DA7D471D1086600028BE58 /* dsp.h in Headers */,
-				431739431CDFC8B20008FEB9 /* quant_levels.h in Headers */,
 				00733A681BC4880E00A5A117 /* SDWebImageManager.h in Headers */,
-				431739591CDFC8B70008FEB9 /* mux.h in Headers */,
-				4317393F1CDFC8B20008FEB9 /* huffman.h in Headers */,
 				00733A6C1BC4880E00A5A117 /* UIButton+WebCache.h in Headers */,
-				43C892941D9D62D40022038D /* msa_macro.h in Headers */,
-				431738DF1CDFC8A40008FEB9 /* vp8li.h in Headers */,
-				4317395B1CDFC8B70008FEB9 /* types.h in Headers */,
 				43CE75D21CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h in Headers */,
-				431739551CDFC8B70008FEB9 /* decode.h in Headers */,
 				00733A731BC4880E00A5A117 /* SDWebImage.h in Headers */,
-				43C8928A1D9D62C60022038D /* common_sse2.h in Headers */,
 				00733A701BC4880E00A5A117 /* UIImageView+HighlightedWebCache.h in Headers */,
 				00733A671BC4880E00A5A117 /* SDImageCache.h in Headers */,
-				431739411CDFC8B20008FEB9 /* huffman_encode.h in Headers */,
 				00733A711BC4880E00A5A117 /* UIImageView+WebCache.h in Headers */,
 				00733A631BC4880E00A5A117 /* SDWebImageCompat.h in Headers */,
-				431739381CDFC8B20008FEB9 /* bit_writer.h in Headers */,
 				00733A661BC4880E00A5A117 /* SDWebImageDownloaderOperation.h in Headers */,
-				4317394B1CDFC8B20008FEB9 /* thread.h in Headers */,
-				43DA7C191D1086120028BE58 /* common.h in Headers */,
 				00733A721BC4880E00A5A117 /* UIView+WebCacheOperation.h in Headers */,
-				43DA7D6C1D1086600028BE58 /* yuv.h in Headers */,
-				43DA7D5C1D1086600028BE58 /* lossless.h in Headers */,
-				4317393B1CDFC8B20008FEB9 /* endian_inl.h in Headers */,
 				00733A6B1BC4880E00A5A117 /* NSData+ImageContentType.h in Headers */,
 				00733A6A1BC4880E00A5A117 /* SDWebImagePrefetcher.h in Headers */,
-				43DA7DDF1D10867B0028BE58 /* extras.h in Headers */,
 				00733A641BC4880E00A5A117 /* SDWebImageOperation.h in Headers */,
-				431738D41CDFC8A40008FEB9 /* alphai.h in Headers */,
-				431739581CDFC8B70008FEB9 /* format_constants.h in Headers */,
-				431739491CDFC8B20008FEB9 /* rescaler.h in Headers */,
-				43CE75781CFE9427006C64D0 /* FLAnimatedImage.h in Headers */,
 				00733A6E1BC4880E00A5A117 /* UIImage+MultiFormat.h in Headers */,
-				43CE757E1CFE9427006C64D0 /* FLAnimatedImageView.h in Headers */,
-				431738DD1CDFC8A40008FEB9 /* vp8i.h in Headers */,
 				00733A6D1BC4880E00A5A117 /* UIImage+GIF.h in Headers */,
 				00733A651BC4880E00A5A117 /* SDWebImageDownloader.h in Headers */,
-				4317393D1CDFC8B20008FEB9 /* filters.h in Headers */,
 				00733A691BC4880E00A5A117 /* SDWebImageDecoder.h in Headers */,
-				431738D61CDFC8A40008FEB9 /* decode_vp8.h in Headers */,
-				431739471CDFC8B20008FEB9 /* random.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1562,59 +580,24 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4314D1621D0E0E3B004B36C9 /* mux_types.h in Headers */,
-				4314D1631D0E0E3B004B36C9 /* demux.h in Headers */,
-				43DA7DDD1D10867A0028BE58 /* extras.h in Headers */,
-				4314D1651D0E0E3B004B36C9 /* utils.h in Headers */,
-				4314D1661D0E0E3B004B36C9 /* quant_levels_dec.h in Headers */,
-				4314D1671D0E0E3B004B36C9 /* bit_reader_inl.h in Headers */,
-				4314D1691D0E0E3B004B36C9 /* color_cache.h in Headers */,
-				4314D16A1D0E0E3B004B36C9 /* webpi.h in Headers */,
-				4314D16B1D0E0E3B004B36C9 /* encode.h in Headers */,
-				4314D16C1D0E0E3B004B36C9 /* bit_reader.h in Headers */,
 				4314D16D1D0E0E3B004B36C9 /* SDImageCache.h in Headers */,
-				4314D16E1D0E0E3B004B36C9 /* quant_levels.h in Headers */,
 				4314D16F1D0E0E3B004B36C9 /* NSData+ImageContentType.h in Headers */,
-				43DA7CEE1D10865E0028BE58 /* lossless.h in Headers */,
-				4314D1701D0E0E3B004B36C9 /* mux.h in Headers */,
-				43DA7CEF1D10865E0028BE58 /* mips_macro.h in Headers */,
-				43DA7CFE1D10865E0028BE58 /* yuv.h in Headers */,
-				4314D1711D0E0E3B004B36C9 /* huffman.h in Headers */,
 				4314D1721D0E0E3B004B36C9 /* SDWebImageCompat.h in Headers */,
 				43A918651D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
-				4314D1731D0E0E3B004B36C9 /* vp8li.h in Headers */,
-				4314D1741D0E0E3B004B36C9 /* types.h in Headers */,
-				4314D1761D0E0E3B004B36C9 /* decode.h in Headers */,
 				4314D1771D0E0E3B004B36C9 /* SDWebImageDecoder.h in Headers */,
 				4314D1781D0E0E3B004B36C9 /* SDWebImageDownloader.h in Headers */,
 				4314D1791D0E0E3B004B36C9 /* SDWebImageManager.h in Headers */,
-				4314D17B1D0E0E3B004B36C9 /* huffman_encode.h in Headers */,
-				43DA7CD91D10865E0028BE58 /* dsp.h in Headers */,
 				4314D17C1D0E0E3B004B36C9 /* UIImage+WebP.h in Headers */,
 				4369C2781D9807EC007E863A /* UIView+WebCache.h in Headers */,
 				4314D17D1D0E0E3B004B36C9 /* SDWebImagePrefetcher.h in Headers */,
-				4314D17E1D0E0E3B004B36C9 /* bit_writer.h in Headers */,
-				43DA7CF01D10865E0028BE58 /* neon.h in Headers */,
 				4314D17F1D0E0E3B004B36C9 /* UIButton+WebCache.h in Headers */,
-				43DA7C171D1086100028BE58 /* common.h in Headers */,
-				4314D1801D0E0E3B004B36C9 /* thread.h in Headers */,
 				4314D1811D0E0E3B004B36C9 /* UIImageView+WebCache.h in Headers */,
-				4314D1821D0E0E3B004B36C9 /* endian_inl.h in Headers */,
 				4314D1841D0E0E3B004B36C9 /* SDWebImageOperation.h in Headers */,
 				4314D1851D0E0E3B004B36C9 /* SDWebImageDownloaderOperation.h in Headers */,
 				4314D1861D0E0E3B004B36C9 /* UIImageView+HighlightedWebCache.h in Headers */,
-				4314D1871D0E0E3B004B36C9 /* alphai.h in Headers */,
-				4314D1881D0E0E3B004B36C9 /* format_constants.h in Headers */,
-				4314D1891D0E0E3B004B36C9 /* rescaler.h in Headers */,
-				4314D18E1D0E0E3B004B36C9 /* vp8i.h in Headers */,
 				4314D18F1D0E0E3B004B36C9 /* UIView+WebCacheOperation.h in Headers */,
 				4314D1901D0E0E3B004B36C9 /* UIImage+GIF.h in Headers */,
-				43C892921D9D62D30022038D /* msa_macro.h in Headers */,
-				4314D1911D0E0E3B004B36C9 /* filters.h in Headers */,
-				43C892881D9D62C50022038D /* common_sse2.h in Headers */,
 				4314D1921D0E0E3B004B36C9 /* UIImage+MultiFormat.h in Headers */,
-				4314D1931D0E0E3B004B36C9 /* decode_vp8.h in Headers */,
-				4314D1941D0E0E3B004B36C9 /* random.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1623,59 +606,24 @@
 			buildActionMask = 2147483647;
 			files = (
 				431BB6D71D06D2C1006A3455 /* UIImage+WebP.h in Headers */,
-				43A62A291D0E0A860089D7DD /* endian_inl.h in Headers */,
 				431BB6D91D06D2C1006A3455 /* SDWebImageManager.h in Headers */,
-				43A62A1B1D0E0A800089D7DD /* decode.h in Headers */,
 				431BB6DC1D06D2C1006A3455 /* UIButton+WebCache.h in Headers */,
-				43A62A371D0E0A860089D7DD /* rescaler.h in Headers */,
 				431BB6E11D06D2C1006A3455 /* SDWebImage.h in Headers */,
-				43DA7DE01D10867C0028BE58 /* extras.h in Headers */,
-				43DA7C1A1D1086120028BE58 /* common.h in Headers */,
-				43A62A2B1D0E0A860089D7DD /* filters.h in Headers */,
-				43A62A281D0E0A860089D7DD /* color_cache.h in Headers */,
-				43A62A641D0E0A8F0089D7DD /* vp8li.h in Headers */,
 				431BB6E21D06D2C1006A3455 /* UIImageView+HighlightedWebCache.h in Headers */,
-				43DA7D951D1086600028BE58 /* neon.h in Headers */,
-				43DA7D7E1D1086600028BE58 /* dsp.h in Headers */,
-				43A62A3B1D0E0A860089D7DD /* utils.h in Headers */,
-				43A62A231D0E0A860089D7DD /* bit_reader.h in Headers */,
-				43C8928B1D9D62C70022038D /* common_sse2.h in Headers */,
-				43A62A2D1D0E0A860089D7DD /* huffman.h in Headers */,
-				43A62A1C1D0E0A800089D7DD /* demux.h in Headers */,
-				43A62A331D0E0A860089D7DD /* quant_levels_dec.h in Headers */,
-				43A62A591D0E0A8F0089D7DD /* alphai.h in Headers */,
 				431BB6E31D06D2C1006A3455 /* SDImageCache.h in Headers */,
-				43A62A1D1D0E0A800089D7DD /* encode.h in Headers */,
 				431BB6E61D06D2C1006A3455 /* UIImageView+WebCache.h in Headers */,
 				431BB6E71D06D2C1006A3455 /* SDWebImageCompat.h in Headers */,
-				43A62A621D0E0A8F0089D7DD /* vp8i.h in Headers */,
-				43A62A261D0E0A860089D7DD /* bit_writer.h in Headers */,
-				43A62A1F1D0E0A800089D7DD /* mux.h in Headers */,
 				431BB6E91D06D2C1006A3455 /* SDWebImageDownloaderOperation.h in Headers */,
 				431BB6EB1D06D2C1006A3455 /* UIView+WebCacheOperation.h in Headers */,
-				43DA7D931D1086600028BE58 /* lossless.h in Headers */,
 				431BB6EE1D06D2C1006A3455 /* NSData+ImageContentType.h in Headers */,
 				431BB6EF1D06D2C1006A3455 /* SDWebImagePrefetcher.h in Headers */,
 				4369C27B1D9807EC007E863A /* UIView+WebCache.h in Headers */,
 				431BB6F01D06D2C1006A3455 /* SDWebImageOperation.h in Headers */,
-				43A62A201D0E0A800089D7DD /* mux_types.h in Headers */,
-				43A62A2F1D0E0A860089D7DD /* huffman_encode.h in Headers */,
-				43A62A241D0E0A860089D7DD /* bit_reader_inl.h in Headers */,
-				43A62A211D0E0A800089D7DD /* types.h in Headers */,
-				43A62A661D0E0A8F0089D7DD /* webpi.h in Headers */,
-				43A62A351D0E0A860089D7DD /* random.h in Headers */,
-				43DA7D941D1086600028BE58 /* mips_macro.h in Headers */,
-				43A62A1E1D0E0A800089D7DD /* format_constants.h in Headers */,
-				43A62A311D0E0A860089D7DD /* quant_levels.h in Headers */,
-				43A62A5B1D0E0A8F0089D7DD /* decode_vp8.h in Headers */,
-				43A62A391D0E0A860089D7DD /* thread.h in Headers */,
-				43DA7DA31D1086600028BE58 /* yuv.h in Headers */,
 				431BB6F61D06D2C1006A3455 /* UIImage+MultiFormat.h in Headers */,
 				431BB6F91D06D2C1006A3455 /* UIImage+GIF.h in Headers */,
 				431BB6FA1D06D2C1006A3455 /* SDWebImageDownloader.h in Headers */,
 				431BB6FC1D06D2C1006A3455 /* SDWebImageDecoder.h in Headers */,
 				43A918681D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
-				43C892951D9D62D40022038D /* msa_macro.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1683,62 +631,27 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43DA7DCC1D1086610028BE58 /* neon.h in Headers */,
-				4397D2BA1D0DDD8C00BB2784 /* demux.h in Headers */,
-				4397D2BB1D0DDD8C00BB2784 /* endian_inl.h in Headers */,
-				4397D2BD1D0DDD8C00BB2784 /* types.h in Headers */,
-				4397D2BF1D0DDD8C00BB2784 /* alphai.h in Headers */,
 				4397D2C01D0DDD8C00BB2784 /* SDWebImage.h in Headers */,
-				4397D2C11D0DDD8C00BB2784 /* format_constants.h in Headers */,
-				4397D2C21D0DDD8C00BB2784 /* filters.h in Headers */,
 				4397D2C31D0DDD8C00BB2784 /* SDWebImageManager.h in Headers */,
 				4397D2C41D0DDD8C00BB2784 /* SDImageCache.h in Headers */,
 				4397D2C51D0DDD8C00BB2784 /* UIImageView+WebCache.h in Headers */,
 				4369C27C1D9807EC007E863A /* UIView+WebCache.h in Headers */,
-				4397D2C61D0DDD8C00BB2784 /* random.h in Headers */,
-				4397D2C71D0DDD8C00BB2784 /* rescaler.h in Headers */,
-				43DA7DE11D10867D0028BE58 /* extras.h in Headers */,
 				4397D2C81D0DDD8C00BB2784 /* SDWebImageCompat.h in Headers */,
-				4397D2C91D0DDD8C00BB2784 /* bit_reader.h in Headers */,
 				4397D2CB1D0DDD8C00BB2784 /* UIImageView+HighlightedWebCache.h in Headers */,
-				4397D2CC1D0DDD8C00BB2784 /* mux.h in Headers */,
-				43C892961D9D62D40022038D /* msa_macro.h in Headers */,
-				4397D2CE1D0DDD8C00BB2784 /* huffman_encode.h in Headers */,
 				4397D2D01D0DDD8C00BB2784 /* SDWebImageDownloaderOperation.h in Headers */,
-				43DA7C1B1D1086130028BE58 /* common.h in Headers */,
-				4397D2D11D0DDD8C00BB2784 /* decode.h in Headers */,
-				4397D2D21D0DDD8C00BB2784 /* webpi.h in Headers */,
-				43DA7DCB1D1086610028BE58 /* mips_macro.h in Headers */,
 				43A918691D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
-				4397D2D31D0DDD8C00BB2784 /* thread.h in Headers */,
-				4397D2D41D0DDD8C00BB2784 /* quant_levels.h in Headers */,
-				4397D2D51D0DDD8C00BB2784 /* bit_reader_inl.h in Headers */,
-				43DA7DCA1D1086610028BE58 /* lossless.h in Headers */,
-				4397D2D61D0DDD8C00BB2784 /* quant_levels_dec.h in Headers */,
 				4397D2D81D0DDD8C00BB2784 /* UIButton+WebCache.h in Headers */,
 				4397D2D91D0DDD8C00BB2784 /* SDWebImagePrefetcher.h in Headers */,
 				4397D2DA1D0DDD8C00BB2784 /* UIView+WebCacheOperation.h in Headers */,
 				4397D2DB1D0DDD8C00BB2784 /* UIImage+MultiFormat.h in Headers */,
-				43DA7DB51D1086610028BE58 /* dsp.h in Headers */,
-				43DA7DDA1D1086610028BE58 /* yuv.h in Headers */,
 				4397D2DC1D0DDD8C00BB2784 /* SDWebImageOperation.h in Headers */,
-				4397D2DD1D0DDD8C00BB2784 /* vp8i.h in Headers */,
 				4397D2F61D0DE2DF00BB2784 /* NSImage+WebCache.h in Headers */,
-				4397D2DE1D0DDD8C00BB2784 /* vp8li.h in Headers */,
-				4397D2DF1D0DDD8C00BB2784 /* color_cache.h in Headers */,
-				4397D2E01D0DDD8C00BB2784 /* utils.h in Headers */,
 				4397D2E11D0DDD8C00BB2784 /* SDWebImageDownloader.h in Headers */,
-				4397D2E21D0DDD8C00BB2784 /* huffman.h in Headers */,
 				4397D2E31D0DDD8C00BB2784 /* MKAnnotationView+WebCache.h in Headers */,
-				4397D2E51D0DDD8C00BB2784 /* bit_writer.h in Headers */,
-				4397D2E61D0DDD8C00BB2784 /* encode.h in Headers */,
 				4397D2E81D0DDD8C00BB2784 /* SDWebImageDecoder.h in Headers */,
 				4397D2E91D0DDD8C00BB2784 /* UIImage+WebP.h in Headers */,
 				4397D2EA1D0DDD8C00BB2784 /* UIImage+GIF.h in Headers */,
 				4397D2EB1D0DDD8C00BB2784 /* NSData+ImageContentType.h in Headers */,
-				4397D2EC1D0DDD8C00BB2784 /* decode_vp8.h in Headers */,
-				4397D2ED1D0DDD8C00BB2784 /* mux_types.h in Headers */,
-				43C8928C1D9D62C70022038D /* common_sse2.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1746,64 +659,27 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43DA7D271D10865F0028BE58 /* neon.h in Headers */,
-				4317394F1CDFC8B70008FEB9 /* demux.h in Headers */,
-				431739211CDFC8B20008FEB9 /* endian_inl.h in Headers */,
-				43CE757D1CFE9427006C64D0 /* FLAnimatedImageView.h in Headers */,
-				431739541CDFC8B70008FEB9 /* types.h in Headers */,
 				4369C2791D9807EC007E863A /* UIView+WebCache.h in Headers */,
-				431738C51CDFC8A30008FEB9 /* alphai.h in Headers */,
 				4A2CAE041AB4BB5400B6BC39 /* SDWebImage.h in Headers */,
-				431739511CDFC8B70008FEB9 /* format_constants.h in Headers */,
-				431739231CDFC8B20008FEB9 /* filters.h in Headers */,
 				43A918661D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
 				4A2CAE211AB4BB7000B6BC39 /* SDWebImageManager.h in Headers */,
 				4A2CAE1F1AB4BB6C00B6BC39 /* SDImageCache.h in Headers */,
-				43DA7D261D10865F0028BE58 /* mips_macro.h in Headers */,
 				4A2CAE351AB4BB7500B6BC39 /* UIImageView+WebCache.h in Headers */,
-				43DA7D101D10865F0028BE58 /* dsp.h in Headers */,
-				4317392D1CDFC8B20008FEB9 /* random.h in Headers */,
-				4317392F1CDFC8B20008FEB9 /* rescaler.h in Headers */,
 				4A2CAE181AB4BB6400B6BC39 /* SDWebImageCompat.h in Headers */,
-				4317391B1CDFC8B20008FEB9 /* bit_reader.h in Headers */,
 				43CE75D11CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h in Headers */,
-				43C892931D9D62D40022038D /* msa_macro.h in Headers */,
 				4A2CAE331AB4BB7500B6BC39 /* UIImageView+HighlightedWebCache.h in Headers */,
-				431739521CDFC8B70008FEB9 /* mux.h in Headers */,
-				431739271CDFC8B20008FEB9 /* huffman_encode.h in Headers */,
 				4A2CAE1D1AB4BB6800B6BC39 /* SDWebImageDownloaderOperation.h in Headers */,
-				4317394E1CDFC8B70008FEB9 /* decode.h in Headers */,
-				43C892891D9D62C60022038D /* common_sse2.h in Headers */,
-				431738D21CDFC8A30008FEB9 /* webpi.h in Headers */,
-				431739311CDFC8B20008FEB9 /* thread.h in Headers */,
-				431739291CDFC8B20008FEB9 /* quant_levels.h in Headers */,
-				4317391C1CDFC8B20008FEB9 /* bit_reader_inl.h in Headers */,
-				4317392B1CDFC8B20008FEB9 /* quant_levels_dec.h in Headers */,
-				43CE75771CFE9427006C64D0 /* FLAnimatedImage.h in Headers */,
 				4A2CAE2B1AB4BB7500B6BC39 /* UIButton+WebCache.h in Headers */,
-				43DA7C181D1086110028BE58 /* common.h in Headers */,
 				4A2CAE251AB4BB7000B6BC39 /* SDWebImagePrefetcher.h in Headers */,
 				4A2CAE371AB4BB7500B6BC39 /* UIView+WebCacheOperation.h in Headers */,
-				43DA7D351D10865F0028BE58 /* yuv.h in Headers */,
-				43DA7D251D10865F0028BE58 /* lossless.h in Headers */,
 				4A2CAE2F1AB4BB7500B6BC39 /* UIImage+MultiFormat.h in Headers */,
 				4A2CAE1A1AB4BB6400B6BC39 /* SDWebImageOperation.h in Headers */,
-				431738CE1CDFC8A30008FEB9 /* vp8i.h in Headers */,
-				43DA7DDE1D10867B0028BE58 /* extras.h in Headers */,
-				431738D01CDFC8A30008FEB9 /* vp8li.h in Headers */,
-				431739201CDFC8B20008FEB9 /* color_cache.h in Headers */,
-				431739331CDFC8B20008FEB9 /* utils.h in Headers */,
 				4A2CAE1B1AB4BB6800B6BC39 /* SDWebImageDownloader.h in Headers */,
-				431739251CDFC8B20008FEB9 /* huffman.h in Headers */,
 				4A2CAE271AB4BB7500B6BC39 /* MKAnnotationView+WebCache.h in Headers */,
-				4317391E1CDFC8B20008FEB9 /* bit_writer.h in Headers */,
-				431739501CDFC8B70008FEB9 /* encode.h in Headers */,
 				4A2CAE231AB4BB7000B6BC39 /* SDWebImageDecoder.h in Headers */,
 				4A2CAE311AB4BB7500B6BC39 /* UIImage+WebP.h in Headers */,
 				4A2CAE2D1AB4BB7500B6BC39 /* UIImage+GIF.h in Headers */,
 				4A2CAE291AB4BB7500B6BC39 /* NSData+ImageContentType.h in Headers */,
-				431738C71CDFC8A30008FEB9 /* decode_vp8.h in Headers */,
-				431739531CDFC8B70008FEB9 /* mux_types.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1811,62 +687,25 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43C892851D9D62B60022038D /* common_sse2.h in Headers */,
-				431738C21CDFC2660008FEB9 /* mux_types.h in Headers */,
-				431738BE1CDFC2660008FEB9 /* demux.h in Headers */,
-				431738BC1CDFC2630008FEB9 /* utils.h in Headers */,
-				43DA7CB91D1086570028BE58 /* neon.h in Headers */,
-				431738B41CDFC2630008FEB9 /* quant_levels_dec.h in Headers */,
-				431738A51CDFC2630008FEB9 /* bit_reader_inl.h in Headers */,
-				431738A91CDFC2630008FEB9 /* color_cache.h in Headers */,
-				431738861CDFC2580008FEB9 /* webpi.h in Headers */,
-				431738BF1CDFC2660008FEB9 /* encode.h in Headers */,
-				431738A41CDFC2630008FEB9 /* bit_reader.h in Headers */,
 				53761316155AD0D5005750A4 /* SDImageCache.h in Headers */,
-				43DA7CB81D1086570028BE58 /* mips_macro.h in Headers */,
-				431738B21CDFC2630008FEB9 /* quant_levels.h in Headers */,
 				5D5B9142188EE8DD006D06BD /* NSData+ImageContentType.h in Headers */,
-				431738C11CDFC2660008FEB9 /* mux.h in Headers */,
-				431738AE1CDFC2630008FEB9 /* huffman.h in Headers */,
 				53761318155AD0D5005750A4 /* SDWebImageCompat.h in Headers */,
-				431738841CDFC2580008FEB9 /* vp8li.h in Headers */,
-				431738C31CDFC2660008FEB9 /* types.h in Headers */,
-				43DA7CC71D1086570028BE58 /* yuv.h in Headers */,
 				43CE75D01CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h in Headers */,
-				43DA7CB71D1086570028BE58 /* lossless.h in Headers */,
-				43DA7CA21D1086570028BE58 /* dsp.h in Headers */,
-				431738BD1CDFC2660008FEB9 /* decode.h in Headers */,
 				53761319155AD0D5005750A4 /* SDWebImageDecoder.h in Headers */,
 				5376131A155AD0D5005750A4 /* SDWebImageDownloader.h in Headers */,
 				4369C2771D9807EC007E863A /* UIView+WebCache.h in Headers */,
 				5376131C155AD0D5005750A4 /* SDWebImageManager.h in Headers */,
-				431738B01CDFC2630008FEB9 /* huffman_encode.h in Headers */,
 				438096741CDFC09C00DC626B /* UIImage+WebP.h in Headers */,
 				5376131E155AD0D5005750A4 /* SDWebImagePrefetcher.h in Headers */,
-				431738A71CDFC2630008FEB9 /* bit_writer.h in Headers */,
 				5376131F155AD0D5005750A4 /* UIButton+WebCache.h in Headers */,
-				431738BA1CDFC2630008FEB9 /* thread.h in Headers */,
 				53761320155AD0D5005750A4 /* UIImageView+WebCache.h in Headers */,
-				431738AA1CDFC2630008FEB9 /* endian_inl.h in Headers */,
 				530E49E816464C25002868E7 /* SDWebImageOperation.h in Headers */,
-				43C892871D9D62B60022038D /* msa_macro.h in Headers */,
 				530E49EA16464C7C002868E7 /* SDWebImageDownloaderOperation.h in Headers */,
 				ABBE71A718C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h in Headers */,
-				431738791CDFC2580008FEB9 /* alphai.h in Headers */,
-				43DA7C161D1086000028BE58 /* common.h in Headers */,
-				431738C01CDFC2660008FEB9 /* format_constants.h in Headers */,
-				431738B81CDFC2630008FEB9 /* rescaler.h in Headers */,
-				43CE75761CFE9427006C64D0 /* FLAnimatedImage.h in Headers */,
 				438096721CDFC08200DC626B /* MKAnnotationView+WebCache.h in Headers */,
-				43CE757C1CFE9427006C64D0 /* FLAnimatedImageView.h in Headers */,
-				431738821CDFC2580008FEB9 /* vp8i.h in Headers */,
 				AB615303192DA24600A2D8E9 /* UIView+WebCacheOperation.h in Headers */,
-				43DA7DDC1D1086740028BE58 /* extras.h in Headers */,
 				A18A6CC7172DC28500419892 /* UIImage+GIF.h in Headers */,
-				431738AC1CDFC2630008FEB9 /* filters.h in Headers */,
 				53EDFB8A17623F7C00698166 /* UIImage+MultiFormat.h in Headers */,
-				4317387B1CDFC2580008FEB9 /* decode_vp8.h in Headers */,
-				431738B61CDFC2630008FEB9 /* random.h in Headers */,
 				43A918641D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2088,104 +927,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43DA7D661D1086600028BE58 /* upsampling_sse2.c in Sources */,
-				431739341CDFC8B20008FEB9 /* bit_reader.c in Sources */,
 				00733A561BC4880000A5A117 /* SDWebImageDownloaderOperation.m in Sources */,
-				431739391CDFC8B20008FEB9 /* color_cache.c in Sources */,
-				43DA7D521D1086600028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */,
-				43DA7D6A1D1086600028BE58 /* yuv_sse2.c in Sources */,
-				43DA7D441D1086600028BE58 /* dec_sse2.c in Sources */,
-				43DA7D461D1086600028BE58 /* dec.c in Sources */,
 				00733A5A1BC4880000A5A117 /* SDWebImagePrefetcher.m in Sources */,
 				43CE75D51CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m in Sources */,
-				43DA7D4C1D1086600028BE58 /* enc_sse2.c in Sources */,
 				00733A5B1BC4880000A5A117 /* NSData+ImageContentType.m in Sources */,
-				43DA7D5A1D1086600028BE58 /* lossless_sse2.c in Sources */,
-				43DA7D451D1086600028BE58 /* dec_sse41.c in Sources */,
-				43C8929E1D9D6DDA0022038D /* anim_decode.c in Sources */,
-				431738D71CDFC8A40008FEB9 /* frame.c in Sources */,
-				43DA7D561D1086600028BE58 /* lossless_enc_sse41.c in Sources */,
-				43DA7D4A1D1086600028BE58 /* enc_mips32.c in Sources */,
-				43DA7D581D1086600028BE58 /* lossless_mips_dsp_r2.c in Sources */,
-				43DA7D551D1086600028BE58 /* lossless_enc_sse2.c in Sources */,
-				43DA7D621D1086600028BE58 /* rescaler_sse2.c in Sources */,
-				43DA7D401D1086600028BE58 /* dec_clip_tables.c in Sources */,
 				00733A551BC4880000A5A117 /* SDWebImageDownloader.m in Sources */,
-				431738E01CDFC8A40008FEB9 /* webp.c in Sources */,
-				43DA7D3F1D1086600028BE58 /* cpu.c in Sources */,
-				431739481CDFC8B20008FEB9 /* rescaler.c in Sources */,
-				43DA7D3E1D1086600028BE58 /* cost.c in Sources */,
-				431738D91CDFC8A40008FEB9 /* io.c in Sources */,
-				43DA7D591D1086600028BE58 /* lossless_neon.c in Sources */,
-				43DA7D411D1086600028BE58 /* dec_mips_dsp_r2.c in Sources */,
-				431738D51CDFC8A40008FEB9 /* buffer.c in Sources */,
-				43DA7D4B1D1086600028BE58 /* enc_neon.c in Sources */,
-				431739371CDFC8B20008FEB9 /* bit_writer.c in Sources */,
-				43C892A31D9D6DDD0022038D /* demux.c in Sources */,
-				43DA7D511D1086600028BE58 /* filters.c in Sources */,
 				00733A611BC4880000A5A117 /* UIImageView+WebCache.m in Sources */,
-				43DA7D491D1086600028BE58 /* enc_mips_dsp_r2.c in Sources */,
-				43DA7D601D1086600028BE58 /* rescaler_mips32.c in Sources */,
-				431738D81CDFC8A40008FEB9 /* idec.c in Sources */,
-				431738DE1CDFC8A40008FEB9 /* vp8l.c in Sources */,
-				43DA7D611D1086600028BE58 /* rescaler_neon.c in Sources */,
-				43DA7D361D1086600028BE58 /* alpha_processing_sse41.c in Sources */,
-				43DA7D641D1086600028BE58 /* upsampling_mips_dsp_r2.c in Sources */,
-				431739461CDFC8B20008FEB9 /* random.c in Sources */,
 				43A9186E1D8308FE00B3925F /* SDImageCacheConfig.m in Sources */,
-				43DA7D3D1D1086600028BE58 /* cost_sse2.c in Sources */,
-				431738DB1CDFC8A40008FEB9 /* tree.c in Sources */,
 				00733A581BC4880000A5A117 /* SDWebImageManager.m in Sources */,
 				4397D2F91D0DF44A00BB2784 /* MKAnnotationView+WebCache.m in Sources */,
-				43DA7D541D1086600028BE58 /* lossless_enc_neon.c in Sources */,
-				43DA7D4D1D1086600028BE58 /* enc_sse41.c in Sources */,
-				43DA7D3B1D1086600028BE58 /* cost_mips_dsp_r2.c in Sources */,
 				00733A541BC4880000A5A117 /* SDWebImageCompat.m in Sources */,
-				4317393E1CDFC8B20008FEB9 /* huffman.c in Sources */,
-				43DA7D3A1D1086600028BE58 /* argb.c in Sources */,
-				43DA7D671D1086600028BE58 /* upsampling.c in Sources */,
-				43DA7D421D1086600028BE58 /* dec_mips32.c in Sources */,
-				43DA7D5B1D1086600028BE58 /* lossless.c in Sources */,
 				00733A621BC4880000A5A117 /* UIView+WebCacheOperation.m in Sources */,
-				4317393C1CDFC8B20008FEB9 /* filters.c in Sources */,
-				43DA7D391D1086600028BE58 /* argb_sse2.c in Sources */,
-				43DA7DEA1D109B9A0028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */,
-				43DA7D631D1086600028BE58 /* rescaler.c in Sources */,
-				43DA7D481D1086600028BE58 /* enc_avx2.c in Sources */,
-				43DA7D571D1086600028BE58 /* lossless_enc.c in Sources */,
-				431738DA1CDFC8A40008FEB9 /* quant.c in Sources */,
 				00733A591BC4880000A5A117 /* SDWebImageDecoder.m in Sources */,
-				43CE75811CFE9427006C64D0 /* FLAnimatedImageView.m in Sources */,
 				00733A5F1BC4880000A5A117 /* UIImage+WebP.m in Sources */,
-				431739441CDFC8B20008FEB9 /* quant_levels_dec.c in Sources */,
-				43DA7D4F1D1086600028BE58 /* filters_mips_dsp_r2.c in Sources */,
 				00733A5C1BC4880000A5A117 /* UIButton+WebCache.m in Sources */,
-				43C8928F1D9D62D00022038D /* dec_msa.c in Sources */,
-				4317394C1CDFC8B20008FEB9 /* utils.c in Sources */,
-				43DA7D381D1086600028BE58 /* argb_mips_dsp_r2.c in Sources */,
-				43DA7D3C1D1086600028BE58 /* cost_mips32.c in Sources */,
-				431739421CDFC8B20008FEB9 /* quant_levels.c in Sources */,
 				00733A5D1BC4880000A5A117 /* UIImage+GIF.m in Sources */,
-				43DA7D501D1086600028BE58 /* filters_sse2.c in Sources */,
-				43DA7D4E1D1086600028BE58 /* enc.c in Sources */,
-				43DA7D6B1D1086600028BE58 /* yuv.c in Sources */,
-				431738DC1CDFC8A40008FEB9 /* vp8.c in Sources */,
-				43CE757B1CFE9427006C64D0 /* FLAnimatedImage.m in Sources */,
 				00733A571BC4880000A5A117 /* SDImageCache.m in Sources */,
-				43DA7D531D1086600028BE58 /* lossless_enc_mips32.c in Sources */,
-				4317394A1CDFC8B20008FEB9 /* thread.c in Sources */,
-				43DA7D681D1086600028BE58 /* yuv_mips_dsp_r2.c in Sources */,
-				43DA7D651D1086600028BE58 /* upsampling_neon.c in Sources */,
-				43DA7D371D1086600028BE58 /* alpha_processing.c in Sources */,
 				4369C2811D9807EC007E863A /* UIView+WebCache.m in Sources */,
-				43DA7D691D1086600028BE58 /* yuv_mips32.c in Sources */,
-				43DA7D5F1D1086600028BE58 /* rescaler_mips_dsp_r2.c in Sources */,
 				00733A5E1BC4880000A5A117 /* UIImage+MultiFormat.m in Sources */,
-				431738D31CDFC8A40008FEB9 /* alpha.c in Sources */,
 				00733A601BC4880000A5A117 /* UIImageView+HighlightedWebCache.m in Sources */,
-				43DA7D431D1086600028BE58 /* dec_neon.c in Sources */,
-				43DA7DEB1D109B9A0028BE58 /* alpha_processing_sse2.c in Sources */,
-				431739401CDFC8B20008FEB9 /* huffman_encode.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2193,100 +953,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4314D11E1D0E0E3B004B36C9 /* huffman.c in Sources */,
-				43DA7CED1D10865E0028BE58 /* lossless.c in Sources */,
-				43DA7CCC1D10865E0028BE58 /* argb.c in Sources */,
-				43DA7CDD1D10865E0028BE58 /* enc_neon.c in Sources */,
-				4314D11F1D0E0E3B004B36C9 /* quant_levels.c in Sources */,
-				4314D1201D0E0E3B004B36C9 /* idec.c in Sources */,
-				4314D1211D0E0E3B004B36C9 /* random.c in Sources */,
-				43C8929C1D9D6DD90022038D /* anim_decode.c in Sources */,
 				4314D1231D0E0E3B004B36C9 /* SDImageCache.m in Sources */,
 				4314D1241D0E0E3B004B36C9 /* SDWebImageDecoder.m in Sources */,
-				4314D1271D0E0E3B004B36C9 /* rescaler.c in Sources */,
-				43DA7CF61D10865E0028BE58 /* upsampling_mips_dsp_r2.c in Sources */,
-				4314D12A1D0E0E3B004B36C9 /* quant.c in Sources */,
-				43DA7DE71D109B980028BE58 /* alpha_processing_sse2.c in Sources */,
-				43DA7CDB1D10865E0028BE58 /* enc_mips_dsp_r2.c in Sources */,
-				4314D12F1D0E0E3B004B36C9 /* thread.c in Sources */,
 				4314D1311D0E0E3B004B36C9 /* SDWebImageDownloader.m in Sources */,
 				4369C27F1D9807EC007E863A /* UIView+WebCache.m in Sources */,
-				43DA7CC91D10865E0028BE58 /* alpha_processing.c in Sources */,
-				4314D1321D0E0E3B004B36C9 /* filters.c in Sources */,
 				4314D1341D0E0E3B004B36C9 /* UIImage+WebP.m in Sources */,
-				43DA7CD41D10865E0028BE58 /* dec_mips32.c in Sources */,
-				43DA7CD31D10865E0028BE58 /* dec_mips_dsp_r2.c in Sources */,
-				4314D1351D0E0E3B004B36C9 /* tree.c in Sources */,
-				43DA7CF31D10865E0028BE58 /* rescaler_neon.c in Sources */,
-				43DA7CE81D10865E0028BE58 /* lossless_enc_sse41.c in Sources */,
-				43DA7CE31D10865E0028BE58 /* filters.c in Sources */,
-				43DA7CF41D10865E0028BE58 /* rescaler_sse2.c in Sources */,
-				43DA7CF71D10865E0028BE58 /* upsampling_neon.c in Sources */,
 				4314D1361D0E0E3B004B36C9 /* SDWebImageManager.m in Sources */,
 				4314D1371D0E0E3B004B36C9 /* SDWebImagePrefetcher.m in Sources */,
-				43DA7CD61D10865E0028BE58 /* dec_sse2.c in Sources */,
-				43DA7CE11D10865E0028BE58 /* filters_mips_dsp_r2.c in Sources */,
-				43DA7CCB1D10865E0028BE58 /* argb_sse2.c in Sources */,
-				43DA7CE41D10865E0028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */,
-				43C8928D1D9D62CF0022038D /* dec_msa.c in Sources */,
-				4314D1391D0E0E3B004B36C9 /* color_cache.c in Sources */,
 				4314D13B1D0E0E3B004B36C9 /* UIButton+WebCache.m in Sources */,
-				43DA7DE61D109B980028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */,
-				43DA7CCF1D10865E0028BE58 /* cost_sse2.c in Sources */,
-				4314D13D1D0E0E3B004B36C9 /* quant_levels_dec.c in Sources */,
-				43C892A11D9D6DDC0022038D /* demux.c in Sources */,
-				4314D13E1D0E0E3B004B36C9 /* vp8l.c in Sources */,
-				43DA7CD51D10865E0028BE58 /* dec_neon.c in Sources */,
-				43DA7CF91D10865E0028BE58 /* upsampling.c in Sources */,
-				43DA7CFD1D10865E0028BE58 /* yuv.c in Sources */,
 				4314D1401D0E0E3B004B36C9 /* UIImageView+WebCache.m in Sources */,
-				43DA7CDC1D10865E0028BE58 /* enc_mips32.c in Sources */,
 				43A9186C1D8308FE00B3925F /* SDImageCacheConfig.m in Sources */,
 				4314D1411D0E0E3B004B36C9 /* SDWebImageDownloaderOperation.m in Sources */,
-				43DA7CCE1D10865E0028BE58 /* cost_mips32.c in Sources */,
-				4314D1421D0E0E3B004B36C9 /* webp.c in Sources */,
-				4314D1441D0E0E3B004B36C9 /* bit_writer.c in Sources */,
-				43DA7CF11D10865E0028BE58 /* rescaler_mips_dsp_r2.c in Sources */,
-				43DA7CEB1D10865E0028BE58 /* lossless_neon.c in Sources */,
-				43DA7CFA1D10865E0028BE58 /* yuv_mips_dsp_r2.c in Sources */,
-				43DA7CCA1D10865E0028BE58 /* argb_mips_dsp_r2.c in Sources */,
-				4314D1451D0E0E3B004B36C9 /* vp8.c in Sources */,
-				43DA7CF51D10865E0028BE58 /* rescaler.c in Sources */,
-				43DA7CDF1D10865E0028BE58 /* enc_sse41.c in Sources */,
-				43DA7CE91D10865E0028BE58 /* lossless_enc.c in Sources */,
-				43DA7CCD1D10865E0028BE58 /* cost_mips_dsp_r2.c in Sources */,
-				43DA7CE51D10865E0028BE58 /* lossless_enc_mips32.c in Sources */,
-				43DA7CFB1D10865E0028BE58 /* yuv_mips32.c in Sources */,
-				43DA7CD21D10865E0028BE58 /* dec_clip_tables.c in Sources */,
 				4314D14B1D0E0E3B004B36C9 /* SDWebImageCompat.m in Sources */,
-				4314D14C1D0E0E3B004B36C9 /* huffman_encode.c in Sources */,
 				4314D14D1D0E0E3B004B36C9 /* UIImage+GIF.m in Sources */,
-				4314D14F1D0E0E3B004B36C9 /* io.c in Sources */,
 				4314D1501D0E0E3B004B36C9 /* UIView+WebCacheOperation.m in Sources */,
-				4314D1511D0E0E3B004B36C9 /* buffer.c in Sources */,
-				43DA7CF81D10865E0028BE58 /* upsampling_sse2.c in Sources */,
-				43DA7CD81D10865E0028BE58 /* dec.c in Sources */,
-				43DA7CEC1D10865E0028BE58 /* lossless_sse2.c in Sources */,
 				4314D1521D0E0E3B004B36C9 /* NSData+ImageContentType.m in Sources */,
-				43DA7CEA1D10865E0028BE58 /* lossless_mips_dsp_r2.c in Sources */,
 				4314D1531D0E0E3B004B36C9 /* UIImage+MultiFormat.m in Sources */,
-				43DA7CE71D10865E0028BE58 /* lossless_enc_sse2.c in Sources */,
-				43DA7CC81D10865E0028BE58 /* alpha_processing_sse41.c in Sources */,
-				43DA7CD01D10865E0028BE58 /* cost.c in Sources */,
-				43DA7CD11D10865E0028BE58 /* cpu.c in Sources */,
-				43DA7CF21D10865E0028BE58 /* rescaler_mips32.c in Sources */,
-				43DA7CE61D10865E0028BE58 /* lossless_enc_neon.c in Sources */,
 				4314D1551D0E0E3B004B36C9 /* UIImageView+HighlightedWebCache.m in Sources */,
-				43DA7CE01D10865E0028BE58 /* enc.c in Sources */,
-				4314D1571D0E0E3B004B36C9 /* frame.c in Sources */,
-				4314D1581D0E0E3B004B36C9 /* bit_reader.c in Sources */,
-				43DA7CDE1D10865E0028BE58 /* enc_sse2.c in Sources */,
-				43DA7CDA1D10865E0028BE58 /* enc_avx2.c in Sources */,
-				43DA7CFC1D10865E0028BE58 /* yuv_sse2.c in Sources */,
-				43DA7CD71D10865E0028BE58 /* dec_sse41.c in Sources */,
-				43DA7CE21D10865E0028BE58 /* filters_sse2.c in Sources */,
-				4314D15A1D0E0E3B004B36C9 /* alpha.c in Sources */,
-				4314D15C1D0E0E3B004B36C9 /* utils.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2295,98 +978,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				431BB68C1D06D2C1006A3455 /* SDWebImageDownloaderOperation.m in Sources */,
-				43DA7D921D1086600028BE58 /* lossless.c in Sources */,
-				43DA7D711D1086600028BE58 /* argb.c in Sources */,
-				43DA7D821D1086600028BE58 /* enc_neon.c in Sources */,
-				43A62A2A1D0E0A860089D7DD /* filters.c in Sources */,
 				431BB68E1D06D2C1006A3455 /* SDWebImagePrefetcher.m in Sources */,
-				43A62A651D0E0A8F0089D7DD /* webp.c in Sources */,
-				43C8929F1D9D6DDA0022038D /* anim_decode.c in Sources */,
-				43A62A3A1D0E0A860089D7DD /* utils.c in Sources */,
-				43A62A271D0E0A860089D7DD /* color_cache.c in Sources */,
 				431BB6921D06D2C1006A3455 /* NSData+ImageContentType.m in Sources */,
-				43DA7D9B1D1086600028BE58 /* upsampling_mips_dsp_r2.c in Sources */,
 				431BB69A1D06D2C1006A3455 /* SDWebImageDownloader.m in Sources */,
-				43DA7DED1D109B9B0028BE58 /* alpha_processing_sse2.c in Sources */,
-				43DA7D801D1086600028BE58 /* enc_mips_dsp_r2.c in Sources */,
-				43A62A631D0E0A8F0089D7DD /* vp8l.c in Sources */,
 				431BB6A31D06D2C1006A3455 /* UIImageView+WebCache.m in Sources */,
 				4369C2821D9807EC007E863A /* UIView+WebCache.m in Sources */,
-				43DA7D6E1D1086600028BE58 /* alpha_processing.c in Sources */,
-				43A62A5E1D0E0A8F0089D7DD /* io.c in Sources */,
-				43A62A321D0E0A860089D7DD /* quant_levels_dec.c in Sources */,
-				43DA7D791D1086600028BE58 /* dec_mips32.c in Sources */,
-				43DA7D781D1086600028BE58 /* dec_mips_dsp_r2.c in Sources */,
 				431BB6AA1D06D2C1006A3455 /* SDWebImageManager.m in Sources */,
-				43DA7D981D1086600028BE58 /* rescaler_neon.c in Sources */,
-				43DA7D8D1D1086600028BE58 /* lossless_enc_sse41.c in Sources */,
-				43DA7D881D1086600028BE58 /* filters.c in Sources */,
-				43DA7D991D1086600028BE58 /* rescaler_sse2.c in Sources */,
-				43DA7D9C1D1086600028BE58 /* upsampling_neon.c in Sources */,
-				43A62A5A1D0E0A8F0089D7DD /* buffer.c in Sources */,
 				431BB6AC1D06D2C1006A3455 /* SDWebImageCompat.m in Sources */,
-				43DA7D7B1D1086600028BE58 /* dec_sse2.c in Sources */,
-				43DA7D861D1086600028BE58 /* filters_mips_dsp_r2.c in Sources */,
-				43DA7D701D1086600028BE58 /* argb_sse2.c in Sources */,
-				43DA7D891D1086600028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */,
-				43C892901D9D62D10022038D /* dec_msa.c in Sources */,
-				43A62A341D0E0A860089D7DD /* random.c in Sources */,
 				431BB6B11D06D2C1006A3455 /* UIView+WebCacheOperation.m in Sources */,
-				43DA7DEC1D109B9B0028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */,
-				43DA7D741D1086600028BE58 /* cost_sse2.c in Sources */,
 				431BB6B41D06D2C1006A3455 /* SDWebImageDecoder.m in Sources */,
-				43C892A41D9D6DDD0022038D /* demux.c in Sources */,
 				431BB6B61D06D2C1006A3455 /* UIImage+WebP.m in Sources */,
-				43DA7D7A1D1086600028BE58 /* dec_neon.c in Sources */,
-				43DA7D9E1D1086600028BE58 /* upsampling.c in Sources */,
-				43DA7DA21D1086600028BE58 /* yuv.c in Sources */,
 				431BB6B91D06D2C1006A3455 /* UIButton+WebCache.m in Sources */,
-				43DA7D811D1086600028BE58 /* enc_mips32.c in Sources */,
 				43A9186F1D8308FE00B3925F /* SDImageCacheConfig.m in Sources */,
-				43A62A5F1D0E0A8F0089D7DD /* quant.c in Sources */,
-				43DA7D731D1086600028BE58 /* cost_mips32.c in Sources */,
 				431BB6BD1D06D2C1006A3455 /* UIImage+GIF.m in Sources */,
-				43A62A581D0E0A8F0089D7DD /* alpha.c in Sources */,
-				43DA7D961D1086600028BE58 /* rescaler_mips_dsp_r2.c in Sources */,
-				43DA7D901D1086600028BE58 /* lossless_neon.c in Sources */,
-				43DA7D9F1D1086600028BE58 /* yuv_mips_dsp_r2.c in Sources */,
-				43DA7D6F1D1086600028BE58 /* argb_mips_dsp_r2.c in Sources */,
-				43A62A2E1D0E0A860089D7DD /* huffman_encode.c in Sources */,
-				43DA7D9A1D1086600028BE58 /* rescaler.c in Sources */,
-				43DA7D841D1086600028BE58 /* enc_sse41.c in Sources */,
-				43DA7D8E1D1086600028BE58 /* lossless_enc.c in Sources */,
-				43DA7D721D1086600028BE58 /* cost_mips_dsp_r2.c in Sources */,
-				43DA7D8A1D1086600028BE58 /* lossless_enc_mips32.c in Sources */,
-				43DA7DA01D1086600028BE58 /* yuv_mips32.c in Sources */,
-				43DA7D771D1086600028BE58 /* dec_clip_tables.c in Sources */,
-				43A62A5D1D0E0A8F0089D7DD /* idec.c in Sources */,
-				43A62A251D0E0A860089D7DD /* bit_writer.c in Sources */,
-				43A62A2C1D0E0A860089D7DD /* huffman.c in Sources */,
-				43A62A381D0E0A860089D7DD /* thread.c in Sources */,
-				43A62A361D0E0A860089D7DD /* rescaler.c in Sources */,
 				431BB6C01D06D2C1006A3455 /* SDImageCache.m in Sources */,
-				43DA7D9D1D1086600028BE58 /* upsampling_sse2.c in Sources */,
-				43DA7D7D1D1086600028BE58 /* dec.c in Sources */,
-				43DA7D911D1086600028BE58 /* lossless_sse2.c in Sources */,
 				431BB6C41D06D2C1006A3455 /* UIImage+MultiFormat.m in Sources */,
-				43DA7D8F1D1086600028BE58 /* lossless_mips_dsp_r2.c in Sources */,
-				43A62A611D0E0A8F0089D7DD /* vp8.c in Sources */,
-				43DA7D8C1D1086600028BE58 /* lossless_enc_sse2.c in Sources */,
-				43DA7D6D1D1086600028BE58 /* alpha_processing_sse41.c in Sources */,
-				43DA7D751D1086600028BE58 /* cost.c in Sources */,
-				43DA7D761D1086600028BE58 /* cpu.c in Sources */,
-				43DA7D971D1086600028BE58 /* rescaler_mips32.c in Sources */,
-				43DA7D8B1D1086600028BE58 /* lossless_enc_neon.c in Sources */,
-				43A62A5C1D0E0A8F0089D7DD /* frame.c in Sources */,
-				43DA7D851D1086600028BE58 /* enc.c in Sources */,
-				43A62A221D0E0A860089D7DD /* bit_reader.c in Sources */,
-				43A62A301D0E0A860089D7DD /* quant_levels.c in Sources */,
-				43DA7D831D1086600028BE58 /* enc_sse2.c in Sources */,
-				43DA7D7F1D1086600028BE58 /* enc_avx2.c in Sources */,
-				43DA7DA11D1086600028BE58 /* yuv_sse2.c in Sources */,
-				43DA7D7C1D1086600028BE58 /* dec_sse41.c in Sources */,
-				43DA7D871D1086600028BE58 /* filters_sse2.c in Sources */,
-				43A62A601D0E0A8F0089D7DD /* tree.c in Sources */,
 				431BB6C71D06D2C1006A3455 /* UIImageView+HighlightedWebCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2395,102 +1001,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43DA7DAC1D1086610028BE58 /* cost.c in Sources */,
-				43DA7DA61D1086610028BE58 /* argb_mips_dsp_r2.c in Sources */,
-				4397D2791D0DDD8C00BB2784 /* huffman.c in Sources */,
-				43DA7DC91D1086610028BE58 /* lossless.c in Sources */,
-				4397D27A1D0DDD8C00BB2784 /* quant_levels.c in Sources */,
-				43DA7DC51D1086610028BE58 /* lossless_enc.c in Sources */,
-				43DA7DA81D1086610028BE58 /* argb.c in Sources */,
-				43DA7DA41D1086610028BE58 /* alpha_processing_sse41.c in Sources */,
-				4397D27B1D0DDD8C00BB2784 /* idec.c in Sources */,
-				43DA7DD91D1086610028BE58 /* yuv.c in Sources */,
-				43DA7DB31D1086610028BE58 /* dec_sse41.c in Sources */,
-				43DA7DD11D1086610028BE58 /* rescaler.c in Sources */,
-				4397D27C1D0DDD8C00BB2784 /* random.c in Sources */,
 				4397D27E1D0DDD8C00BB2784 /* UIImage+GIF.m in Sources */,
-				43DA7DBE1D1086610028BE58 /* filters_sse2.c in Sources */,
 				4397D27F1D0DDD8C00BB2784 /* UIImage+WebP.m in Sources */,
 				4397D2F71D0DE2DF00BB2784 /* NSImage+WebCache.m in Sources */,
-				4397D2821D0DDD8C00BB2784 /* rescaler.c in Sources */,
-				43DA7DC41D1086610028BE58 /* lossless_enc_sse41.c in Sources */,
-				43C892A01D9D6DDA0022038D /* anim_decode.c in Sources */,
-				4397D2851D0DDD8C00BB2784 /* quant.c in Sources */,
-				43DA7DA51D1086610028BE58 /* alpha_processing.c in Sources */,
-				43DA7DD51D1086610028BE58 /* upsampling.c in Sources */,
-				43DA7DD31D1086610028BE58 /* upsampling_neon.c in Sources */,
-				4397D28A1D0DDD8C00BB2784 /* thread.c in Sources */,
-				43DA7DB11D1086610028BE58 /* dec_neon.c in Sources */,
-				43DA7DBB1D1086610028BE58 /* enc_sse41.c in Sources */,
-				43C892A51D9D6DDE0022038D /* demux.c in Sources */,
-				43DA7DBA1D1086610028BE58 /* enc_sse2.c in Sources */,
-				43DA7DCD1D1086610028BE58 /* rescaler_mips_dsp_r2.c in Sources */,
 				4397D28C1D0DDD8C00BB2784 /* UIImageView+WebCache.m in Sources */,
-				4397D28D1D0DDD8C00BB2784 /* filters.c in Sources */,
 				4397D28F1D0DDD8C00BB2784 /* SDWebImageDownloaderOperation.m in Sources */,
-				43DA7DB61D1086610028BE58 /* enc_avx2.c in Sources */,
-				4397D2901D0DDD8C00BB2784 /* tree.c in Sources */,
-				43DA7DD01D1086610028BE58 /* rescaler_sse2.c in Sources */,
-				43DA7DEE1D109B9B0028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */,
-				43DA7DC01D1086610028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */,
-				43DA7DD21D1086610028BE58 /* upsampling_mips_dsp_r2.c in Sources */,
-				43DA7DD41D1086610028BE58 /* upsampling_sse2.c in Sources */,
 				4397D2911D0DDD8C00BB2784 /* MKAnnotationView+WebCache.m in Sources */,
-				43DA7DD61D1086610028BE58 /* yuv_mips_dsp_r2.c in Sources */,
 				4397D2921D0DDD8C00BB2784 /* SDWebImagePrefetcher.m in Sources */,
-				43DA7DAD1D1086610028BE58 /* cpu.c in Sources */,
-				4397D2941D0DDD8C00BB2784 /* color_cache.c in Sources */,
 				4397D2961D0DDD8C00BB2784 /* UIImage+MultiFormat.m in Sources */,
-				4397D2981D0DDD8C00BB2784 /* quant_levels_dec.c in Sources */,
-				4397D2991D0DDD8C00BB2784 /* vp8l.c in Sources */,
 				4397D29B1D0DDD8C00BB2784 /* SDWebImageDownloader.m in Sources */,
-				43DA7DEF1D109B9B0028BE58 /* alpha_processing_sse2.c in Sources */,
-				43C892911D9D62D10022038D /* dec_msa.c in Sources */,
-				43DA7DBD1D1086610028BE58 /* filters_mips_dsp_r2.c in Sources */,
-				43DA7DC61D1086610028BE58 /* lossless_mips_dsp_r2.c in Sources */,
 				4397D29C1D0DDD8C00BB2784 /* NSData+ImageContentType.m in Sources */,
-				4397D29D1D0DDD8C00BB2784 /* webp.c in Sources */,
-				4397D29F1D0DDD8C00BB2784 /* bit_writer.c in Sources */,
-				43DA7DD71D1086610028BE58 /* yuv_mips32.c in Sources */,
-				4397D2A01D0DDD8C00BB2784 /* vp8.c in Sources */,
 				4397D2A11D0DDD8C00BB2784 /* SDWebImageManager.m in Sources */,
-				43DA7DC71D1086610028BE58 /* lossless_neon.c in Sources */,
-				43DA7DBF1D1086610028BE58 /* filters.c in Sources */,
-				43DA7DC81D1086610028BE58 /* lossless_sse2.c in Sources */,
-				43DA7DC21D1086610028BE58 /* lossless_enc_neon.c in Sources */,
-				43DA7DB41D1086610028BE58 /* dec.c in Sources */,
 				4397D2A61D0DDD8C00BB2784 /* SDWebImageCompat.m in Sources */,
-				43DA7DD81D1086610028BE58 /* yuv_sse2.c in Sources */,
-				4397D2A71D0DDD8C00BB2784 /* huffman_encode.c in Sources */,
 				4397D2A81D0DDD8C00BB2784 /* UIButton+WebCache.m in Sources */,
-				4397D2AA1D0DDD8C00BB2784 /* io.c in Sources */,
-				43DA7DCF1D1086610028BE58 /* rescaler_neon.c in Sources */,
-				43DA7DC31D1086610028BE58 /* lossless_enc_sse2.c in Sources */,
 				43A918701D8308FE00B3925F /* SDImageCacheConfig.m in Sources */,
 				4397D2AB1D0DDD8C00BB2784 /* UIView+WebCacheOperation.m in Sources */,
-				43DA7DA91D1086610028BE58 /* cost_mips_dsp_r2.c in Sources */,
-				43DA7DB01D1086610028BE58 /* dec_mips32.c in Sources */,
-				43DA7DAA1D1086610028BE58 /* cost_mips32.c in Sources */,
-				43DA7DAB1D1086610028BE58 /* cost_sse2.c in Sources */,
 				4369C2831D9807EC007E863A /* UIView+WebCache.m in Sources */,
-				43DA7DB71D1086610028BE58 /* enc_mips_dsp_r2.c in Sources */,
-				43DA7DC11D1086610028BE58 /* lossless_enc_mips32.c in Sources */,
-				43DA7DBC1D1086610028BE58 /* enc.c in Sources */,
-				4397D2AC1D0DDD8C00BB2784 /* buffer.c in Sources */,
 				4397D2AD1D0DDD8C00BB2784 /* SDWebImageDecoder.m in Sources */,
 				4397D2AE1D0DDD8C00BB2784 /* UIImageView+HighlightedWebCache.m in Sources */,
 				4397D2B01D0DDD8C00BB2784 /* SDImageCache.m in Sources */,
-				4397D2B21D0DDD8C00BB2784 /* frame.c in Sources */,
-				43DA7DCE1D1086610028BE58 /* rescaler_mips32.c in Sources */,
-				43DA7DAE1D1086610028BE58 /* dec_clip_tables.c in Sources */,
-				4397D2B31D0DDD8C00BB2784 /* bit_reader.c in Sources */,
-				4397D2B51D0DDD8C00BB2784 /* alpha.c in Sources */,
-				43DA7DA71D1086610028BE58 /* argb_sse2.c in Sources */,
-				43DA7DB81D1086610028BE58 /* enc_mips32.c in Sources */,
-				43DA7DB91D1086610028BE58 /* enc_neon.c in Sources */,
-				43DA7DB21D1086610028BE58 /* dec_sse2.c in Sources */,
-				43DA7DAF1D1086610028BE58 /* dec_mips_dsp_r2.c in Sources */,
-				4397D2B71D0DDD8C00BB2784 /* utils.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2498,104 +1027,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43DA7D2F1D10865F0028BE58 /* upsampling_sse2.c in Sources */,
-				431739241CDFC8B20008FEB9 /* huffman.c in Sources */,
-				431739281CDFC8B20008FEB9 /* quant_levels.c in Sources */,
-				431738C91CDFC8A30008FEB9 /* idec.c in Sources */,
-				43DA7D1B1D10865F0028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */,
-				43DA7D331D10865F0028BE58 /* yuv_sse2.c in Sources */,
-				43DA7D0D1D10865F0028BE58 /* dec_sse2.c in Sources */,
-				43DA7D0F1D10865F0028BE58 /* dec.c in Sources */,
-				4317392C1CDFC8B20008FEB9 /* random.c in Sources */,
 				4A2CAE2E1AB4BB7500B6BC39 /* UIImage+GIF.m in Sources */,
-				43DA7D151D10865F0028BE58 /* enc_sse2.c in Sources */,
 				4A2CAE321AB4BB7500B6BC39 /* UIImage+WebP.m in Sources */,
-				43DA7D231D10865F0028BE58 /* lossless_sse2.c in Sources */,
-				43DA7D0E1D10865F0028BE58 /* dec_sse41.c in Sources */,
-				43C8929D1D9D6DD90022038D /* anim_decode.c in Sources */,
 				43CE75D41CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m in Sources */,
-				43DA7D1F1D10865F0028BE58 /* lossless_enc_sse41.c in Sources */,
-				43DA7D131D10865F0028BE58 /* enc_mips32.c in Sources */,
-				43DA7D211D10865F0028BE58 /* lossless_mips_dsp_r2.c in Sources */,
-				43DA7D1E1D10865F0028BE58 /* lossless_enc_sse2.c in Sources */,
-				43DA7D2B1D10865F0028BE58 /* rescaler_sse2.c in Sources */,
-				43DA7D091D10865F0028BE58 /* dec_clip_tables.c in Sources */,
-				4317392E1CDFC8B20008FEB9 /* rescaler.c in Sources */,
-				431738CB1CDFC8A30008FEB9 /* quant.c in Sources */,
-				43DA7D081D10865F0028BE58 /* cpu.c in Sources */,
-				431739301CDFC8B20008FEB9 /* thread.c in Sources */,
-				43DA7D071D10865F0028BE58 /* cost.c in Sources */,
-				43CE757A1CFE9427006C64D0 /* FLAnimatedImage.m in Sources */,
-				43DA7D221D10865F0028BE58 /* lossless_neon.c in Sources */,
-				43DA7D0A1D10865F0028BE58 /* dec_mips_dsp_r2.c in Sources */,
 				4A2CAE361AB4BB7500B6BC39 /* UIImageView+WebCache.m in Sources */,
-				43DA7D141D10865F0028BE58 /* enc_neon.c in Sources */,
-				431739221CDFC8B20008FEB9 /* filters.c in Sources */,
-				43C892A21D9D6DDD0022038D /* demux.c in Sources */,
-				43DA7D1A1D10865F0028BE58 /* filters.c in Sources */,
 				4A2CAE1E1AB4BB6800B6BC39 /* SDWebImageDownloaderOperation.m in Sources */,
-				43DA7D121D10865F0028BE58 /* enc_mips_dsp_r2.c in Sources */,
-				43DA7D291D10865F0028BE58 /* rescaler_mips32.c in Sources */,
-				431738CC1CDFC8A30008FEB9 /* tree.c in Sources */,
 				4A2CAE281AB4BB7500B6BC39 /* MKAnnotationView+WebCache.m in Sources */,
-				43DA7D2A1D10865F0028BE58 /* rescaler_neon.c in Sources */,
-				43DA7CFF1D10865F0028BE58 /* alpha_processing_sse41.c in Sources */,
-				43DA7D2D1D10865F0028BE58 /* upsampling_mips_dsp_r2.c in Sources */,
 				4A2CAE261AB4BB7000B6BC39 /* SDWebImagePrefetcher.m in Sources */,
 				43A9186D1D8308FE00B3925F /* SDImageCacheConfig.m in Sources */,
-				43DA7D061D10865F0028BE58 /* cost_sse2.c in Sources */,
-				4317391F1CDFC8B20008FEB9 /* color_cache.c in Sources */,
 				4A2CAE301AB4BB7500B6BC39 /* UIImage+MultiFormat.m in Sources */,
-				4317392A1CDFC8B20008FEB9 /* quant_levels_dec.c in Sources */,
-				43DA7D1D1D10865F0028BE58 /* lossless_enc_neon.c in Sources */,
-				43DA7D161D10865F0028BE58 /* enc_sse41.c in Sources */,
-				43DA7D041D10865F0028BE58 /* cost_mips_dsp_r2.c in Sources */,
-				431738CF1CDFC8A30008FEB9 /* vp8l.c in Sources */,
 				4A2CAE1C1AB4BB6800B6BC39 /* SDWebImageDownloader.m in Sources */,
-				43DA7D031D10865F0028BE58 /* argb.c in Sources */,
-				43DA7D301D10865F0028BE58 /* upsampling.c in Sources */,
-				43DA7D0B1D10865F0028BE58 /* dec_mips32.c in Sources */,
-				43DA7D241D10865F0028BE58 /* lossless.c in Sources */,
 				4A2CAE2A1AB4BB7500B6BC39 /* NSData+ImageContentType.m in Sources */,
-				431738D11CDFC8A30008FEB9 /* webp.c in Sources */,
-				43DA7D021D10865F0028BE58 /* argb_sse2.c in Sources */,
-				43DA7DE81D109B990028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */,
-				43DA7D2C1D10865F0028BE58 /* rescaler.c in Sources */,
-				43DA7D111D10865F0028BE58 /* enc_avx2.c in Sources */,
-				43DA7D201D10865F0028BE58 /* lossless_enc.c in Sources */,
-				4317391D1CDFC8B20008FEB9 /* bit_writer.c in Sources */,
-				431738CD1CDFC8A30008FEB9 /* vp8.c in Sources */,
 				4A2CAE221AB4BB7000B6BC39 /* SDWebImageManager.m in Sources */,
 				4A2CAE191AB4BB6400B6BC39 /* SDWebImageCompat.m in Sources */,
-				431739261CDFC8B20008FEB9 /* huffman_encode.c in Sources */,
-				43DA7D181D10865F0028BE58 /* filters_mips_dsp_r2.c in Sources */,
 				4A2CAE2C1AB4BB7500B6BC39 /* UIButton+WebCache.m in Sources */,
-				43C8928E1D9D62D00022038D /* dec_msa.c in Sources */,
-				431738CA1CDFC8A30008FEB9 /* io.c in Sources */,
-				43DA7D011D10865F0028BE58 /* argb_mips_dsp_r2.c in Sources */,
-				43DA7D051D10865F0028BE58 /* cost_mips32.c in Sources */,
 				4A2CAE381AB4BB7500B6BC39 /* UIView+WebCacheOperation.m in Sources */,
-				431738C61CDFC8A30008FEB9 /* buffer.c in Sources */,
-				43DA7D191D10865F0028BE58 /* filters_sse2.c in Sources */,
-				43DA7D171D10865F0028BE58 /* enc.c in Sources */,
-				43DA7D341D10865F0028BE58 /* yuv.c in Sources */,
 				4A2CAE241AB4BB7000B6BC39 /* SDWebImageDecoder.m in Sources */,
 				4A2CAE341AB4BB7500B6BC39 /* UIImageView+HighlightedWebCache.m in Sources */,
 				4A2CAE201AB4BB6C00B6BC39 /* SDImageCache.m in Sources */,
-				43DA7D1C1D10865F0028BE58 /* lossless_enc_mips32.c in Sources */,
-				43CE75801CFE9427006C64D0 /* FLAnimatedImageView.m in Sources */,
-				43DA7D311D10865F0028BE58 /* yuv_mips_dsp_r2.c in Sources */,
-				43DA7D2E1D10865F0028BE58 /* upsampling_neon.c in Sources */,
-				43DA7D001D10865F0028BE58 /* alpha_processing.c in Sources */,
 				4369C2801D9807EC007E863A /* UIView+WebCache.m in Sources */,
-				43DA7D321D10865F0028BE58 /* yuv_mips32.c in Sources */,
-				43DA7D281D10865F0028BE58 /* rescaler_mips_dsp_r2.c in Sources */,
-				431738C81CDFC8A30008FEB9 /* frame.c in Sources */,
-				4317391A1CDFC8B20008FEB9 /* bit_reader.c in Sources */,
-				431738C41CDFC8A30008FEB9 /* alpha.c in Sources */,
-				43DA7D0C1D10865F0028BE58 /* dec_neon.c in Sources */,
-				43DA7DE91D109B990028BE58 /* alpha_processing_sse2.c in Sources */,
-				431739321CDFC8B20008FEB9 /* utils.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2603,104 +1053,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43DA7CC11D1086570028BE58 /* upsampling_sse2.c in Sources */,
-				431738AD1CDFC2630008FEB9 /* huffman.c in Sources */,
-				431738B11CDFC2630008FEB9 /* quant_levels.c in Sources */,
-				4317387D1CDFC2580008FEB9 /* idec.c in Sources */,
-				43DA7CAD1D1086570028BE58 /* lossless_enc_mips_dsp_r2.c in Sources */,
-				43DA7CC51D1086570028BE58 /* yuv_sse2.c in Sources */,
-				43DA7C9F1D1086570028BE58 /* dec_sse2.c in Sources */,
-				43DA7CA11D1086570028BE58 /* dec.c in Sources */,
-				431738B51CDFC2630008FEB9 /* random.c in Sources */,
 				53761309155AD0D5005750A4 /* SDImageCache.m in Sources */,
-				43DA7CA71D1086570028BE58 /* enc_sse2.c in Sources */,
 				5376130A155AD0D5005750A4 /* SDWebImageDecoder.m in Sources */,
-				43DA7CB51D1086570028BE58 /* lossless_sse2.c in Sources */,
-				43DA7CA01D1086570028BE58 /* dec_sse41.c in Sources */,
-				43C8929A1D9D6DD70022038D /* anim_decode.c in Sources */,
 				43CE75D31CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m in Sources */,
-				43DA7CB11D1086570028BE58 /* lossless_enc_sse41.c in Sources */,
-				43DA7CA51D1086570028BE58 /* enc_mips32.c in Sources */,
-				43DA7CB31D1086570028BE58 /* lossless_mips_dsp_r2.c in Sources */,
-				43DA7CB01D1086570028BE58 /* lossless_enc_sse2.c in Sources */,
-				43DA7CBD1D1086570028BE58 /* rescaler_sse2.c in Sources */,
-				43DA7C9B1D1086570028BE58 /* dec_clip_tables.c in Sources */,
-				431738B71CDFC2630008FEB9 /* rescaler.c in Sources */,
-				4317387F1CDFC2580008FEB9 /* quant.c in Sources */,
-				43DA7C9A1D1086570028BE58 /* cpu.c in Sources */,
-				431738B91CDFC2630008FEB9 /* thread.c in Sources */,
-				43DA7C991D1086570028BE58 /* cost.c in Sources */,
-				43CE75791CFE9427006C64D0 /* FLAnimatedImage.m in Sources */,
-				43DA7CB41D1086570028BE58 /* lossless_neon.c in Sources */,
-				43DA7C9C1D1086570028BE58 /* dec_mips_dsp_r2.c in Sources */,
 				5376130B155AD0D5005750A4 /* SDWebImageDownloader.m in Sources */,
-				43DA7CA61D1086570028BE58 /* enc_neon.c in Sources */,
-				431738AB1CDFC2630008FEB9 /* filters.c in Sources */,
-				43C8929B1D9D6DD70022038D /* demux.c in Sources */,
-				43DA7CAC1D1086570028BE58 /* filters.c in Sources */,
 				438096751CDFC0A100DC626B /* UIImage+WebP.m in Sources */,
-				43DA7CA41D1086570028BE58 /* enc_mips_dsp_r2.c in Sources */,
-				43DA7CBB1D1086570028BE58 /* rescaler_mips32.c in Sources */,
-				431738801CDFC2580008FEB9 /* tree.c in Sources */,
 				5376130C155AD0D5005750A4 /* SDWebImageManager.m in Sources */,
-				43DA7CBC1D1086570028BE58 /* rescaler_neon.c in Sources */,
-				43DA7C911D1086570028BE58 /* alpha_processing_sse41.c in Sources */,
-				43DA7CBF1D1086570028BE58 /* upsampling_mips_dsp_r2.c in Sources */,
 				5376130D155AD0D5005750A4 /* SDWebImagePrefetcher.m in Sources */,
 				43A9186B1D8308FE00B3925F /* SDImageCacheConfig.m in Sources */,
-				43DA7C981D1086570028BE58 /* cost_sse2.c in Sources */,
-				431738A81CDFC2630008FEB9 /* color_cache.c in Sources */,
 				5376130E155AD0D5005750A4 /* UIButton+WebCache.m in Sources */,
-				431738B31CDFC2630008FEB9 /* quant_levels_dec.c in Sources */,
-				43DA7CAF1D1086570028BE58 /* lossless_enc_neon.c in Sources */,
-				43DA7CA81D1086570028BE58 /* enc_sse41.c in Sources */,
-				43DA7C961D1086570028BE58 /* cost_mips_dsp_r2.c in Sources */,
-				431738831CDFC2580008FEB9 /* vp8l.c in Sources */,
 				5376130F155AD0D5005750A4 /* UIImageView+WebCache.m in Sources */,
-				43DA7C951D1086570028BE58 /* argb.c in Sources */,
-				43DA7CC21D1086570028BE58 /* upsampling.c in Sources */,
-				43DA7C9D1D1086570028BE58 /* dec_mips32.c in Sources */,
-				43DA7CB61D1086570028BE58 /* lossless.c in Sources */,
 				530E49EC16464C84002868E7 /* SDWebImageDownloaderOperation.m in Sources */,
-				431738851CDFC2580008FEB9 /* webp.c in Sources */,
-				43DA7C941D1086570028BE58 /* argb_sse2.c in Sources */,
-				43DA7DE41D109B160028BE58 /* alpha_processing_mips_dsp_r2.c in Sources */,
-				43DA7CBE1D1086570028BE58 /* rescaler.c in Sources */,
-				43DA7CA31D1086570028BE58 /* enc_avx2.c in Sources */,
-				43DA7CB21D1086570028BE58 /* lossless_enc.c in Sources */,
-				431738A61CDFC2630008FEB9 /* bit_writer.c in Sources */,
-				431738811CDFC2580008FEB9 /* vp8.c in Sources */,
 				438096731CDFC08F00DC626B /* MKAnnotationView+WebCache.m in Sources */,
 				53406750167780C40042B59E /* SDWebImageCompat.m in Sources */,
-				431738AF1CDFC2630008FEB9 /* huffman_encode.c in Sources */,
-				43DA7CAA1D1086570028BE58 /* filters_mips_dsp_r2.c in Sources */,
 				A18A6CC9172DC28500419892 /* UIImage+GIF.m in Sources */,
-				43C892861D9D62B60022038D /* dec_msa.c in Sources */,
-				4317387E1CDFC2580008FEB9 /* io.c in Sources */,
-				43DA7C931D1086570028BE58 /* argb_mips_dsp_r2.c in Sources */,
-				43DA7C971D1086570028BE58 /* cost_mips32.c in Sources */,
 				AB615306192DA24600A2D8E9 /* UIView+WebCacheOperation.m in Sources */,
-				4317387A1CDFC2580008FEB9 /* buffer.c in Sources */,
-				43DA7CAB1D1086570028BE58 /* filters_sse2.c in Sources */,
-				43DA7CA91D1086570028BE58 /* enc.c in Sources */,
-				43DA7CC61D1086570028BE58 /* yuv.c in Sources */,
 				5D5B9145188EE8DD006D06BD /* NSData+ImageContentType.m in Sources */,
 				53EDFB8C17623F7C00698166 /* UIImage+MultiFormat.m in Sources */,
 				ABBE71A818C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m in Sources */,
-				43DA7CAE1D1086570028BE58 /* lossless_enc_mips32.c in Sources */,
-				43CE757F1CFE9427006C64D0 /* FLAnimatedImageView.m in Sources */,
-				43DA7CC31D1086570028BE58 /* yuv_mips_dsp_r2.c in Sources */,
-				43DA7CC01D1086570028BE58 /* upsampling_neon.c in Sources */,
-				43DA7C921D1086570028BE58 /* alpha_processing.c in Sources */,
 				4369C27E1D9807EC007E863A /* UIView+WebCache.m in Sources */,
-				43DA7CC41D1086570028BE58 /* yuv_mips32.c in Sources */,
-				43DA7CBA1D1086570028BE58 /* rescaler_mips_dsp_r2.c in Sources */,
-				4317387C1CDFC2580008FEB9 /* frame.c in Sources */,
-				431738A31CDFC2630008FEB9 /* bit_reader.c in Sources */,
-				431738781CDFC2580008FEB9 /* alpha.c in Sources */,
-				43DA7C9E1D1086570028BE58 /* dec_neon.c in Sources */,
-				43DA7DE51D109B160028BE58 /* alpha_processing_sse2.c in Sources */,
-				431738BB1CDFC2630008FEB9 /* utils.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2709,6 +1080,7 @@
 /* Begin XCBuildConfiguration section */
 		00733A511BC487C100A5A117 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BEC1EC961E40007E443 /* Pods-SDWebImage TV Demo.debug.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2724,6 +1096,9 @@
 				INFOPLIST_FILE = WebImage/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "$(inherited)";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).tvos";
 				PRODUCT_NAME = SDWebImage;
 				SDKROOT = appletvos;
@@ -2738,6 +1113,7 @@
 		};
 		00733A521BC487C100A5A117 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BED1EC961E40007E443 /* Pods-SDWebImage TV Demo.release.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				COPY_PHASE_STRIP = NO;
@@ -2754,6 +1130,9 @@
 				INFOPLIST_FILE = WebImage/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "$(inherited)";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).tvos";
 				PRODUCT_NAME = SDWebImage;
 				SDKROOT = appletvos;
@@ -2767,11 +1146,15 @@
 		};
 		4314D1971D0E0E3B004B36C9 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BEE1EC961E40007E443 /* Pods-SDWebImage Watch Demo Extension.debug.xcconfig */;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"WEBP_USE_INTRINSICS=1",
 					"$(inherited)",
 				);
+				OTHER_LDFLAGS = "-ObjC";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/SDWebImage;
 				SDKROOT = watchos;
@@ -2782,11 +1165,15 @@
 		};
 		4314D1981D0E0E3B004B36C9 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BEF1EC961E40007E443 /* Pods-SDWebImage Watch Demo Extension.release.xcconfig */;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"WEBP_USE_INTRINSICS=1",
 					"$(inherited)",
 				);
+				OTHER_LDFLAGS = "-ObjC";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/SDWebImage;
 				SDKROOT = watchos;
@@ -2797,6 +1184,7 @@
 		};
 		431BB7011D06D2C1006A3455 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BF01EC961E40007E443 /* Pods-SDWebImage Watch Demo.debug.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -2814,7 +1202,14 @@
 				);
 				INFOPLIST_FILE = WebImage/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-watchos/libwebp-watchOS",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "$(inherited)";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).watchos";
 				PRODUCT_NAME = SDWebImage;
 				SDKROOT = watchos;
@@ -2829,6 +1224,7 @@
 		};
 		431BB7021D06D2C1006A3455 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BF11EC961E40007E443 /* Pods-SDWebImage Watch Demo.release.xcconfig */;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				COPY_PHASE_STRIP = NO;
@@ -2847,7 +1243,14 @@
 				);
 				INFOPLIST_FILE = WebImage/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/build/Debug-watchos/libwebp-watchOS",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "$(inherited)";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).watchos";
 				PRODUCT_NAME = SDWebImage;
 				SDKROOT = watchos;
@@ -2861,6 +1264,7 @@
 		};
 		4397D2F01D0DDD8C00BB2784 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BEA1EC961E40007E443 /* Pods-SDWebImage OSX Demo.debug.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -2874,6 +1278,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "$(inherited)";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).ios";
 				PRODUCT_NAME = SDWebImage;
 				SDKROOT = macosx;
@@ -2882,6 +1289,7 @@
 		};
 		4397D2F11D0DDD8C00BB2784 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BEB1EC961E40007E443 /* Pods-SDWebImage OSX Demo.release.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -2895,6 +1303,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "$(inherited)";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).ios";
 				PRODUCT_NAME = SDWebImage;
 				SDKROOT = macosx;
@@ -2903,6 +1314,7 @@
 		};
 		4A2CAE131AB4BB5400B6BC39 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BF21EC961E40007E443 /* Pods-SDWebImage iOS Demo.debug.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2912,10 +1324,16 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = WebImage/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).ios";
 				PRODUCT_NAME = SDWebImage;
 				SDKROOT = iphoneos;
@@ -2925,6 +1343,7 @@
 		};
 		4A2CAE141AB4BB5400B6BC39 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BF31EC961E40007E443 /* Pods-SDWebImage iOS Demo.release.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -2934,10 +1353,16 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = WebImage/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).ios";
 				PRODUCT_NAME = SDWebImage;
 				SDKROOT = iphoneos;
@@ -2947,9 +1372,16 @@
 		};
 		53761323155AD0D5005750A4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BF21EC961E40007E443 /* Pods-SDWebImage iOS Demo.debug.xcconfig */;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/SDWebImage;
 				SDKROOT = iphoneos;
@@ -2959,8 +1391,14 @@
 		};
 		53761324155AD0D5005750A4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB977BF31EC961E40007E443 /* Pods-SDWebImage iOS Demo.release.xcconfig */;
 			buildSettings = {
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PODS_PODFILE_DIR_PATH = "${SRCROOT}";
+				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PUBLIC_HEADERS_FOLDER_PATH = include/SDWebImage;
 				SDKROOT = iphoneos;
@@ -2993,10 +1431,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)\"",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -3022,7 +1457,8 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = Vendors/libwebp/src;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -3054,10 +1490,7 @@
 				COPY_PHASE_STRIP = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)\"",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -3079,7 +1512,8 @@
 				GCC_WARN_UNUSED_LABEL = YES;
 				GCC_WARN_UNUSED_PARAMETER = NO;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = Vendors/libwebp/src;
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SKIP_INSTALL = YES;

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage OSX.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,6 +29,15 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4397D2761D0DDD8C00BB2784"
+            BuildableName = "SDWebImage.framework"
+            BlueprintName = "SDWebImage OSX"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS static.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS static.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,6 +29,15 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "53761307155AD0D5005750A4"
+            BuildableName = "libSDWebImage iOS static.a"
+            BlueprintName = "SDWebImage iOS static"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -60,6 +69,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "53761307155AD0D5005750A4"
+            BuildableName = "libSDWebImage iOS static.a"
+            BlueprintName = "SDWebImage iOS static"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,6 +29,15 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A2CADFE1AB4BB5300B6BC39"
+            BuildableName = "SDWebImage.framework"
+            BlueprintName = "SDWebImage iOS"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage tvOS.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,6 +29,15 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "00733A4B1BC487C000A5A117"
+            BuildableName = "SDWebImage.framework"
+            BlueprintName = "SDWebImage tvOS"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage watchOS static.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage watchOS static.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage watchOS.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,6 +29,15 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "431BB6891D06D2C1006A3455"
+            BuildableName = "SDWebImage.framework"
+            BlueprintName = "SDWebImage watchOS"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/SDWebImage.xcworkspace/contents.xcworkspacedata
+++ b/SDWebImage.xcworkspace/contents.xcworkspacedata
@@ -23,6 +23,6 @@
       location = "group:Docs">
    </FileRef>
    <FileRef
-      location = "group:Tests/Pods/Pods.xcodeproj">
+      location = "group:Pods/Pods.xcodeproj">
    </FileRef>
 </Workspace>

--- a/SDWebImage.xcworkspace/xcshareddata/xcschemes/Demo iOS.xcscheme
+++ b/SDWebImage.xcworkspace/xcshareddata/xcschemes/Demo iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "43A629CE1D0DFD000089D7DD"
-               BuildableName = "SDWebImage OSX Demo.app"
-               BlueprintName = "SDWebImage OSX Demo"
-               ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
+               BlueprintIdentifier = "53761294155AB74D005750A4"
+               BuildableName = "SDWebImage iOS Demo.app"
+               BlueprintName = "SDWebImage iOS Demo"
+               ReferencedContainer = "container:Examples/SDWebImage Demo.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -32,10 +32,10 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "43A629CE1D0DFD000089D7DD"
-            BuildableName = "SDWebImage OSX Demo.app"
-            BlueprintName = "SDWebImage OSX Demo"
-            ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
+            BlueprintIdentifier = "53761294155AB74D005750A4"
+            BuildableName = "SDWebImage iOS Demo.app"
+            BlueprintName = "SDWebImage iOS Demo"
+            ReferencedContainer = "container:Examples/SDWebImage Demo.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
@@ -55,10 +55,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "43A629CE1D0DFD000089D7DD"
-            BuildableName = "SDWebImage OSX Demo.app"
-            BlueprintName = "SDWebImage OSX Demo"
-            ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
+            BlueprintIdentifier = "53761294155AB74D005750A4"
+            BuildableName = "SDWebImage iOS Demo.app"
+            BlueprintName = "SDWebImage iOS Demo"
+            ReferencedContainer = "container:Examples/SDWebImage Demo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <EnvironmentVariables>
@@ -81,10 +81,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "43A629CE1D0DFD000089D7DD"
-            BuildableName = "SDWebImage OSX Demo.app"
-            BlueprintName = "SDWebImage OSX Demo"
-            ReferencedContainer = "container:SDWebImage Demo.xcodeproj">
+            BlueprintIdentifier = "53761294155AB74D005750A4"
+            BuildableName = "SDWebImage iOS Demo.app"
+            BlueprintName = "SDWebImage iOS Demo"
+            ReferencedContainer = "container:Examples/SDWebImage Demo.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/SDWebImage/UIImage+WebP.m
+++ b/SDWebImage/UIImage+WebP.m
@@ -9,9 +9,9 @@
 #ifdef SD_WEBP
 
 #import "UIImage+WebP.h"
-#import "webp/decode.h"
-#import "webp/mux_types.h"
-#import "webp/demux.h"
+#import <libwebp/webp/decode.h>
+#import <libwebp/webp/mux_types.h>
+#import <libwebp/webp/demux.h>
 #import "NSImage+WebCache.h"
 
 // Callback for CGDataProviderRelease

--- a/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
+++ b/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
@@ -15,8 +15,8 @@
 		4369C1D11D97F80F007E863A /* SDWebImagePrefetcherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4369C1D01D97F80F007E863A /* SDWebImagePrefetcherTests.m */; };
 		4369C2741D9804B1007E863A /* SDCategoriesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4369C2731D9804B1007E863A /* SDCategoriesTests.m */; };
 		43828A451DA67F9900000E62 /* TestImageLarge.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 43828A441DA67F9900000E62 /* TestImageLarge.jpg */; };
-		53F0240D24D359127872F512 /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DAAA77E3CA7387F702040D9 /* Pods_Tests.framework */; };
 		5F7F38AD1AE2A77A00B0E330 /* TestImage.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 5F7F38AC1AE2A77A00B0E330 /* TestImage.jpg */; };
+		C99DE3434DB5443DC3EC84D1 /* libPods-Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 547FDDF84641B362BFB13A1D /* libPods-Tests.a */; };
 		DA248D57195472AA00390AB0 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA248D56195472AA00390AB0 /* XCTest.framework */; };
 		DA248D59195472AA00390AB0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA248D58195472AA00390AB0 /* Foundation.framework */; };
 		DA248D5B195472AA00390AB0 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA248D5A195472AA00390AB0 /* UIKit.framework */; };
@@ -27,8 +27,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		1DAAA77E3CA7387F702040D9 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E3C51E819B46E370092B5E6 /* SDWebImageDownloaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDownloaderTests.m; sourceTree = "<group>"; };
+		3D59535B8624FCFEF846536D /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		433BBBB41D7EF5C00086B6E9 /* SDWebImageDecoderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDecoderTests.m; sourceTree = "<group>"; };
 		433BBBB61D7EF8200086B6E9 /* TestImage.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = TestImage.gif; sourceTree = "<group>"; };
 		433BBBB81D7EF8260086B6E9 /* TestImage.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TestImage.png; sourceTree = "<group>"; };
@@ -36,9 +36,8 @@
 		4369C1D01D97F80F007E863A /* SDWebImagePrefetcherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImagePrefetcherTests.m; sourceTree = "<group>"; };
 		4369C2731D9804B1007E863A /* SDCategoriesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDCategoriesTests.m; sourceTree = "<group>"; };
 		43828A441DA67F9900000E62 /* TestImageLarge.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = TestImageLarge.jpg; sourceTree = "<group>"; };
+		547FDDF84641B362BFB13A1D /* libPods-Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F7F38AC1AE2A77A00B0E330 /* TestImage.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = TestImage.jpg; sourceTree = "<group>"; };
-		700B00151041D7EE118B1ABD /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		A0085854E7D88C98F2F6C9FC /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		DA248D53195472AA00390AB0 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA248D56195472AA00390AB0 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		DA248D58195472AA00390AB0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -49,6 +48,7 @@
 		DA248D68195475D800390AB0 /* SDImageCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDImageCacheTests.m; sourceTree = "<group>"; };
 		DA248D6A195476AC00390AB0 /* SDWebImageManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageManagerTests.m; sourceTree = "<group>"; };
 		DA91BEBB19795BC9006F2536 /* UIImageMultiFormatTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIImageMultiFormatTests.m; sourceTree = "<group>"; };
+		DCC631661A608D276C0A602A /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,18 +59,18 @@
 				DA248D57195472AA00390AB0 /* XCTest.framework in Frameworks */,
 				DA248D5B195472AA00390AB0 /* UIKit.framework in Frameworks */,
 				DA248D59195472AA00390AB0 /* Foundation.framework in Frameworks */,
-				53F0240D24D359127872F512 /* Pods_Tests.framework in Frameworks */,
+				C99DE3434DB5443DC3EC84D1 /* libPods-Tests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		3E8D7663CD326C6F44B23889 /* Pods */ = {
+		A093FFEEF26E56FC328BEDC7 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				700B00151041D7EE118B1ABD /* Pods-Tests.debug.xcconfig */,
-				A0085854E7D88C98F2F6C9FC /* Pods-Tests.release.xcconfig */,
+				DCC631661A608D276C0A602A /* Pods-Tests.debug.xcconfig */,
+				3D59535B8624FCFEF846536D /* Pods-Tests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -81,7 +81,7 @@
 				DA248D5C195472AA00390AB0 /* Tests */,
 				DA248D55195472AA00390AB0 /* Frameworks */,
 				DA248D54195472AA00390AB0 /* Products */,
-				3E8D7663CD326C6F44B23889 /* Pods */,
+				A093FFEEF26E56FC328BEDC7 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -99,7 +99,7 @@
 				DA248D56195472AA00390AB0 /* XCTest.framework */,
 				DA248D58195472AA00390AB0 /* Foundation.framework */,
 				DA248D5A195472AA00390AB0 /* UIKit.framework */,
-				1DAAA77E3CA7387F702040D9 /* Pods_Tests.framework */,
+				547FDDF84641B362BFB13A1D /* libPods-Tests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -141,7 +141,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA248D67195472AA00390AB0 /* Build configuration list for PBXNativeTarget "Tests" */;
 			buildPhases = (
-				09522B7196293172D6408744 /* [CP] Check Pods Manifest.lock */,
+				BBC8A6691D62E72C72FE2A96 /* [CP] Check Pods Manifest.lock */,
 				DA248D4F195472AA00390AB0 /* Sources */,
 				DA248D50195472AA00390AB0 /* Frameworks */,
 				DA248D51195472AA00390AB0 /* Resources */,
@@ -199,21 +199,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		09522B7196293172D6408744 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
 		85E5D3885A03BFC23B050908 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -226,7 +211,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-Tests/Pods-Tests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BBC8A6691D62E72C72FE2A96 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		C86216497B5A0BA9501E2C07 /* [CP] Embed Pods Frameworks */ = {
@@ -241,7 +241,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-Tests/Pods-Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -327,12 +327,13 @@
 		};
 		DA248D65195472AA00390AB0 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 700B00151041D7EE118B1ABD /* Pods-Tests.debug.xcconfig */;
+			baseConfigurationReference = DCC631661A608D276C0A602A /* Pods-Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -361,6 +362,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.SDWebImage.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -370,12 +372,13 @@
 		};
 		DA248D66195472AA00390AB0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A0085854E7D88C98F2F6C9FC /* Pods-Tests.release.xcconfig */;
+			baseConfigurationReference = 3D59535B8624FCFEF846536D /* Pods-Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -397,6 +400,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
+				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.SDWebImage.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Tests/SDWebImage Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Tests/SDWebImage Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -17,8 +17,7 @@
 #import <SDWebImage/MKAnnotationView+WebCache.h>
 #import <SDWebImage/UIButton+WebCache.h>
 #import <SDWebImage/FLAnimatedImageView+WebCache.h>
-
-@import FLAnimatedImage;
+#import <FLAnimatedImage/FLAnimatedImageView.h>
 
 @interface SDCategoriesTests : XCTestCase
 

--- a/Vendors/libwebp.podspec.json
+++ b/Vendors/libwebp.podspec.json
@@ -1,0 +1,94 @@
+{
+  "name": "libwebp",
+  "version": "0.6.0",
+  "summary": "Library to encode and decode images in WebP format.",
+  "homepage": "https://developers.google.com/speed/webp/",
+  "authors": "Google Inc.",
+  "license": {
+    "type": "BSD",
+    "file": "COPYING"
+  },
+  "source": {
+    "git": "https://chromium.googlesource.com/webm/libwebp",
+    "tag": "v0.6.0"
+  },
+  "compiler_flags": "-D_THREAD_SAFE",
+  "requires_arc": false,
+  "platforms": {
+    "osx": null,
+    "ios": null,
+    "tvos": null,
+    "watchos": null
+  },
+  "subspecs": [
+    {
+      "name": "webp",
+      "header_dir": "webp",
+      "source_files": "src/webp/*.h"
+    },
+    {
+      "name": "core",
+      "source_files": [
+        "src/utils/*.{h,c}",
+        "src/dsp/*.{h,c}",
+        "src/enc/*.{h,c}",
+        "src/dec/*.{h,c}"
+      ],
+      "dependencies": {
+        "libwebp/webp": [
+
+        ]
+      }
+    },
+    {
+      "name": "utils",
+      "dependencies": {
+        "libwebp/core": [
+
+        ]
+      }
+    },
+    {
+      "name": "dsp",
+      "dependencies": {
+        "libwebp/core": [
+
+        ]
+      }
+    },
+    {
+      "name": "enc",
+      "dependencies": {
+        "libwebp/core": [
+
+        ]
+      }
+    },
+    {
+      "name": "dec",
+      "dependencies": {
+        "libwebp/core": [
+
+        ]
+      }
+    },
+    {
+      "name": "demux",
+      "source_files": "src/demux/*.{h,c}",
+      "dependencies": {
+        "libwebp/core": [
+
+        ]
+      }
+    },
+    {
+      "name": "mux",
+      "source_files": "src/mux/*.{h,c}",
+      "dependencies": {
+        "libwebp/core": [
+
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Update libwebp to v0.6.0
- Fix import header fail (Fix #1887)
- Use cocoapods to manage the libwebp and FLAnimatedImage

Please run `pod install`, and open `SDWebImage.xcworkspace`.

Now, The Demo,  Framework and Tests will work fine, except the watch framework.

The FLAnimatedImage's podspec said it support iOS only, not support watchos and other platform. So I can not install FLAnimatedImage in these targets.