### PR TITLE
Move common test logic to SDTestCase

### DIFF
--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -107,5 +107,3 @@ FOUNDATION_EXPORT NSString *const SDWebImageErrorDomain;
         dispatch_async(dispatch_get_main_queue(), block);\
     }
 #endif
-
-static int64_t kAsyncTestTimeout = 5;

--- a/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
+++ b/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1E3C51E919B46E370092B5E6 /* SDWebImageDownloaderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E3C51E819B46E370092B5E6 /* SDWebImageDownloaderTests.m */; };
+		2D7AF0601F329763000083C2 /* SDTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D7AF05F1F329763000083C2 /* SDTestCase.m */; };
 		433BBBB51D7EF5C00086B6E9 /* SDWebImageDecoderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 433BBBB41D7EF5C00086B6E9 /* SDWebImageDecoderTests.m */; };
 		433BBBB71D7EF8200086B6E9 /* TestImage.gif in Resources */ = {isa = PBXBuildFile; fileRef = 433BBBB61D7EF8200086B6E9 /* TestImage.gif */; };
 		433BBBB91D7EF8260086B6E9 /* TestImage.png in Resources */ = {isa = PBXBuildFile; fileRef = 433BBBB81D7EF8260086B6E9 /* TestImage.png */; };
@@ -29,6 +30,8 @@
 /* Begin PBXFileReference section */
 		1DAAA77E3CA7387F702040D9 /* Pods_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E3C51E819B46E370092B5E6 /* SDWebImageDownloaderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDownloaderTests.m; sourceTree = "<group>"; };
+		2D7AF05E1F329763000083C2 /* SDTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDTestCase.h; sourceTree = "<group>"; };
+		2D7AF05F1F329763000083C2 /* SDTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDTestCase.m; sourceTree = "<group>"; };
 		433BBBB41D7EF5C00086B6E9 /* SDWebImageDecoderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDecoderTests.m; sourceTree = "<group>"; };
 		433BBBB61D7EF8200086B6E9 /* TestImage.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = TestImage.gif; sourceTree = "<group>"; };
 		433BBBB81D7EF8260086B6E9 /* TestImage.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TestImage.png; sourceTree = "<group>"; };
@@ -120,6 +123,8 @@
 				433BBBB41D7EF5C00086B6E9 /* SDWebImageDecoderTests.m */,
 				4369C1D01D97F80F007E863A /* SDWebImagePrefetcherTests.m */,
 				4369C2731D9804B1007E863A /* SDCategoriesTests.m */,
+				2D7AF05E1F329763000083C2 /* SDTestCase.h */,
+				2D7AF05F1F329763000083C2 /* SDTestCase.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -253,6 +258,7 @@
 			files = (
 				1E3C51E919B46E370092B5E6 /* SDWebImageDownloaderTests.m in Sources */,
 				4369C2741D9804B1007E863A /* SDCategoriesTests.m in Sources */,
+				2D7AF0601F329763000083C2 /* SDTestCase.m in Sources */,
 				4369C1D11D97F80F007E863A /* SDWebImagePrefetcherTests.m in Sources */,
 				DA248D69195475D800390AB0 /* SDImageCacheTests.m in Sources */,
 				DA248D6B195476AC00390AB0 /* SDWebImageManagerTests.m in Sources */,

--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -7,11 +7,7 @@
  * file that was distributed with this source code.
  */
 
-#define EXP_SHORTHAND   // required by Expecta
-
-#import <XCTest/XCTest.h>
-#import <Expecta/Expecta.h>
-
+#import "SDTestCase.h"
 #import <SDWebImage/UIImageView+WebCache.h>
 #import <SDWebImage/UIImageView+HighlightedWebCache.h>
 #import <SDWebImage/MKAnnotationView+WebCache.h>
@@ -20,7 +16,7 @@
 
 @import FLAnimatedImage;
 
-@interface SDCategoriesTests : XCTestCase
+@interface SDCategoriesTests : SDTestCase
 
 @end
 
@@ -39,7 +35,7 @@
                             expect(imageView.image).to.equal(image);
                             [expectation fulfill];
                         }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testUIImageViewSetHighlightedImageWithURL {
@@ -55,7 +51,7 @@
                                        expect(imageView.highlightedImage).to.equal(image);
                                        [expectation fulfill];
                                    }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testMKAnnotationViewSetImageWithURL {
@@ -71,7 +67,7 @@
                                  expect(annotationView.image).to.equal(image);
                                  [expectation fulfill];
                              }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testUIButtonSetImageWithURLNormalState {
@@ -88,7 +84,7 @@
                          expect([button imageForState:UIControlStateNormal]).to.equal(image);
                          [expectation fulfill];
                      }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testUIButtonSetImageWithURLHighlightedState {
@@ -105,7 +101,7 @@
                          expect([button imageForState:UIControlStateHighlighted]).to.equal(image);
                          [expectation fulfill];
                      }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testUIButtonSetBackgroundImageWithURLNormalState {
@@ -122,7 +118,7 @@
                                    expect([button backgroundImageForState:UIControlStateNormal]).to.equal(image);
                                    [expectation fulfill];
                                }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)testFLAnimatedImageViewSetImageWithURL {
@@ -140,7 +136,7 @@
                             expect(imageView.animatedImage).toNot.beNil();
                             [expectation fulfill];
                                 }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 @end

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -6,17 +6,12 @@
  * file that was distributed with this source code.
  */
 
-#define EXP_SHORTHAND   // required by Expecta
-
-
-#import <XCTest/XCTest.h>
-#import <Expecta/Expecta.h>
-
+#import "SDTestCase.h"
 #import <SDWebImage/SDImageCache.h>
 
 NSString *kImageTestKey = @"TestImageKey.jpg";
 
-@interface SDImageCacheTests : XCTestCase
+@interface SDImageCacheTests : SDTestCase
 @property (strong, nonatomic) SDImageCache *sharedImageCache;
 @end
 
@@ -56,7 +51,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
         }];
         expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.equal([self imageForTesting]);
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test05ClearMemoryCache{
@@ -72,7 +67,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
             XCTFail(@"Image should be in cache");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 // Testing storeImage:forKey:
@@ -89,7 +84,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
             XCTFail(@"Image should be in cache");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 // Testing storeImage:forKey:toDisk:YES
@@ -106,7 +101,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
             XCTFail(@"Image should be in cache");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 // Testing storeImage:forKey:toDisk:NO
@@ -125,7 +120,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     }];
     [self.sharedImageCache clearMemory];
     expect([self.sharedImageCache imageFromMemoryCacheForKey:kImageTestKey]).to.beNil();
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test09RetrieveImageThroughNSOperation{

--- a/Tests/Tests/SDTestCase.h
+++ b/Tests/Tests/SDTestCase.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ * (c) Matt Galloway
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#define EXP_SHORTHAND   // required by Expecta
+
+
+#import <XCTest/XCTest.h>
+#import <Expecta/Expecta.h>
+
+extern const int64_t kAsyncTestTimeout;
+
+@interface SDTestCase : XCTestCase
+
+- (void)waitForExpectationsWithCommonTimeout;
+- (void)waitForExpectationsWithCommonTimeoutUsingHandler:(XCWaitCompletionHandler)handler;
+
+@end

--- a/Tests/Tests/SDTestCase.m
+++ b/Tests/Tests/SDTestCase.m
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ * (c) Matt Galloway
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDTestCase.h"
+
+const int64_t kAsyncTestTimeout = 5;
+
+@implementation SDTestCase
+
+- (void)waitForExpectationsWithCommonTimeout {
+    [self waitForExpectationsWithCommonTimeoutUsingHandler:nil];
+}
+
+- (void)waitForExpectationsWithCommonTimeoutUsingHandler:(XCWaitCompletionHandler)handler {
+    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:handler];
+}
+
+@end

--- a/Tests/Tests/SDWebImageDecoderTests.m
+++ b/Tests/Tests/SDWebImageDecoderTests.m
@@ -7,14 +7,10 @@
  * file that was distributed with this source code.
  */
 
-#define EXP_SHORTHAND   // required by Expecta
-
-
-#import <XCTest/XCTest.h>
-#import <Expecta/Expecta.h>
+#import "SDTestCase.h"
 #import <SDWebImage/SDWebImageDecoder.h>
 
-@interface SDWebImageDecoderTests : XCTestCase
+@interface SDWebImageDecoderTests : SDTestCase
 
 @end
 

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -7,12 +7,7 @@
  * file that was distributed with this source code.
  */
 
-#define EXP_SHORTHAND   // required by Expecta
-
-
-#import <XCTest/XCTest.h>
-#import <Expecta/Expecta.h>
-
+#import "SDTestCase.h"
 #import <SDWebImage/SDWebImageDownloader.h>
 #import <SDWebImage/SDWebImageDownloaderOperation.h>
 
@@ -55,7 +50,7 @@
 
 
 
-@interface SDWebImageDownloaderTests : XCTestCase
+@interface SDWebImageDownloaderTests : SDTestCase
 
 @end
 
@@ -91,7 +86,7 @@
             XCTFail(@"Something went wrong");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test05ThatSetAndGetMaxConcurrentDownloadsWorks {
@@ -141,7 +136,7 @@
             XCTFail(@"Something went wrong");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
     [SDWebImageDownloader sharedDownloader].username = nil;
     [SDWebImageDownloader sharedDownloader].password = nil;
 }
@@ -158,7 +153,7 @@
             // progressive updates
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test10That404CaseCallsCompletionWithError {
@@ -172,7 +167,7 @@
             XCTFail(@"Something went wrong");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test11ThatCancelWorks {
@@ -193,7 +188,7 @@
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test12ThatWeCanUseAnotherSessionForEachDownloadOperation {
@@ -219,7 +214,7 @@
     
     [operation start];
     
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test13ThatDownloadCanContinueWhenTheAppEntersBackground {
@@ -232,7 +227,7 @@
             XCTFail(@"Something went wrong");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test14ThatPNGWorks {
@@ -245,7 +240,7 @@
             XCTFail(@"Something went wrong");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test15ThatWEBPWorks {
@@ -258,7 +253,7 @@
             XCTFail(@"Something went wrong");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 /**
@@ -296,7 +291,7 @@
 
     [[SDWebImageDownloader sharedDownloader] cancel:token1];
 
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 /**
@@ -335,7 +330,7 @@
                                        }];
     expect(token2).toNot.beNil();
     
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 @end

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -6,17 +6,12 @@
  * file that was distributed with this source code.
  */
 
-#define EXP_SHORTHAND   // required by Expecta
-
-
-#import <XCTest/XCTest.h>
-#import <Expecta/Expecta.h>
-
+#import "SDTestCase.h"
 #import <SDWebImage/SDWebImageManager.h>
 
 NSString *workingImageURL = @"http://s3.amazonaws.com/fast-image-cache/demo-images/FICDDemoImage001.jpg";
 
-@interface SDWebImageManagerTests : XCTestCase
+@interface SDWebImageManagerTests : SDTestCase
 
 @end
 
@@ -45,7 +40,7 @@ NSString *workingImageURL = @"http://s3.amazonaws.com/fast-image-cache/demo-imag
     }];
     expect([[SDWebImageManager sharedManager] isRunning]).to.equal(YES);
 
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test03ThatDownloadWithIncorrectURLInvokesCompletionBlockWithAnErrorAsync {
@@ -65,7 +60,7 @@ NSString *workingImageURL = @"http://s3.amazonaws.com/fast-image-cache/demo-imag
         expectation = nil;
     }];
     
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test04CachedImageExistsForURL {
@@ -91,7 +86,7 @@ NSString *workingImageURL = @"http://s3.amazonaws.com/fast-image-cache/demo-imag
             XCTFail(@"Image should be in cache");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test06CancellAll {
@@ -110,7 +105,7 @@ NSString *workingImageURL = @"http://s3.amazonaws.com/fast-image-cache/demo-imag
         [expectation fulfill];
     });
     
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 @end

--- a/Tests/Tests/SDWebImagePrefetcherTests.m
+++ b/Tests/Tests/SDWebImagePrefetcherTests.m
@@ -7,15 +7,10 @@
  * file that was distributed with this source code.
  */
 
-#define EXP_SHORTHAND   // required by Expecta
-
-
-#import <XCTest/XCTest.h>
-#import <Expecta/Expecta.h>
-
+#import "SDTestCase.h"
 #import <SDWebImage/SDWebImagePrefetcher.h>
 
-@interface SDWebImagePrefetcherTests : XCTestCase
+@interface SDWebImagePrefetcherTests : SDTestCase
 
 @end
 
@@ -51,7 +46,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test03PrefetchWithEmptyArrayWillCallTheCompletionWithAllZeros {
@@ -63,7 +58,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 // TODO: test the prefetcher delegate works

--- a/Tests/Tests/UIImageMultiFormatTests.m
+++ b/Tests/Tests/UIImageMultiFormatTests.m
@@ -6,16 +6,10 @@
  * file that was distributed with this source code.
  */
 
-#define EXP_SHORTHAND   // required by Expecta
-
-
-#import <XCTest/XCTest.h>
-#import <Expecta/Expecta.h>
-
+#import "SDTestCase.h"
 #import <SDWebImage/UIImage+MultiFormat.h>
 
-
-@interface UIImageMultiFormatTests : XCTestCase
+@interface UIImageMultiFormatTests : SDTestCase
 
 @end
 


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [X] I have added the required tests to prove the fix/feature I am adding
* [X] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

Let's make writing test cases easier. Besides `kAsyncTestTimeout` in `SDWebImageCompat.h` just feels wrong to me.