### PR TITLE
Fix refresh cache behavior

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -23,7 +23,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     /**
      * Call completion block with nil image/imageData if the image was read from NSURLCache
      * (to be combined with `SDWebImageDownloaderUseNSURLCache`).
-     * I think this option should be renamed to 'SDWebImageDownloaderUsingCachedResponseDontLoad'
+     * This will check NSURLCache without sending any request to the server.
      */
     SDWebImageDownloaderIgnoreCachedResponse = 1 << 3,
     

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -423,9 +423,6 @@ didReceiveResponse:(NSURLResponse *)response
         if ([self callbacksForKey:kCompletedCallbackKey].count > 0) {
             /**
              *  If you specified to use `NSURLCache`, then the response you get here is what you need.
-             *  if you specified to only use cached data via `SDWebImageDownloaderIgnoreCachedResponse`,
-             *  the response data will be nil.
-             *  So we don't need to check the cache option here, since the system will obey the cache option
              */
             if (self.imageData) {
                 UIImage *image = [UIImage sd_imageWithData:self.imageData];

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -39,8 +39,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * Even if the image is cached, respect the HTTP response cache control, and refresh the image from remote location if needed.
      * The disk caching will be handled by NSURLCache instead of SDWebImage leading to slight performance degradation.
      * This option helps deal with images changing behind the same request URL, e.g. Facebook graph api profile pics.
-     * If a cached image is refreshed, the completion block is called once with the cached image and again with the final image.
-     *
+     * The completion block is called once with the cached image and again with the final image.
      * Use this flag only if you can't make your URLs static with embedded cache busting parameter.
      */
     SDWebImageRefreshCached = 1 << 4,

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -167,8 +167,6 @@
             if (cachedImage && options & SDWebImageRefreshCached) {
                 // force progressive off if image already cached but forced refreshing
                 downloaderOptions &= ~SDWebImageDownloaderProgressiveDownload;
-                // ignore image read from NSURLCache if image if cached but force refreshing
-                downloaderOptions |= SDWebImageDownloaderIgnoreCachedResponse;
             }
             
             SDWebImageDownloadToken *subOperationToken = [self.imageDownloader downloadImageWithURL:url options:downloaderOptions progress:progressBlock completed:^(UIImage *downloadedImage, NSData *downloadedData, NSError *error, BOOL finished) {
@@ -202,9 +200,7 @@
                     
                     BOOL cacheOnDisk = !(options & SDWebImageCacheMemoryOnly);
 
-                    if (options & SDWebImageRefreshCached && cachedImage && !downloadedImage) {
-                        // Image refresh hit the NSURLCache cache, do not call the completion block
-                    } else if (downloadedImage && (!downloadedImage.images || (options & SDWebImageTransformAnimatedImage)) && [self.delegate respondsToSelector:@selector(imageManager:transformDownloadedImage:withURL:)]) {
+                    if (downloadedImage && (!downloadedImage.images || (options & SDWebImageTransformAnimatedImage)) && [self.delegate respondsToSelector:@selector(imageManager:transformDownloadedImage:withURL:)]) {
                         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
                             UIImage *transformedImage = [self.delegate imageManager:self transformDownloadedImage:downloadedImage withURL:url];
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This pull request do the **OPPOSITE** thing about #2032 . It modify that description about `SDWebImageRefreshCached` from 

>  If a cached image is refreshed, the completion block is called once with the cached image and again with the final image.

to

> The completion block is called once with the cached image and again with the final image.

Which means the completion block with `SDWebImageRefreshCached` **MUST** called twice. One is from `SDImageCache` memory-disk cache and one from `NRURLCache` system cache or `NSURLSession` network response(It just use that `NSURLRequestUseProtocolCachePolicy` and let system maintains).

Why I suggest to change this is that our old behavior is sometime misdirected. Even if the server reponse the same `imageData`, we still call that completion block twice at some cases and not really obey what it says. So it's better to ensure that **MUST** be called twice and let end-user to render their views depended on the callback times.

Moreover, the `SDWebImageDownloaderIgnoreCachedResponse` will be not used for `SDWebImageRefreshCached`. It will kept just for compatibility which check the cache before any network request and immediately return.

This PR must be conflicted with #2032

