### PR TITLE
Fix unreachable code build warning on macOS

### DIFF
--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -21,7 +21,7 @@
     
 #if SD_MAC
     return [[UIImage alloc] initWithData:data];
-#endif
+#else
 
     CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
 
@@ -53,6 +53,7 @@
     CFRelease(source);
 
     return staticImage;
+#endif
 }
 
 - (BOOL)isGIF {

--- a/SDWebImage/UIImage+WebP.m
+++ b/SDWebImage/UIImage+WebP.m
@@ -60,8 +60,8 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     
 #if SD_UIKIT || SD_WATCH
     int loopCount = WebPDemuxGetI(demuxer, WEBP_FF_LOOP_COUNT);
-#endif
     int frameCount = WebPDemuxGetI(demuxer, WEBP_FF_FRAME_COUNT);
+#endif
     int canvasWidth = WebPDemuxGetI(demuxer, WEBP_FF_CANVAS_WIDTH);
     int canvasHeight = WebPDemuxGetI(demuxer, WEBP_FF_CANVAS_HEIGHT);
     CGBitmapInfo bitmapInfo;
@@ -78,8 +78,10 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     }
     
     NSMutableArray<UIImage *> *images = [NSMutableArray array];
+#if SD_UIKIT || SD_WATCH
     NSTimeInterval totalDuration = 0;
     int durations[frameCount];
+#endif
     
     do {
         UIImage *image;
@@ -97,7 +99,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
         
 #if SD_MAC
         break;
-#endif
+#else
         
         int duration = iter.duration;
         if (duration <= 10) {
@@ -108,7 +110,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
         totalDuration += duration;
         size_t count = images.count;
         durations[count - 1] = duration;
-        
+#endif
     } while (WebPDemuxNextFrame(&iter));
     
     WebPDemuxReleaseIterator(&iter);


### PR DESCRIPTION
Fix unreachable code warning because of the return and break expression in #if SD_MAC

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: Fix pod lib lint warning

### Pull Request Description

It's my fault, I build the project for both 4 platform targets and Xcode does report any warning (seems strange but you can also have a try). And after I integrated SDWebImage master branch to my project and build, it does not report any warning issues. So my last commit I forgot to run `pod lib lint`. But once I use `pod lib lint`, it shows `warning: code will never be executed` here. This because of that `return` and `break` expression into the `#if SD_MAC` macros. So this is an fix to get actual **0-warning**