### PR TITLE
Fix request cache policy

### DIFF
--- a/Examples/SDWebImage Demo/DetailViewController.m
+++ b/Examples/SDWebImage Demo/DetailViewController.m
@@ -43,11 +43,13 @@
                           placeholderImage:nil
                                    options:SDWebImageProgressiveDownload
                                   progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL *targetURL) {
-                                      if (!activityIndicator) {
-                                          [weakImageView addSubview:activityIndicator = [UIActivityIndicatorView.alloc initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray]];
-                                          activityIndicator.center = weakImageView.center;
-                                          [activityIndicator startAnimating];
-                                      }
+                                      dispatch_async(dispatch_get_main_queue(), ^{
+                                          if (!activityIndicator) {
+                                              [weakImageView addSubview:activityIndicator = [UIActivityIndicatorView.alloc initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray]];
+                                              activityIndicator.center = weakImageView.center;
+                                              [activityIndicator startAnimating];
+                                          }
+                                      });
                                   }
                                  completed:^(UIImage *image, NSError *error, SDImageCacheType cacheType, NSURL *imageURL) {
                                      [activityIndicator removeFromSuperview];

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -166,14 +166,7 @@
         }
 
         // In order to prevent from potential duplicate caching (NSURLCache + SDImageCache) we disable the cache for image requests if told otherwise
-        NSURLRequestCachePolicy cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
-        if (options & SDWebImageDownloaderUseNSURLCache) {
-            if (options & SDWebImageDownloaderIgnoreCachedResponse) {
-                cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
-            } else {
-                cachePolicy = NSURLRequestUseProtocolCachePolicy;
-            }
-        }
+        NSURLRequestCachePolicy cachePolicy = options & SDWebImageDownloaderUseNSURLCache ? NSURLRequestUseProtocolCachePolicy : NSURLRequestReloadIgnoringLocalCacheData;
         NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url
                                                                     cachePolicy:cachePolicy
                                                                 timeoutInterval:timeoutInterval];

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -166,16 +166,10 @@
         }
 
         // In order to prevent from potential duplicate caching (NSURLCache + SDImageCache) we disable the cache for image requests if told otherwise
-        NSURLRequestCachePolicy cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
-        if (options & SDWebImageDownloaderUseNSURLCache) {
-            if (options & SDWebImageDownloaderIgnoreCachedResponse) {
-                cachePolicy = NSURLRequestReturnCacheDataDontLoad;
-            } else {
-                cachePolicy = NSURLRequestUseProtocolCachePolicy;
-            }
-        }
-        
-        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url cachePolicy:cachePolicy timeoutInterval:timeoutInterval];
+        NSURLRequestCachePolicy cachePolicy = options & SDWebImageDownloaderUseNSURLCache ? NSURLRequestUseProtocolCachePolicy : NSURLRequestReloadIgnoringLocalCacheData;
+        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url
+                                                                    cachePolicy:cachePolicy
+                                                                timeoutInterval:timeoutInterval];
         
         request.HTTPShouldHandleCookies = (options & SDWebImageDownloaderHandleCookies);
         request.HTTPShouldUsePipelining = YES;

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -166,7 +166,14 @@
         }
 
         // In order to prevent from potential duplicate caching (NSURLCache + SDImageCache) we disable the cache for image requests if told otherwise
-        NSURLRequestCachePolicy cachePolicy = options & SDWebImageDownloaderUseNSURLCache ? NSURLRequestUseProtocolCachePolicy : NSURLRequestReloadIgnoringLocalCacheData;
+        NSURLRequestCachePolicy cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+        if (options & SDWebImageDownloaderUseNSURLCache) {
+            if (options & SDWebImageDownloaderIgnoreCachedResponse) {
+                cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+            } else {
+                cachePolicy = NSURLRequestUseProtocolCachePolicy;
+            }
+        }
         NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url
                                                                     cachePolicy:cachePolicy
                                                                 timeoutInterval:timeoutInterval];


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [X] I have added the required tests to prove the fix/feature I am adding
* [X] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

This merge request fixes the following issues: #1993 and refers to #1737 

### Pull Request Description

- Fixed #1993 Load image with option `SDWebImageRefreshCached` get error
#1737 introduced an issue that is using `NSURLRequestReturnCacheDataDontLoad` for our cached images which makes us never download again, which is not ok when using `SDWebImageRefreshCached`.
- Fixed by reverting to the original implementation here: `NSURLRequestUseProtocolCachePolicy` vs `NSURLRequestReloadIgnoringLocalCacheData` (when `SDWebImageRefreshCached` is set).
- The docs say the `progressBlock` is called on a background queue, so when doing UI, we need to dispatch on the main queue
```
* @param progressBlock A block called while image is downloading
* @note the progress block is executed on a background queue
```