### PR TITLE
Set UIButton's placeholer-image even if the url is nil

### DIFF
--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -71,10 +71,9 @@ static inline NSString * backgroundImageURLKeyForState(UIControlState state) {
                  completed:(nullable SDExternalCompletionBlock)completedBlock {
     if (!url) {
         [self.imageURLStorage removeObjectForKey:imageURLKeyForState(state)];
-        return;
+    } else {
+        self.imageURLStorage[imageURLKeyForState(state)] = url;
     }
-    
-    self.imageURLStorage[imageURLKeyForState(state)] = url;
     
     __weak typeof(self)weakSelf = self;
     [self sd_internalSetImageWithURL:url
@@ -131,10 +130,9 @@ static inline NSString * backgroundImageURLKeyForState(UIControlState state) {
                            completed:(nullable SDExternalCompletionBlock)completedBlock {
     if (!url) {
         [self.imageURLStorage removeObjectForKey:backgroundImageURLKeyForState(state)];
-        return;
+    } else {
+        self.imageURLStorage[backgroundImageURLKeyForState(state)] = url;
     }
-    
-    self.imageURLStorage[backgroundImageURLKeyForState(state)] = url;
     
     __weak typeof(self)weakSelf = self;
     [self sd_internalSetImageWithURL:url


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1964

### Pull Request Description

This is the update for #1790. Which will set UIButton's placeholer-image even if the url is nil. This behavior is what SD3.x obey but break in SD4.0
