### PR TITLE
support animated GIF on macOS

### DIFF
--- a/Examples/SDWebImage OSX Demo/ViewController.m
+++ b/Examples/SDWebImage OSX Demo/ViewController.m
@@ -27,6 +27,8 @@
     // NOTE: https links or authentication ones do not work (there is a crash)
     
 //     Do any additional setup after loading the view.
+    // For animated GIF rendering, set `animates` to YES or will only show the first frame
+    self.imageView1.animates = YES;
     [self.imageView1 sd_setImageWithURL:[NSURL URLWithString:@"http://assets.sbnation.com/assets/2512203/dogflops.gif"]];
     [self.imageView2 sd_setImageWithURL:[NSURL URLWithString:@"http://www.ioncannon.net/wp-content/uploads/2011/06/test2.webp"]];
     [self.imageView3 sd_setImageWithURL:[NSURL URLWithString:@"http://littlesvr.ca/apng/images/SteamEngine.webp"]];

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ imageView.sd_setImage(with: URL(string: "http://www.domain.com/path/to/image.jpg
 - If you use cocoapods, add `pod 'SDWebImage/GIF'` to your podfile.
 - To use it, simply make sure you use `FLAnimatedImageView` instead of `UIImageView`.
 - **Note**: there is a backwards compatible feature, so if you are still trying to load a GIF into a `UIImageView`, it will only show the 1st frame as a static image.
-- **Important**: FLAnimatedImage only works on the iOS platform, so for all the other platforms (OS X, tvOS, watchOS) we will fallback to the backwards compatibility feature described above 
+- **Important**: FLAnimatedImage only works on the iOS platform. For OS X, use `NSImageView` with `animates` set to `YES` to show the entire animated images and `NO` to only show the 1st frame. For all the other platforms (tvOS, watchOS) we will fallback to the backwards compatibility feature described above 
 
 ## Common Problems
 

--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -18,6 +18,10 @@
     if (!data) {
         return nil;
     }
+    
+#if SD_MAC
+    return [[UIImage alloc] initWithData:data];
+#endif
 
     CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
 
@@ -42,8 +46,6 @@
 #if SD_UIKIT || SD_WATCH
         UIImage *frameImage = [UIImage imageWithCGImage:CGImage scale:scale orientation:UIImageOrientationUp];
         staticImage = [UIImage animatedImageWithImages:@[frameImage] duration:0.0f];
-#elif SD_MAC
-        staticImage = [[UIImage alloc] initWithCGImage:CGImage size:NSZeroSize];
 #endif
         CGImageRelease(CGImage);
     }


### PR DESCRIPTION
macOS provide animated GIF support for built-in NSImageView and can use FLAnimatedImageView

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

SDWebImage 4.0-core drop the animated GIF support and use `FLAnimatedImageView` to take care of GIF. But actually macOS has a well built-in support for GIF and it's really easy to use. So it's no need to only show the first frame on macOS. Instead, use the built-in NSImage to maintain and render on NSImageView.

Fix:
When loading GIF images on macOS, showing the entire animated GIF images on NSImageView if you set `NSImageView.animates`=YES or only show the first frame of GIF images if you set `NSImageView.animates`=NO
