### PR TITLE
Adopt the previous version behavior about SDWebImageDownloaderIgnoreC…

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -23,7 +23,6 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     /**
      * Call completion block with nil image/imageData if the image was read from NSURLCache
      * (to be combined with `SDWebImageDownloaderUseNSURLCache`).
-     * I think this option should be renamed to 'SDWebImageDownloaderUsingCachedResponseDontLoad'
      */
     SDWebImageDownloaderIgnoreCachedResponse = 1 << 3,
     


### PR DESCRIPTION
…achedResponse and SDWebImageRefreshCached without hack code

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rexase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Currently, we remove that hack code related to `SDWebImageDownloaderIgnoreCachedResponse` to avoid crash related to NSURLCache. But it's just because we try to acess the cache during URLSessionDelegate call and this is an race condition.

> In iOS 8 and later, and macOS 10.10 and later, NSURLCache is thread safe.
> Although NSURLCache instance methods can safely be called from multiple execution contexts at the same time, be aware that methods like cachedResponseForRequest: and storeCachedResponse:forRequest: have an unavoidable race condition when attempting to read or write responses for the same request.

So if we could acess this before any network start and later compare the data, we can keep this behavior and also avoid crash.

This PR must be conflicted with #2033 