### PR TITLE
Fix CFRelease on NULL if CGImageSourceRef create failed

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -376,7 +376,9 @@ didReceiveResponse:(NSURLResponse *)response
             }
         }
 
-        CFRelease(imageSource);
+        if (imageSource) {
+            CFRelease(imageSource);
+        }
     }
 
     for (SDWebImageDownloaderProgressBlock progressBlock in [self callbacksForKey:kProgressCallbackKey]) {


### PR DESCRIPTION
Fix CFRelease on NULL if CGImageSourceRef create failed, this may happen on progressive download with wrong image data

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Fix CFRelease on NULL if the CGImageSourceRef create failed.
This may happen if you use progressive download and the imagedata can't be decoded to image data. The previous version only check `CGImageSourceCreateImageAtIndex` and `CGImageSourceCopyPropertiesAtIndex` but forget CFRelease need called on nonnull CFTypeRef

