### PR TITLE
#1951: Fix animated WebP decoding issue, including canvas size, the support for dispose method and the duration per frame

### DIFF
--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -8,6 +8,8 @@
 
 #import "SDWebImageCompat.h"
 
+#import "objc/runtime.h"
+
 #if !__has_feature(objc_arc)
 #error SDWebImage is ARC only. Either turn on ARC for the project or use -fobjc-arc flag
 #endif
@@ -26,8 +28,18 @@ inline UIImage *SDScaledImageForKey(NSString * _Nullable key, UIImage * _Nullabl
         for (UIImage *tempImage in image.images) {
             [scaledImages addObject:SDScaledImageForKey(key, tempImage)];
         }
-
-        return [UIImage animatedImageWithImages:scaledImages duration:image.duration];
+        UIImage *animatedImage = [UIImage animatedImageWithImages:scaledImages duration:image.duration];
+#ifdef SD_WEBP
+        if (animatedImage) {
+            SEL sd_webpLoopCount = NSSelectorFromString(@"sd_webpLoopCount");
+            NSNumber *value = objc_getAssociatedObject(image, sd_webpLoopCount);
+            NSInteger loopCount = value.integerValue;
+            if (loopCount) {
+                objc_setAssociatedObject(animatedImage, sd_webpLoopCount, @(loopCount), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+            }
+        }
+#endif
+        return animatedImage;
     }
     else {
 #if SD_WATCH

--- a/SDWebImage/UIImage+WebP.h
+++ b/SDWebImage/UIImage+WebP.h
@@ -12,6 +12,16 @@
 
 @interface UIImage (WebP)
 
+/**
+ * Get the current WebP image loop count, the default value is 0.
+ * For static WebP image, the value is 0.
+ * For animated WebP image, 0 means repeat the animation indefinitely.
+ * Note that because of the limitations of categories this property can get out of sync
+ * if you create another instance with CGImage or other methods.
+ * @return WebP image loop count
+ */
+- (NSInteger)sd_webpLoopCount;
+
 + (nullable UIImage *)sd_imageWithWebPData:(nullable NSData *)data;
 
 @end

--- a/SDWebImage/UIImage+WebP.m
+++ b/SDWebImage/UIImage+WebP.m
@@ -58,8 +58,10 @@ static void FreeImageData(void *info, const void *data, size_t size) {
         return nil;
     }
     
-    int frameCount = WebPDemuxGetI(demuxer, WEBP_FF_FRAME_COUNT);
+#if SD_UIKIT || SD_WATCH
     int loopCount = WebPDemuxGetI(demuxer, WEBP_FF_LOOP_COUNT);
+#endif
+    int frameCount = WebPDemuxGetI(demuxer, WEBP_FF_FRAME_COUNT);
     int canvasWidth = WebPDemuxGetI(demuxer, WEBP_FF_CANVAS_WIDTH);
     int canvasHeight = WebPDemuxGetI(demuxer, WEBP_FF_CANVAS_HEIGHT);
     CGBitmapInfo bitmapInfo;
@@ -69,6 +71,11 @@ static void FreeImageData(void *info, const void *data, size_t size) {
         bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast;
     }
     CGContextRef canvas = CGBitmapContextCreate(NULL, canvasWidth, canvasHeight, 8, 0, SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
+    if (!canvas) {
+        WebPDemuxReleaseIterator(&iter);
+        WebPDemuxDelete(demuxer);
+        return nil;
+    }
     
     NSMutableArray<UIImage *> *images = [NSMutableArray array];
     NSTimeInterval totalDuration = 0;
@@ -87,17 +94,20 @@ static void FreeImageData(void *info, const void *data, size_t size) {
         }
         
         [images addObject:image];
+        
+#if SD_MAC
+        break;
+#endif
+        
         int duration = iter.duration;
-        if (!duration) {
-            // WebP standard says duration for 0 is used for canvas updating but not showing image, but actually Chrome set this to the default 100ms duration.
-            // Some animated WebP images also create without duration, we should keep compatibility
+        if (duration <= 10) {
+            // WebP standard says 0 duration is used for canvas updating but not showing image, but actually Chrome and other implementations set it to 100ms if duration is lower or equal than 10ms
+            // Some animated WebP images also created without duration, we should keep compatibility
             duration = 100;
         }
         totalDuration += duration;
         size_t count = images.count;
-        if (count) {
-            durations[count - 1] = duration;
-        }
+        durations[count - 1] = duration;
         
     } while (WebPDemuxNextFrame(&iter));
     
@@ -143,9 +153,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     
     CGImageRelease(newImageRef);
     
-    if (iter.dispose_method == WEBP_MUX_DISPOSE_NONE) {
-        // do not dispose
-    } else {
+    if (iter.dispose_method == WEBP_MUX_DISPOSE_BACKGROUND) {
         CGContextClearRect(canvas, imageRect);
     }
     
@@ -177,9 +185,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     
     CGImageRelease(newImageRef);
     
-    if (iter.dispose_method == WEBP_MUX_DISPOSE_NONE) {
-        // do not dispose
-    } else {
+    if (iter.dispose_method == WEBP_MUX_DISPOSE_BACKGROUND) {
         CGContextClearRect(canvas, imageRect);
     }
     
@@ -199,7 +205,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     config.output.colorspace = config.input.has_alpha ? MODE_rgbA : MODE_RGB;
     config.options.use_threads = 1;
 
-    // Decode the WebP image data into a RGBA value array.
+    // Decode the WebP image data into a RGBA value array
     if (WebPDecode(webpData.bytes, webpData.size, &config) != VP8_STATUS_OK) {
         return nil;
     }
@@ -211,7 +217,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
         height = config.options.scaled_height;
     }
 
-    // Construct a UIImage from the decoded RGBA value array.
+    // Construct a UIImage from the decoded RGBA value array
     CGDataProviderRef provider =
     CGDataProviderCreateWithData(NULL, config.output.u.RGBA.rgba, config.output.u.RGBA.size, FreeImageData);
     CGColorSpaceRef colorSpaceRef = SDCGColorSpaceGetDeviceRGB();

--- a/Tests/Tests/UIImageMultiFormatTests.m
+++ b/Tests/Tests/UIImageMultiFormatTests.m
@@ -22,12 +22,41 @@
 
 @implementation UIImageMultiFormatTests
 
-- (void)testImageOrientationFromImageDataWithInvalidData {
+- (void)test01ImageOrientationFromImageDataWithInvalidData {
     // sync download image
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
     SEL selector = @selector(sd_imageOrientationFromImageData:);
+#pragma clang diagnostic pop
     
-    UIImageOrientation orientation = [[UIImage class] performSelector:selector withObject:nil];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    UIImageOrientation orientation = (UIImageOrientation)[[UIImage class] performSelector:selector withObject:nil];
+#pragma clang diagnostic pop
     expect(orientation).to.equal(UIImageOrientationUp);
+}
+
+- (void)test02AnimatedWebPImageArrayWithEqualSizeAndScale {
+    NSURL *webpURL = [NSURL URLWithString:@"https://isparta.github.io/compare-webp/image/gif_webp/webp/2.webp"];
+    NSData *data = [NSData dataWithContentsOfURL:webpURL];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+    SEL selector = @selector(sd_imageWithWebPData:);
+#pragma clang diagnostic pop
+    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    UIImage *animatedImage = [[UIImage class] performSelector:selector withObject:data];
+#pragma clang diagnostic pop
+    CGSize imageSize = animatedImage.size;
+    CGFloat imageScale = animatedImage.scale;
+    [animatedImage.images enumerateObjectsUsingBlock:^(UIImage * _Nonnull image, NSUInteger idx, BOOL * _Nonnull stop) {
+        CGSize size = image.size;
+        CGFloat scale = image.scale;
+        expect(imageSize.width).to.equal(size.width);
+        expect(imageSize.height).to.equal(size.height);
+        expect(imageScale).to.equal(scale);
+    }];
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [X] I have added the required tests to prove the fix/feature I am adding - add an new test for ensure animated image array share the same size
* [x] I have updated the documentation (if necessary) - added `sd_webpLoopCount`(UIImage+WebP.h)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

SDWebImage 4.0 add support for animated WebP images. And the UIImage+WebP category use `+[UIImage animatedImageWithImages:duration:]` to create animated image. 

Fixed Bugs:
1. While decoding animated WebP image, for each frame, you need to draw the frame image on the canvas. The older version just use `sd_rawWepImageWithData` to draw, but the `config.input.width/height` for this frame does not refer the total image size, it refer to this frame's canvas size(can be smaller than image size). So finally this will lead the final UIImage array (which is used to build animated image) have different size, cause UIImage render strange.

2. CGBitmapInfo should not use 0 for non-alpha channel, you should explicit assign it to kCGImageAlphaNoneSkipLast (with the byte-order bit kCGBitmapByteOrder32Big)

3. The older version animated WeP decoding does not concentrate any [diposal method](https://developers.google.com/speed/webp/docs/riff_container#animation). Which will cause animated WebP images render issue for many images. To fix this, I add a CGBitmapContext before the loop and share it and draw the frames. For each frame, it will clear the frame rect in context only when the background diposal method.

4. `+[UIImage animatedImageWithImages:duration:]` just use the average duration for each frame, which is not the animated WebP standard. Animated WebP can has different duration per frame. Therefore, I divide the total duration and add image item multiple times to solve this issue.

Known Issues:
1. Currently all the animated WebP showing animation infinity. To solve this, we can get the loop count and set UIImageView's `animationRepeatCount` property. But UIImageView need use this property with both `animationImages` and `animationDuration`. Only set `image` with an animated UIImage and `animationDuration` will not work. However sometimes auto-set this property may break user code. So I just add an new property called `sd_webpLoopCount` at `UIImage+WebP.h` to get the loop count from WebP data. For nil or static WebP, the default value is 0, otherwise it should become animated WebP loop count.