### PR TITLE
#1909: Crash on multiple concurrent downloads when accessing self.URLOperations dictionary

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -230,11 +230,13 @@
 
             __weak SDWebImageDownloaderOperation *woperation = operation;
             operation.completionBlock = ^{
-              SDWebImageDownloaderOperation *soperation = woperation;
-              if (!soperation) return;
-              if (self.URLOperations[url] == soperation) {
-                  [self.URLOperations removeObjectForKey:url];
-              };
+				dispatch_barrier_sync(self.barrierQueue, ^{
+					SDWebImageDownloaderOperation *soperation = woperation;
+					if (!soperation) return;
+					if (self.URLOperations[url] == soperation) {
+						[self.URLOperations removeObjectForKey:url];
+					};
+				});
             };
         }
         id downloadOperationCancelToken = [operation addHandlersForProgress:progressBlock completed:completedBlock];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

...

Added barrier before accessing `self.URLOperations` in `SDWebImageDownloaderOperation.completionHandler`