### PR TITLE
Add progressive image load for WebP images

### DIFF
--- a/SDWebImage/SDWebImageDecoder.h
+++ b/SDWebImage/SDWebImageDecoder.h
@@ -10,6 +10,22 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSUInteger, SDWebImageDecoderType) {
+    SDWebImageDecoderTypeAuto = 0, // default, will check image format by sd_imageFormatForImageData and decode only the recognized format
+    SDWebImageDecoderTypeImageIO, // use ImageIO to decode image format that ImageIO support
+    SDWebImageDecoderTypeWebP // use libwebp to decode WebP format
+};
+
+@interface SDWebImageDecoder : NSObject
+
+- (instancetype)initWithType:(SDWebImageDecoderType)type;
+
+- (nullable UIImage *)incrementalDecodedImageWithUpdateData:(nullable NSData *)updateData finished:(BOOL)finished;
+
+@end
+
 @interface UIImage (ForceDecode)
 
 + (nullable UIImage *)decodedImageWithImage:(nullable UIImage *)image;
@@ -17,3 +33,5 @@
 + (nullable UIImage *)decodedAndScaledDownImageWithImage:(nullable UIImage *)image;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SDWebImage/SDWebImageDecoder.h
+++ b/SDWebImage/SDWebImageDecoder.h
@@ -9,20 +9,11 @@
 
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
-
-NS_ASSUME_NONNULL_BEGIN
-
-typedef NS_ENUM(NSUInteger, SDWebImageDecoderType) {
-    SDWebImageDecoderTypeAuto = 0, // default, will check image format by sd_imageFormatForImageData and decode only the recognized format
-    SDWebImageDecoderTypeImageIO, // use ImageIO to decode image format that ImageIO support
-    SDWebImageDecoderTypeWebP // use libwebp to decode WebP format
-};
+#import "NSData+ImageContentType.h"
 
 @interface SDWebImageDecoder : NSObject
 
-- (instancetype)initWithType:(SDWebImageDecoderType)type;
-
-- (nullable UIImage *)incrementalDecodedImageWithUpdateData:(nullable NSData *)updateData finished:(BOOL)finished;
+- (nullable UIImage *)incrementalDecodedImageWithData:(nullable NSData *)data format:(SDImageFormat)format finished:(BOOL)finished;
 
 @end
 
@@ -33,5 +24,3 @@ typedef NS_ENUM(NSUInteger, SDWebImageDecoderType) {
 + (nullable UIImage *)decodedAndScaledDownImageWithImage:(nullable UIImage *)image;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -8,7 +8,6 @@
  */
 
 #import "SDWebImageDecoder.h"
-#import "NSData+ImageContentType.h"
 #import <ImageIO/ImageIO.h>
 #ifdef SD_WEBP
 #if __has_include(<webp/decode.h>)
@@ -17,12 +16,6 @@
 #import "webp/decode.h"
 #endif
 #endif
-
-@interface SDWebImageDecoder ()
-
-@property (assign, nonatomic) SDWebImageDecoderType type;
-
-@end
 
 @implementation SDWebImageDecoder {
     size_t _width, _height;
@@ -48,40 +41,18 @@
 #endif
 }
 
-- (instancetype)initWithType:(SDWebImageDecoderType)type {
-    self = [super init];
-    if (self) {
-        self.type = type;
-    }
-    
-    return self;
-}
-
-- (UIImage *)incrementalDecodedImageWithUpdateData:(NSData *)updateData finished:(BOOL)finished {
-    if (!updateData) {
+- (nullable UIImage *)incrementalDecodedImageWithData:(nullable NSData *)data format:(SDImageFormat)format finished:(BOOL)finished {
+    if (!data) {
         return nil;
     }
     
     UIImage *image;
-    NSData *imageData = [updateData copy];
-    // check image format until it recognize the format
-    if (self.type == SDWebImageDecoderTypeAuto) {
-        SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
-        if (imageFormat == SDImageFormatUndefined) {
-            return nil;
-        } else if (imageFormat == SDWebImageDecoderTypeWebP) {
-            self.type = SDWebImageDecoderTypeWebP;
-        } else {
-            self.type = SDWebImageDecoderTypeImageIO;
-        }
-    }
-    
-    if (self.type == SDWebImageDecoderTypeWebP) {
+    if (format == SDImageFormatWebP) {
 #ifdef SD_WEBP
-        image = [self incrementalWebPDecodedImageWithData:imageData finished:finished];
+        image = [self incrementalWebPDecodedImageWithData:data finished:finished];
 #endif
     } else {
-        image = [self incrementalImageIODecodedImageWithData:imageData finished:finished];
+        image = [self incrementalImageIODecodedImageWithData:data finished:finished];
     }
     
     return image;

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -380,7 +380,7 @@ didReceiveResponse:(NSURLResponse *)response
             if (self.imageData) {
                 UIImage *image = [UIImage sd_imageWithData:self.imageData];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-                image = SDScaledImageForKey(key, image);
+                image = [self scaledImageForKey:key image:image];
                 
                 // Do not force decoding animated GIFs
                 if (!image.images) {
@@ -436,6 +436,10 @@ didReceiveResponse:(NSURLResponse *)response
     if (completionHandler) {
         completionHandler(disposition, credential);
     }
+}
+
+- (nullable UIImage *)scaledImageForKey:(nullable NSString *)key image:(nullable UIImage *)image {
+    return SDScaledImageForKey(key, image);
 }
 
 #pragma mark Helper methods

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -13,6 +13,16 @@
 #import "SDWebImageManager.h"
 #import "NSImage+WebCache.h"
 
+#ifdef SD_WEBP
+#if __has_include(<webp/decode.h>)
+#import <webp/decode.h>
+#else
+#import "webp/decode.h"
+#endif
+
+static NSString *const kWebPMIMEType = @"image/webp";
+#endif
+
 NSString *const SDWebImageDownloadStartNotification = @"SDWebImageDownloadStartNotification";
 NSString *const SDWebImageDownloadReceiveResponseNotification = @"SDWebImageDownloadReceiveResponseNotification";
 NSString *const SDWebImageDownloadStopNotification = @"SDWebImageDownloadStopNotification";
@@ -30,6 +40,7 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 @property (assign, nonatomic, getter = isExecuting) BOOL executing;
 @property (assign, nonatomic, getter = isFinished) BOOL finished;
 @property (strong, nonatomic, nullable) NSMutableData *imageData;
+@property (copy, nonatomic, nullable) NSString *MIMEType;
 
 // This is weak because it is injected by whoever manages this session. If this gets nil-ed out, we won't be able to run
 // the task associated with this operation
@@ -48,9 +59,14 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 @end
 
 @implementation SDWebImageDownloaderOperation {
-    size_t width, height;
+    size_t _width, _height;
 #if SD_UIKIT || SD_WATCH
-    UIImageOrientation orientation;
+    UIImageOrientation _orientation;
+#endif
+    CGImageSourceRef _imageSource;
+#ifdef SD_WEBP
+    WebPIDecoder *_idec;
+    WebPDecoderConfig _config;
 #endif
 }
 
@@ -292,6 +308,8 @@ didReceiveResponse:(NSURLResponse *)response
         [self done];
     }
     
+    self.MIMEType = response.MIMEType;
+    
     if (completionHandler) {
         completionHandler(NSURLSessionResponseAllow);
     }
@@ -301,84 +319,15 @@ didReceiveResponse:(NSURLResponse *)response
     [self.imageData appendData:data];
 
     if ((self.options & SDWebImageDownloaderProgressiveDownload) && self.expectedSize > 0) {
-        // The following code is from http://www.cocoaintheshell.com/2011/05/progressive-images-download-imageio/
-        // Thanks to the author @Nyx0uf
-
-        // Get the total bytes downloaded
-        const NSInteger totalSize = self.imageData.length;
-
-        // Update the data source, we must pass ALL the data, not just the new bytes
-        CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)self.imageData, NULL);
-
-        if (width + height == 0) {
-            CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
-            if (properties) {
-                NSInteger orientationValue = -1;
-                CFTypeRef val = CFDictionaryGetValue(properties, kCGImagePropertyPixelHeight);
-                if (val) CFNumberGetValue(val, kCFNumberLongType, &height);
-                val = CFDictionaryGetValue(properties, kCGImagePropertyPixelWidth);
-                if (val) CFNumberGetValue(val, kCFNumberLongType, &width);
-                val = CFDictionaryGetValue(properties, kCGImagePropertyOrientation);
-                if (val) CFNumberGetValue(val, kCFNumberNSIntegerType, &orientationValue);
-                CFRelease(properties);
-
-                // When we draw to Core Graphics, we lose orientation information,
-                // which means the image below born of initWithCGIImage will be
-                // oriented incorrectly sometimes. (Unlike the image born of initWithData
-                // in didCompleteWithError.) So save it here and pass it on later.
-#if SD_UIKIT || SD_WATCH
-                orientation = [[self class] orientationFromPropertyValue:(orientationValue == -1 ? 1 : orientationValue)];
+#ifdef SD_WEBP
+        if ([self.MIMEType isEqualToString:kWebPMIMEType]) {
+            [self progressiveDownloadForWebP];
+        } else {
 #endif
-            }
+            [self progressiveDownloadForImageIO];
+#ifdef SD_WEBP
         }
-
-        if (width + height > 0 && totalSize < self.expectedSize) {
-            // Create the image
-            CGImageRef partialImageRef = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
-
-#if SD_UIKIT || SD_WATCH
-            // Workaround for iOS anamorphic image
-            if (partialImageRef) {
-                const size_t partialHeight = CGImageGetHeight(partialImageRef);
-                CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-                CGContextRef bmContext = CGBitmapContextCreate(NULL, width, height, 8, width * 4, colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
-                CGColorSpaceRelease(colorSpace);
-                if (bmContext) {
-                    CGContextDrawImage(bmContext, (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = width, .size.height = partialHeight}, partialImageRef);
-                    CGImageRelease(partialImageRef);
-                    partialImageRef = CGBitmapContextCreateImage(bmContext);
-                    CGContextRelease(bmContext);
-                }
-                else {
-                    CGImageRelease(partialImageRef);
-                    partialImageRef = nil;
-                }
-            }
 #endif
-
-            if (partialImageRef) {
-#if SD_UIKIT || SD_WATCH
-                UIImage *image = [UIImage imageWithCGImage:partialImageRef scale:1 orientation:orientation];
-#elif SD_MAC
-                UIImage *image = [[UIImage alloc] initWithCGImage:partialImageRef size:NSZeroSize];
-#endif
-                NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-                UIImage *scaledImage = [self scaledImageForKey:key image:image];
-                if (self.shouldDecompressImages) {
-                    image = [UIImage decodedImageWithImage:scaledImage];
-                }
-                else {
-                    image = scaledImage;
-                }
-                CGImageRelease(partialImageRef);
-                
-                [self callCompletionBlocksWithImage:image imageData:nil error:nil finished:NO];
-            }
-        }
-
-        if (imageSource) {
-            CFRelease(imageSource);
-        }
     }
 
     for (SDWebImageDownloaderProgressBlock progressBlock in [self callbacksForKey:kProgressCallbackKey]) {
@@ -485,6 +434,181 @@ didReceiveResponse:(NSURLResponse *)response
     if (completionHandler) {
         completionHandler(disposition, credential);
     }
+}
+
+#pragma mark Progressive Download
+- (void)progressiveDownloadForImageIO {
+    if (!_imageSource) {
+        _imageSource = CGImageSourceCreateIncremental(NULL);
+    }
+    // The following code is from http://www.cocoaintheshell.com/2011/05/progressive-images-download-imageio/
+    // Thanks to the author @Nyx0uf
+    
+    // Get the total bytes downloaded
+    NSData *imageData = [self.imageData copy];
+    const NSInteger totalSize = imageData.length;
+    BOOL finished = (self.expectedSize == totalSize);
+    
+    // Update the data source, we must pass ALL the data, not just the new bytes
+    CGImageSourceUpdateData(_imageSource, (__bridge CFDataRef)imageData, finished);
+    
+    if (_width + _height == 0) {
+        CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(_imageSource, 0, NULL);
+        if (properties) {
+            NSInteger orientationValue = -1;
+            CFTypeRef val = CFDictionaryGetValue(properties, kCGImagePropertyPixelHeight);
+            if (val) CFNumberGetValue(val, kCFNumberLongType, &_height);
+            val = CFDictionaryGetValue(properties, kCGImagePropertyPixelWidth);
+            if (val) CFNumberGetValue(val, kCFNumberLongType, &_width);
+            val = CFDictionaryGetValue(properties, kCGImagePropertyOrientation);
+            if (val) CFNumberGetValue(val, kCFNumberNSIntegerType, &orientationValue);
+            CFRelease(properties);
+            
+            // When we draw to Core Graphics, we lose orientation information,
+            // which means the image below born of initWithCGIImage will be
+            // oriented incorrectly sometimes. (Unlike the image born of initWithData
+            // in didCompleteWithError.) So save it here and pass it on later.
+#if SD_UIKIT || SD_WATCH
+            _orientation = [[self class] orientationFromPropertyValue:(orientationValue == -1 ? 1 : orientationValue)];
+#endif
+        }
+    }
+    
+    if (_width + _height > 0 && totalSize < self.expectedSize) {
+        // Create the image
+        CGImageRef partialImageRef = CGImageSourceCreateImageAtIndex(_imageSource, 0, NULL);
+        
+#if SD_UIKIT || SD_WATCH
+        // Workaround for iOS anamorphic image
+        if (partialImageRef) {
+            const size_t partialHeight = CGImageGetHeight(partialImageRef);
+            CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+            CGContextRef bmContext = CGBitmapContextCreate(NULL, _width, _height, 8, _width * 4, colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
+            CGColorSpaceRelease(colorSpace);
+            if (bmContext) {
+                CGContextDrawImage(bmContext, (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = _width, .size.height = partialHeight}, partialImageRef);
+                CGImageRelease(partialImageRef);
+                partialImageRef = CGBitmapContextCreateImage(bmContext);
+                CGContextRelease(bmContext);
+            }
+            else {
+                CGImageRelease(partialImageRef);
+                partialImageRef = nil;
+            }
+        }
+#endif
+        
+        if (partialImageRef) {
+#if SD_UIKIT || SD_WATCH
+            UIImage *image = [UIImage imageWithCGImage:partialImageRef scale:1 orientation:_orientation];
+#elif SD_MAC
+            UIImage *image = [[UIImage alloc] initWithCGImage:partialImageRef size:NSZeroSize];
+#endif
+            NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
+            UIImage *scaledImage = [self scaledImageForKey:key image:image];
+            if (self.shouldDecompressImages) {
+                image = [UIImage decodedImageWithImage:scaledImage];
+            }
+            else {
+                image = scaledImage;
+            }
+            CGImageRelease(partialImageRef);
+            
+            [self callCompletionBlocksWithImage:image imageData:nil error:nil finished:NO];
+        }
+    }
+    
+    if (finished) {
+        if (_imageSource) {
+            CFRelease(_imageSource);
+        }
+    }
+}
+#ifdef SD_WEBP
+- (void)progressiveDownloadForWebP {
+    if (!_idec) {
+        // Progressive images need transparent, so always use RGBA
+        _config.output.colorspace = MODE_rgbA;
+        _idec = WebPINewDecoder(&_config.output);
+        if (!_idec) {
+            return;
+        }
+    }
+    
+    // Get the total bytes downloaded
+    NSData *imageData = [self.imageData copy];
+    const NSInteger totalSize = imageData.length;
+    BOOL finished = (self.expectedSize == totalSize);
+    
+    VP8StatusCode status = WebPIUpdate(_idec, imageData.bytes, totalSize);
+    if (status != VP8_STATUS_OK && status != VP8_STATUS_SUSPENDED) {
+        return;
+    }
+    
+    int partialHeight;
+    int stride;
+    WebPIDecGetRGB(_idec, &partialHeight, (int *)&_width, (int *)&_height, &stride);
+    
+    if (_config.output.u.RGBA.rgba) {
+        // Construct a UIImage from the decoded RGBA value array
+        CGDataProviderRef provider =
+        CGDataProviderCreateWithData(NULL, _config.output.u.RGBA.rgba, _config.output.u.RGBA.size, NULL);
+        CGColorSpaceRef colorSpaceRef = SDCGColorSpaceGetDeviceRGB();
+        
+        CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast;
+        size_t components = 4;
+        CGColorRenderingIntent renderingIntent = kCGRenderingIntentDefault;
+        CGImageRef imageRef = CGImageCreate(_width, _height, 8, components * 8, components * _width, colorSpaceRef, bitmapInfo, provider, NULL, NO, renderingIntent);
+        
+        CGDataProviderRelease(provider);
+        
+        if (!imageRef) {
+            return;
+        }
+        
+        CGContextRef canvas = CGBitmapContextCreate(NULL, _width, _height, 8, 0, SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
+        if (!canvas) {
+            CGImageRelease(imageRef);
+            return;
+        }
+        
+        CGContextDrawImage(canvas, CGRectMake(0, 0, _width, _height), imageRef);
+        CGImageRef newImageRef = CGBitmapContextCreateImage(canvas);
+        CGImageRelease(imageRef);
+        if (!newImageRef) {
+            CGContextRelease(canvas);
+            return;
+        }
+        
+#if SD_UIKIT || SD_WATCH
+        UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef];
+#else
+        UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef size:NSZeroSize];
+#endif
+        CGImageRelease(newImageRef);
+        CGContextRelease(canvas);
+        
+        NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
+        image = [self scaledImageForKey:key image:image];
+        
+        [self callCompletionBlocksWithImage:image imageData:nil error:nil finished:NO];
+    }
+
+    if (finished) {
+        if (_idec) {
+            WebPIDelete(_idec);
+        }
+        WebPFreeDecBuffer(&_config.output);
+    }
+}
+#endif
+static CGColorSpaceRef _Nonnull SDCGColorSpaceGetDeviceRGB(void) {
+    static CGColorSpaceRef colorSpace;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        colorSpace = CGColorSpaceCreateDeviceRGB();
+    });
+    return colorSpace;
 }
 
 #pragma mark Helper methods

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -66,7 +66,6 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
     CGImageSourceRef _imageSource;
 #ifdef SD_WEBP
     WebPIDecoder *_idec;
-    WebPDecoderConfig _config;
 #endif
 }
 
@@ -96,6 +95,16 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 
 - (void)dealloc {
     SDDispatchQueueRelease(_barrierQueue);
+    if (_imageSource) {
+        CFRelease(_imageSource);
+        _imageSource = NULL;
+    }
+#ifdef SD_WEBP
+    if (_idec) {
+        WebPIDelete(_idec);
+        _idec = NULL;
+    }
+#endif
 }
 
 - (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
@@ -482,9 +491,8 @@ didReceiveResponse:(NSURLResponse *)response
         // Workaround for iOS anamorphic image
         if (partialImageRef) {
             const size_t partialHeight = CGImageGetHeight(partialImageRef);
-            CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+            CGColorSpaceRef colorSpace = SDCGColorSpaceGetDeviceRGB();
             CGContextRef bmContext = CGBitmapContextCreate(NULL, _width, _height, 8, _width * 4, colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
-            CGColorSpaceRelease(colorSpace);
             if (bmContext) {
                 CGContextDrawImage(bmContext, (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = _width, .size.height = partialHeight}, partialImageRef);
                 CGImageRelease(partialImageRef);
@@ -521,15 +529,15 @@ didReceiveResponse:(NSURLResponse *)response
     if (finished) {
         if (_imageSource) {
             CFRelease(_imageSource);
+            _imageSource = NULL;
         }
     }
 }
 #ifdef SD_WEBP
 - (void)progressiveDownloadForWebP {
     if (!_idec) {
-        // Progressive images need transparent, so always use RGBA
-        _config.output.colorspace = MODE_rgbA;
-        _idec = WebPINewDecoder(&_config.output);
+        // Progressive images need transparent, so always use premultiplied RGBA
+        _idec = WebPINewRGB(MODE_rgbA, NULL, 0, 0);
         if (!_idec) {
             return;
         }
@@ -545,14 +553,12 @@ didReceiveResponse:(NSURLResponse *)response
         return;
     }
     
-    int partialHeight;
-    int stride;
-    WebPIDecGetRGB(_idec, &partialHeight, (int *)&_width, (int *)&_height, &stride);
+    uint8_t *rgba = WebPIDecGetRGB(_idec, NULL, (int *)&_width, (int *)&_height, NULL);
     
-    if (_config.output.u.RGBA.rgba) {
+    if (_width + _height > 0 && totalSize < self.expectedSize) {
         // Construct a UIImage from the decoded RGBA value array
         CGDataProviderRef provider =
-        CGDataProviderCreateWithData(NULL, _config.output.u.RGBA.rgba, _config.output.u.RGBA.size, NULL);
+        CGDataProviderCreateWithData(NULL, rgba, 0, NULL);
         CGColorSpaceRef colorSpaceRef = SDCGColorSpaceGetDeviceRGB();
         
         CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast;
@@ -593,15 +599,16 @@ didReceiveResponse:(NSURLResponse *)response
         
         [self callCompletionBlocksWithImage:image imageData:nil error:nil finished:NO];
     }
-
+    
     if (finished) {
         if (_idec) {
             WebPIDelete(_idec);
+            _idec = NULL;
         }
-        WebPFreeDecBuffer(&_config.output);
     }
 }
 #endif
+
 static CGColorSpaceRef _Nonnull SDCGColorSpaceGetDeviceRGB(void) {
     static CGColorSpaceRef colorSpace;
     static dispatch_once_t onceToken;

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -9,19 +9,8 @@
 #import "SDWebImageDownloaderOperation.h"
 #import "SDWebImageDecoder.h"
 #import "UIImage+MultiFormat.h"
-#import <ImageIO/ImageIO.h>
 #import "SDWebImageManager.h"
 #import "NSImage+WebCache.h"
-
-#ifdef SD_WEBP
-#if __has_include(<webp/decode.h>)
-#import <webp/decode.h>
-#else
-#import "webp/decode.h"
-#endif
-
-static NSString *const kWebPMIMEType = @"image/webp";
-#endif
 
 NSString *const SDWebImageDownloadStartNotification = @"SDWebImageDownloadStartNotification";
 NSString *const SDWebImageDownloadReceiveResponseNotification = @"SDWebImageDownloadReceiveResponseNotification";
@@ -30,6 +19,8 @@ NSString *const SDWebImageDownloadFinishNotification = @"SDWebImageDownloadFinis
 
 static NSString *const kProgressCallbackKey = @"progress";
 static NSString *const kCompletedCallbackKey = @"completed";
+
+static NSString *const kWebPMIMEType = @"image/webp";
 
 typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 
@@ -41,6 +32,7 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 @property (assign, nonatomic, getter = isFinished) BOOL finished;
 @property (strong, nonatomic, nullable) NSMutableData *imageData;
 @property (copy, nonatomic, nullable) NSString *MIMEType;
+@property (strong, nonatomic, nullable) SDWebImageDecoder *decoder;
 
 // This is weak because it is injected by whoever manages this session. If this gets nil-ed out, we won't be able to run
 // the task associated with this operation
@@ -58,16 +50,7 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 
 @end
 
-@implementation SDWebImageDownloaderOperation {
-    size_t _width, _height;
-#if SD_UIKIT || SD_WATCH
-    UIImageOrientation _orientation;
-#endif
-    CGImageSourceRef _imageSource;
-#ifdef SD_WEBP
-    WebPIDecoder *_idec;
-#endif
-}
+@implementation SDWebImageDownloaderOperation
 
 @synthesize executing = _executing;
 @synthesize finished = _finished;
@@ -95,16 +78,6 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 
 - (void)dealloc {
     SDDispatchQueueRelease(_barrierQueue);
-    if (_imageSource) {
-        CFRelease(_imageSource);
-        _imageSource = NULL;
-    }
-#ifdef SD_WEBP
-    if (_idec) {
-        WebPIDelete(_idec);
-        _idec = NULL;
-    }
-#endif
 }
 
 - (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
@@ -328,15 +301,33 @@ didReceiveResponse:(NSURLResponse *)response
     [self.imageData appendData:data];
 
     if ((self.options & SDWebImageDownloaderProgressiveDownload) && self.expectedSize > 0) {
+        UIImage *image;
+        if (!self.decoder) {
 #ifdef SD_WEBP
-        if ([self.MIMEType isEqualToString:kWebPMIMEType]) {
-            [self progressiveDownloadForWebP];
-        } else {
+            if ([self.MIMEType isEqualToString:kWebPMIMEType]) {
+                self.decoder = [[SDWebImageDecoder alloc] initWithType:SDWebImageDecoderTypeWebP];
+            } else {
 #endif
-            [self progressiveDownloadForImageIO];
+                self.decoder = [[SDWebImageDecoder alloc] initWithType:SDWebImageDecoderTypeImageIO];
 #ifdef SD_WEBP
+            }
+#endif
         }
-#endif
+        const NSInteger totalSize = self.imageData.length;
+        BOOL finished = (self.expectedSize == totalSize);
+        image = [self.decoder incrementalDecodedImageWithUpdateData:self.imageData finished:finished];
+        if (image) {
+            NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
+            UIImage *scaledImage = SDScaledImageForKey(key, image);
+            if (self.shouldDecompressImages) {
+                image = [UIImage decodedImageWithImage:scaledImage];
+            }
+            else {
+                image = scaledImage;
+            }
+            
+            [self callCompletionBlocksWithImage:image imageData:nil error:nil finished:NO];
+        }
     }
 
     for (SDWebImageDownloaderProgressBlock progressBlock in [self callbacksForKey:kProgressCallbackKey]) {
@@ -387,7 +378,7 @@ didReceiveResponse:(NSURLResponse *)response
             if (self.imageData) {
                 UIImage *image = [UIImage sd_imageWithData:self.imageData];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-                image = [self scaledImageForKey:key image:image];
+                image = SDScaledImageForKey(key, image);
                 
                 // Do not force decoding animated GIFs
                 if (!image.images) {
@@ -445,209 +436,7 @@ didReceiveResponse:(NSURLResponse *)response
     }
 }
 
-#pragma mark Progressive Download
-- (void)progressiveDownloadForImageIO {
-    if (!_imageSource) {
-        _imageSource = CGImageSourceCreateIncremental(NULL);
-    }
-    // The following code is from http://www.cocoaintheshell.com/2011/05/progressive-images-download-imageio/
-    // Thanks to the author @Nyx0uf
-    
-    // Get the total bytes downloaded
-    NSData *imageData = [self.imageData copy];
-    const NSInteger totalSize = imageData.length;
-    BOOL finished = (self.expectedSize == totalSize);
-    
-    // Update the data source, we must pass ALL the data, not just the new bytes
-    CGImageSourceUpdateData(_imageSource, (__bridge CFDataRef)imageData, finished);
-    
-    if (_width + _height == 0) {
-        CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(_imageSource, 0, NULL);
-        if (properties) {
-            NSInteger orientationValue = -1;
-            CFTypeRef val = CFDictionaryGetValue(properties, kCGImagePropertyPixelHeight);
-            if (val) CFNumberGetValue(val, kCFNumberLongType, &_height);
-            val = CFDictionaryGetValue(properties, kCGImagePropertyPixelWidth);
-            if (val) CFNumberGetValue(val, kCFNumberLongType, &_width);
-            val = CFDictionaryGetValue(properties, kCGImagePropertyOrientation);
-            if (val) CFNumberGetValue(val, kCFNumberNSIntegerType, &orientationValue);
-            CFRelease(properties);
-            
-            // When we draw to Core Graphics, we lose orientation information,
-            // which means the image below born of initWithCGIImage will be
-            // oriented incorrectly sometimes. (Unlike the image born of initWithData
-            // in didCompleteWithError.) So save it here and pass it on later.
-#if SD_UIKIT || SD_WATCH
-            _orientation = [[self class] orientationFromPropertyValue:(orientationValue == -1 ? 1 : orientationValue)];
-#endif
-        }
-    }
-    
-    if (_width + _height > 0 && totalSize < self.expectedSize) {
-        // Create the image
-        CGImageRef partialImageRef = CGImageSourceCreateImageAtIndex(_imageSource, 0, NULL);
-        
-#if SD_UIKIT || SD_WATCH
-        // Workaround for iOS anamorphic image
-        if (partialImageRef) {
-            const size_t partialHeight = CGImageGetHeight(partialImageRef);
-            CGColorSpaceRef colorSpace = SDCGColorSpaceGetDeviceRGB();
-            CGContextRef bmContext = CGBitmapContextCreate(NULL, _width, _height, 8, _width * 4, colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
-            if (bmContext) {
-                CGContextDrawImage(bmContext, (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = _width, .size.height = partialHeight}, partialImageRef);
-                CGImageRelease(partialImageRef);
-                partialImageRef = CGBitmapContextCreateImage(bmContext);
-                CGContextRelease(bmContext);
-            }
-            else {
-                CGImageRelease(partialImageRef);
-                partialImageRef = nil;
-            }
-        }
-#endif
-        
-        if (partialImageRef) {
-#if SD_UIKIT || SD_WATCH
-            UIImage *image = [UIImage imageWithCGImage:partialImageRef scale:1 orientation:_orientation];
-#elif SD_MAC
-            UIImage *image = [[UIImage alloc] initWithCGImage:partialImageRef size:NSZeroSize];
-#endif
-            NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-            UIImage *scaledImage = [self scaledImageForKey:key image:image];
-            if (self.shouldDecompressImages) {
-                image = [UIImage decodedImageWithImage:scaledImage];
-            }
-            else {
-                image = scaledImage;
-            }
-            CGImageRelease(partialImageRef);
-            
-            [self callCompletionBlocksWithImage:image imageData:nil error:nil finished:NO];
-        }
-    }
-    
-    if (finished) {
-        if (_imageSource) {
-            CFRelease(_imageSource);
-            _imageSource = NULL;
-        }
-    }
-}
-#ifdef SD_WEBP
-- (void)progressiveDownloadForWebP {
-    if (!_idec) {
-        // Progressive images need transparent, so always use premultiplied RGBA
-        _idec = WebPINewRGB(MODE_rgbA, NULL, 0, 0);
-        if (!_idec) {
-            return;
-        }
-    }
-    
-    // Get the total bytes downloaded
-    NSData *imageData = [self.imageData copy];
-    const NSInteger totalSize = imageData.length;
-    BOOL finished = (self.expectedSize == totalSize);
-    
-    VP8StatusCode status = WebPIUpdate(_idec, imageData.bytes, totalSize);
-    if (status != VP8_STATUS_OK && status != VP8_STATUS_SUSPENDED) {
-        return;
-    }
-    
-    uint8_t *rgba = WebPIDecGetRGB(_idec, NULL, (int *)&_width, (int *)&_height, NULL);
-    
-    if (_width + _height > 0 && totalSize < self.expectedSize) {
-        // Construct a UIImage from the decoded RGBA value array
-        CGDataProviderRef provider =
-        CGDataProviderCreateWithData(NULL, rgba, 0, NULL);
-        CGColorSpaceRef colorSpaceRef = SDCGColorSpaceGetDeviceRGB();
-        
-        CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast;
-        size_t components = 4;
-        CGColorRenderingIntent renderingIntent = kCGRenderingIntentDefault;
-        CGImageRef imageRef = CGImageCreate(_width, _height, 8, components * 8, components * _width, colorSpaceRef, bitmapInfo, provider, NULL, NO, renderingIntent);
-        
-        CGDataProviderRelease(provider);
-        
-        if (!imageRef) {
-            return;
-        }
-        
-        CGContextRef canvas = CGBitmapContextCreate(NULL, _width, _height, 8, 0, SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
-        if (!canvas) {
-            CGImageRelease(imageRef);
-            return;
-        }
-        
-        CGContextDrawImage(canvas, CGRectMake(0, 0, _width, _height), imageRef);
-        CGImageRef newImageRef = CGBitmapContextCreateImage(canvas);
-        CGImageRelease(imageRef);
-        if (!newImageRef) {
-            CGContextRelease(canvas);
-            return;
-        }
-        
-#if SD_UIKIT || SD_WATCH
-        UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef];
-#else
-        UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef size:NSZeroSize];
-#endif
-        CGImageRelease(newImageRef);
-        CGContextRelease(canvas);
-        
-        NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-        image = [self scaledImageForKey:key image:image];
-        
-        [self callCompletionBlocksWithImage:image imageData:nil error:nil finished:NO];
-    }
-    
-    if (finished) {
-        if (_idec) {
-            WebPIDelete(_idec);
-            _idec = NULL;
-        }
-    }
-}
-#endif
-
-static CGColorSpaceRef _Nonnull SDCGColorSpaceGetDeviceRGB(void) {
-    static CGColorSpaceRef colorSpace;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        colorSpace = CGColorSpaceCreateDeviceRGB();
-    });
-    return colorSpace;
-}
-
 #pragma mark Helper methods
-
-#if SD_UIKIT || SD_WATCH
-+ (UIImageOrientation)orientationFromPropertyValue:(NSInteger)value {
-    switch (value) {
-        case 1:
-            return UIImageOrientationUp;
-        case 3:
-            return UIImageOrientationDown;
-        case 8:
-            return UIImageOrientationLeft;
-        case 6:
-            return UIImageOrientationRight;
-        case 2:
-            return UIImageOrientationUpMirrored;
-        case 4:
-            return UIImageOrientationDownMirrored;
-        case 5:
-            return UIImageOrientationLeftMirrored;
-        case 7:
-            return UIImageOrientationRightMirrored;
-        default:
-            return UIImageOrientationUp;
-    }
-}
-#endif
-
-- (nullable UIImage *)scaledImageForKey:(nullable NSString *)key image:(nullable UIImage *)image {
-    return SDScaledImageForKey(key, image);
-}
 
 - (BOOL)shouldContinueWhenAppEntersBackground {
     return self.options & SDWebImageDownloaderContinueInBackground;

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -256,6 +256,21 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
+- (void)test16ThatProgressiveWebPWorks {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Progressive WebP download"];
+    NSURL *imageURL = [NSURL URLWithString:@"http://www.ioncannon.net/wp-content/uploads/2011/06/test9.webp"];
+    [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL options:SDWebImageDownloaderProgressiveDownload progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
+        if (image && data && !error && finished) {
+            [expectation fulfill];
+        } else if (finished) {
+            XCTFail(@"Something went wrong");
+        } else {
+            // progressive updates
+        }
+    }];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 /**
  *  Per #883 - Fix multiple requests for same image and then canceling one
  *  Old SDWebImage (3.x) could not handle correctly multiple requests for the same image + cancel


### PR DESCRIPTION
Check the image data in advance. And if that failed, check whether HTTP response MIMEType is ‘image/webp’, then use the WebP progressive decoding, otherwise use ImageIO progressive decoding
Progressive WebP load works for static single WebP images
Refactor code to make it more readable

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase) // This may be conflicts after the #1985 merged, so please merge that first and notify me to fix the conflicts. 
* [x] I have added the required tests to prove the fix/feature I am adding // Added test16ThatProgressiveWebPWorks
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`) // no warning

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This pull request add the feature to progressively load single static WebP images.

Changes:
1. Add progressive decoding using libwebp's WebPIDecoder. Because currently we use ImageIO to load progressive images. But it does not support WebP and will fail on CGImageSourceCreateWithData.
2. Refactor code about current progressive code after than long code `if ((self.options & SDWebImageDownloaderProgressiveDownload) && self.expectedSize > 0) {xxxxxxx}`. I create two method called progressiveDownloadForImageIO and progressiveDownloadForWebP to do these procedure.