### PR TITLE
Added `SDWebImageWebPAvailable()` function to check whether WebP is available.

### DIFF
--- a/SDWebImage/UIImage+WebP.h
+++ b/SDWebImage/UIImage+WebP.h
@@ -27,3 +27,8 @@
 @end
 
 #endif
+
+/**
+ * Whether WebP is available in SDWebImage.
+ */
+extern BOOL SDWebImageWebPAvailable();

--- a/SDWebImage/UIImage+WebP.m
+++ b/SDWebImage/UIImage+WebP.m
@@ -299,4 +299,14 @@ static int gcd(int a,int b) {
 
 @end
 
+BOOL SDWebImageWebPAvailable() {
+    return YES;
+}
+
+#else
+
+BOOL SDWebImageWebPAvailable() {
+    return NO;
+}
+
 #endif

--- a/Tests/Tests/UIImageMultiFormatTests.m
+++ b/Tests/Tests/UIImageMultiFormatTests.m
@@ -8,6 +8,7 @@
 
 #import "SDTestCase.h"
 #import <SDWebImage/UIImage+MultiFormat.h>
+#import <SDWebImage/UIImage+WebP.h>
 
 @interface UIImageMultiFormatTests : SDTestCase
 
@@ -31,6 +32,7 @@
 }
 
 - (void)test02AnimatedWebPImageArrayWithEqualSizeAndScale {
+    expect(SDWebImageWebPAvailable()).to.beTruthy();
     NSURL *webpURL = [NSURL URLWithString:@"https://isparta.github.io/compare-webp/image/gif_webp/webp/2.webp"];
     NSData *data = [NSData dataWithContentsOfURL:webpURL];
 #pragma clang diagnostic push


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Added `SDWebImageWebPAvailable()` function to check whether WebP is available.

I need checking whether WebP is available in my framework, because I donot know whether the main app imported `SDWebImage/WebP`.

`SD_WEBP` is not available in my framework, and checking whether `UIImage` responds to selector `sd_imageWithWebPData:` is not a good solution.
