### PR TITLE
Performance enhancement related to single WebP and animated WebP decoding...

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -347,6 +347,12 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     if (data) {
         UIImage *image = [UIImage sd_imageWithData:data];
         image = [self scaledImageForKey:key image:image];
+#ifdef SD_WEBP
+        SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:data];
+        if (imageFormat == SDImageFormatWebP) {
+            return image;
+        }
+#endif
         if (self.config.shouldDecompressImages) {
             image = [UIImage decodedImageWithImage:image];
         }

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -446,8 +446,20 @@ didReceiveResponse:(NSURLResponse *)response
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                 image = [self scaledImageForKey:key image:image];
                 
-                // Do not force decoding animated GIFs
-                if (!image.images) {
+                BOOL shouldDecode = YES;
+                // Do not force decoding animated GIFs and WebPs
+                if (image.images) {
+                    shouldDecode = NO;
+                } else {
+#ifdef SD_WEBP
+                    SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:self.imageData];
+                    if (imageFormat == SDImageFormatWebP) {
+                        shouldDecode = NO;
+                    }
+#endif
+                }
+
+                if (shouldDecode) {
                     if (self.shouldDecompressImages) {
                         if (self.options & SDWebImageDownloaderScaleDownLargeImages) {
 #if SD_UIKIT || SD_WATCH


### PR DESCRIPTION
1. Change the code to not decode WebP images created in SD because it has been decoded
2. Add @autoreleasepool for animated WebP decoding do-while loop to reduce memory peak

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary): NO changes in API
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`): This time I check and it passed

This merge request fixes / reffers to the following issues: #1885 #1889 

### Pull Request Description

This Pull request is an performance enhancement. Including 3 small changes:
1. For single WebP images, previous when called with `[SDImageCache diskImageForKey]` shouldDecompressImages to YES(default), it will try decoded image before set to UIImageView. For WebP images, it's not created with ImageIO but with CGImageCreate with the raw bitmap data, which means it already been decoded. But `+[UIImage shouldDecodeImage]` return YES for this situation and will decoded again. It cause extra CPU and memory usage.
2. For animated WebP images, during libwebp decoding, there is an do-while loop to create each frame image. This may cause an memory peak and  place an autoreleasepool here is better.

