### PR TITLE
Keep exif metadata when scale down

### DIFF
--- a/SDWebImage/SDWebImageDecoder.h
+++ b/SDWebImage/SDWebImageDecoder.h
@@ -10,6 +10,22 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSUInteger, SDWebImageDecoderType) {
+    SDWebImageDecoderTypeAuto = 0, // default, will check image format by sd_imageFormatForImageData and decode only the recognized format
+    SDWebImageDecoderTypeImageIO, // use ImageIO to decode image format that ImageIO support
+    SDWebImageDecoderTypeWebP // use libwebp to decode WebP format
+};
+
+@interface SDWebImageDecoder : NSObject
+
+- (instancetype)initWithType:(SDWebImageDecoderType)type;
+
+- (nullable UIImage *)incrementalDecodedImageWithUpdateData:(nullable NSData *)updateData finished:(BOOL)finished;
+
+@end
+
 @interface UIImage (ForceDecode)
 
 + (nullable UIImage *)decodedImageWithImage:(nullable UIImage *)image;
@@ -17,3 +33,5 @@
 + (nullable UIImage *)decodedAndScaledDownImageWithImage:(nullable UIImage *)image;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/SDWebImage/SDWebImageDecoder.h
+++ b/SDWebImage/SDWebImageDecoder.h
@@ -15,6 +15,10 @@
 
 - (nullable UIImage *)incrementalDecodedImageWithData:(nullable NSData *)data format:(SDImageFormat)format finished:(BOOL)finished;
 
+- (nullable NSData *)encodedDataWithImage:(nullable UIImage *)image format:(SDImageFormat)format properties:(nullable NSDictionary *)properties;
+
+- (nullable NSDictionary *)propertiesOfImageData:(nullable NSData *)data;
+
 @end
 
 @interface UIImage (ForceDecode)

--- a/SDWebImage/SDWebImageDecoder.h
+++ b/SDWebImage/SDWebImageDecoder.h
@@ -9,20 +9,11 @@
 
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
-
-NS_ASSUME_NONNULL_BEGIN
-
-typedef NS_ENUM(NSUInteger, SDWebImageDecoderType) {
-    SDWebImageDecoderTypeAuto = 0, // default, will check image format by sd_imageFormatForImageData and decode only the recognized format
-    SDWebImageDecoderTypeImageIO, // use ImageIO to decode image format that ImageIO support
-    SDWebImageDecoderTypeWebP // use libwebp to decode WebP format
-};
+#import "NSData+ImageContentType.h"
 
 @interface SDWebImageDecoder : NSObject
 
-- (instancetype)initWithType:(SDWebImageDecoderType)type;
-
-- (nullable UIImage *)incrementalDecodedImageWithUpdateData:(nullable NSData *)updateData finished:(BOOL)finished;
+- (nullable UIImage *)incrementalDecodedImageWithData:(nullable NSData *)data format:(SDImageFormat)format finished:(BOOL)finished;
 
 @end
 
@@ -33,5 +24,3 @@ typedef NS_ENUM(NSUInteger, SDWebImageDecoderType) {
 + (nullable UIImage *)decodedAndScaledDownImageWithImage:(nullable UIImage *)image;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/SDWebImage/SDWebImageDecoder.m
+++ b/SDWebImage/SDWebImageDecoder.m
@@ -8,7 +8,6 @@
  */
 
 #import "SDWebImageDecoder.h"
-#import "NSData+ImageContentType.h"
 #import <ImageIO/ImageIO.h>
 #ifdef SD_WEBP
 #if __has_include(<webp/decode.h>)
@@ -17,12 +16,6 @@
 #import "webp/decode.h"
 #endif
 #endif
-
-@interface SDWebImageDecoder ()
-
-@property (assign, nonatomic) SDWebImageDecoderType type;
-
-@end
 
 @implementation SDWebImageDecoder {
     size_t _width, _height;
@@ -48,40 +41,18 @@
 #endif
 }
 
-- (instancetype)initWithType:(SDWebImageDecoderType)type {
-    self = [super init];
-    if (self) {
-        self.type = type;
-    }
-    
-    return self;
-}
-
-- (UIImage *)incrementalDecodedImageWithUpdateData:(NSData *)updateData finished:(BOOL)finished {
-    if (!updateData) {
+- (nullable UIImage *)incrementalDecodedImageWithData:(nullable NSData *)data format:(SDImageFormat)format finished:(BOOL)finished {
+    if (!data) {
         return nil;
     }
     
     UIImage *image;
-    NSData *imageData = [updateData copy];
-    // check image format until it recognize the format
-    if (self.type == SDWebImageDecoderTypeAuto) {
-        SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
-        if (imageFormat == SDImageFormatUndefined) {
-            return nil;
-        } else if (imageFormat == SDWebImageDecoderTypeWebP) {
-            self.type = SDWebImageDecoderTypeWebP;
-        } else {
-            self.type = SDWebImageDecoderTypeImageIO;
-        }
-    }
-    
-    if (self.type == SDWebImageDecoderTypeWebP) {
+    if (format == SDImageFormatWebP) {
 #ifdef SD_WEBP
-        image = [self incrementalWebPDecodedImageWithData:imageData finished:finished];
+        image = [self incrementalWebPDecodedImageWithData:data finished:finished];
 #endif
     } else {
-        image = [self incrementalImageIODecodedImageWithData:imageData finished:finished];
+        image = [self incrementalImageIODecodedImageWithData:data finished:finished];
     }
     
     return image;

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -304,19 +304,21 @@ didReceiveResponse:(NSURLResponse *)response
     if ((self.options & SDWebImageDownloaderProgressiveDownload) && self.expectedSize > 0) {
         UIImage *image;
         if (!self.decoder) {
-#ifdef SD_WEBP
-            if ([self.MIMEType isEqualToString:kWebPMIMEType]) {
-                self.decoder = [[SDWebImageDecoder alloc] initWithType:SDWebImageDecoderTypeWebP];
-            } else {
-#endif
-                self.decoder = [[SDWebImageDecoder alloc] initWithType:SDWebImageDecoderTypeImageIO];
-#ifdef SD_WEBP
-            }
-#endif
+            self.decoder = [[SDWebImageDecoder alloc] init];
         }
-        const NSInteger totalSize = self.imageData.length;
+        
+        NSData *imageData = [self.imageData copy];
+        SDImageFormat format = [NSData sd_imageFormatForImageData:imageData];
+        if (format == SDImageFormatUndefined) {
+            // Check MIME type in case of current received data is too short
+            if ([self.MIMEType isEqualToString:kWebPMIMEType]) {
+                format = SDImageFormatWebP;
+            }
+        }
+        
+        const NSInteger totalSize = imageData.length;
         BOOL finished = (self.expectedSize == totalSize);
-        image = [self.decoder incrementalDecodedImageWithUpdateData:self.imageData finished:finished];
+        image = [self.decoder incrementalDecodedImageWithData:imageData format:format finished:finished];
         if (image) {
             NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
             UIImage *scaledImage = SDScaledImageForKey(key, image);

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -381,7 +381,7 @@ didReceiveResponse:(NSURLResponse *)response
             if (self.imageData) {
                 UIImage *image = [UIImage sd_imageWithData:self.imageData];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
-                image = SDScaledImageForKey(key, image);
+                image = [self scaledImageForKey:key image:image];
                 
                 // Do not force decoding animated GIFs
                 if (!image.images) {
@@ -437,6 +437,10 @@ didReceiveResponse:(NSURLResponse *)response
     if (completionHandler) {
         completionHandler(disposition, credential);
     }
+}
+
+- (nullable UIImage *)scaledImageForKey:(nullable NSString *)key image:(nullable UIImage *)image {
+    return SDScaledImageForKey(key, image);
 }
 
 #pragma mark Helper methods

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -226,7 +226,20 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
         [weakSelf.callbackBlocks removeAllObjects];
     });
     self.dataTask = nil;
-    self.imageData = nil;
+    
+    NSOperationQueue *delegateQueue;
+    if (self.unownedSession) {
+        delegateQueue = self.unownedSession.delegateQueue;
+    } else {
+        delegateQueue = self.ownedSession.delegateQueue;
+    }
+    if (delegateQueue) {
+        NSAssert(delegateQueue.maxConcurrentOperationCount == 1, @"NSURLSession delegate queue should be a serial queue");
+        [delegateQueue addOperationWithBlock:^{
+            weakSelf.imageData = nil;
+        }];
+    }
+    
     if (self.ownedSession) {
         [self.ownedSession invalidateAndCancel];
         self.ownedSession = nil;
@@ -378,8 +391,9 @@ didReceiveResponse:(NSURLResponse *)response
              *  the response data will be nil.
              *  So we don't need to check the cache option here, since the system will obey the cache option
              */
-            if (self.imageData) {
-                UIImage *image = [UIImage sd_imageWithData:self.imageData];
+            NSData *imageData = [self.imageData copy];
+            if (imageData) {
+                UIImage *image = [UIImage sd_imageWithData:imageData];
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                 image = [self scaledImageForKey:key image:image];
                 
@@ -389,7 +403,7 @@ didReceiveResponse:(NSURLResponse *)response
                         if (self.options & SDWebImageDownloaderScaleDownLargeImages) {
 #if SD_UIKIT || SD_WATCH
                             image = [UIImage decodedAndScaledDownImageWithImage:image];
-                            [self.imageData setData:UIImagePNGRepresentation(image)];
+                            imageData = UIImagePNGRepresentation(image);
 #endif
                         } else {
                             image = [UIImage decodedImageWithImage:image];
@@ -399,7 +413,7 @@ didReceiveResponse:(NSURLResponse *)response
                 if (CGSizeEqualToSize(image.size, CGSizeZero)) {
                     [self callCompletionBlocksWithError:[NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Downloaded image has 0 pixels"}]];
                 } else {
-                    [self callCompletionBlocksWithImage:image imageData:self.imageData error:nil finished:YES];
+                    [self callCompletionBlocksWithImage:image imageData:imageData error:nil finished:YES];
                 }
             } else {
                 [self callCompletionBlocksWithError:[NSError errorWithDomain:SDWebImageErrorDomain code:0 userInfo:@{NSLocalizedDescriptionKey : @"Image data is nil"}]];

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -256,6 +256,21 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
+- (void)test16ThatProgressiveWebPWorks {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Progressive WebP download"];
+    NSURL *imageURL = [NSURL URLWithString:@"http://www.ioncannon.net/wp-content/uploads/2011/06/test9.webp"];
+    [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL options:SDWebImageDownloaderProgressiveDownload progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
+        if (image && data && !error && finished) {
+            [expectation fulfill];
+        } else if (finished) {
+            XCTFail(@"Something went wrong");
+        } else {
+            // progressive updates
+        }
+    }];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 /**
  *  Per #883 - Fix multiple requests for same image and then canceling one
  *  Old SDWebImage (3.x) could not handle correctly multiple requests for the same image + cancel


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Fix #2026.
Our `SDWebImageScaleDownLargeImages` options implementation just use `UIImagePNGRepresentation` and this will lose all the EXIF metadata(Because UIImage instance will not keep this information, it was kept in the CGImageSource).

Since we have ImageIO, it's much easier to do image encoding and keep all the EXIF metadata. So we can use this instead of that and keep cross-platform support.

To keep the code clean, I pick the commits from #1987 because it will move all that image decoding/encoding code into seperate class and keep this `SDWebImageDownloadOperation` easy.



