### PR TITLE
Fix CGBitmapContextCreate bitmap memory leak issue

### DIFF
--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -115,16 +115,10 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         
         size_t bytesPerRow = kBytesPerPixel * destResolution.width;
         
-        // Allocate enough pixel data to hold the output image.
-        void* destBitmapData = malloc( bytesPerRow * destResolution.height );
-        if (destBitmapData == NULL) {
-            return image;
-        }
-        
         // kCGImageAlphaNone is not supported in CGBitmapContextCreate.
         // Since the original image here has no alpha info, use kCGImageAlphaNoneSkipLast
         // to create bitmap graphics contexts without alpha info.
-        destContext = CGBitmapContextCreate(destBitmapData,
+        destContext = CGBitmapContextCreate(NULL,
                                             destResolution.width,
                                             destResolution.height,
                                             kBitsPerComponent,
@@ -133,7 +127,6 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
                                             kCGBitmapByteOrderDefault|kCGImageAlphaNoneSkipLast);
         
         if (destContext == NULL) {
-            free(destBitmapData);
             return image;
         }
         CGContextSetInterpolationQuality(destContext, kCGInterpolationHigh);


### PR DESCRIPTION
Pass NULL to CGBitmapContextCreate whenever the data param is not used later to reduce memory leak issue

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

As Apple Docs says for `CGBitmapContextCreate` first param `data`:

> A pointer to the destination in memory where the drawing is to be rendered. The size of this memory block should be at least (bytesPerRow*height) bytes.
> 
> Pass NULL if you want this function to allocate memory for the bitmap. This frees you from managing your own memory, which reduces memory leak issues.

Here if `CGBitmapContextCreate` success,  `destBitmapData` will contains the bitmap vector. But it not used in later procedure and not been released after line:197 `CGContextRelease(destContext)` (You need call `free(destBitmapData)`). It's better to follow that guide and just pat NULL to let Core Graphics automatically alloc and free bitmap data.

