### PR TITLE
Fix SDWebImage v4 can not import libwebp framework's header files.

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -13,7 +13,7 @@
 #if __has_include(<FLAnimatedImage/FLAnimatedImage.h>)
 #import <FLAnimatedImage/FLAnimatedImage.h>
 #else
-#import "FLAnimatedImageView.h"
+#import "FLAnimatedImage.h"
 #endif
 
 #import "SDWebImageManager.h"

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -13,7 +13,6 @@
 #import "UIView+WebCacheOperation.h"
 #import "UIView+WebCache.h"
 #import "NSData+ImageContentType.h"
-#import "FLAnimatedImage.h"
 #import "UIImageView+WebCache.h"
 
 @implementation FLAnimatedImageView (WebCache)

--- a/SDWebImage/UIImage+WebP.m
+++ b/SDWebImage/UIImage+WebP.m
@@ -9,10 +9,17 @@
 #ifdef SD_WEBP
 
 #import "UIImage+WebP.h"
+#import "NSImage+WebCache.h"
+
+#if __has_include(<webp/decode.h>) && __has_include(<webp/mux_types.h>) && __has_include(<webp/demux.h>)
+#import <webp/decode.h>
+#import <webp/mux_types.h>
+#import <webp/demux.h>
+#else
 #import "webp/decode.h"
 #import "webp/mux_types.h"
 #import "webp/demux.h"
-#import "NSImage+WebCache.h"
+#endif
 
 #import "objc/runtime.h"
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1887 

### Pull Request Description

SD now import the source webp headers with local `"webp/xxx.h"` but not global `<webp/xxx.h>`, which cause the third party application can't import webp headers if they also manually install `libwebp` dependency by building it from source and add the framework to project. We can change the webp headers to "<>" to allow search global libwebp header files preferentially, then check project header files.

This also fix an header issue in `FLAnimatedImageView+WebCache`, it use an mixed import local and global headers in header file and source file.

