### PR TITLE
Add a test for SDWebImageRefreshCached

### DIFF
--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -73,7 +73,7 @@ NSString *workingImageURL = @"http://s3.amazonaws.com/fast-image-cache/demo-imag
             XCTFail(@"Image should be in cache");
         }
     }];
-    [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:nil];
+    [self waitForExpectationsWithCommonTimeout];
 }
 
 - (void)test05DiskImageExistsForURL {
@@ -105,6 +105,25 @@ NSString *workingImageURL = @"http://s3.amazonaws.com/fast-image-cache/demo-imag
         [expectation fulfill];
     });
     
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+- (void)test07ThatLoadImageWithSDWebImageRefreshCachedWorks {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Image download twice with SDWebImageRefresh failed"];
+    NSURL *originalImageURL = [NSURL URLWithString:@"http://s3.amazonaws.com/fast-image-cache/demo-images/FICDDemoImage007.jpg"];
+    [[SDImageCache sharedImageCache] clearDiskOnCompletion:nil];
+    
+    [[SDWebImageManager sharedManager] loadImageWithURL:originalImageURL options:SDWebImageRefreshCached progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+        expect(image).toNot.beNil();
+        expect(error).to.beNil();
+        // #1993, load image with SDWebImageRefreshCached twice should not fail if the first time success.
+        
+        [[SDWebImageManager sharedManager] loadImageWithURL:originalImageURL options:SDWebImageRefreshCached progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+            expect(image).toNot.beNil();
+            expect(error).to.beNil();
+            [expectation fulfill];
+        }];
+    }];
     [self waitForExpectationsWithCommonTimeout];
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

+ Add test for `SDWebImageRefreshCached ` to ensure that download image twice works.