### PR TITLE
Creating FLAnimatedImage in global queue to improve displaying gif performance

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -47,6 +47,7 @@ Pod::Spec.new do |s|
     gif.dependency 'SDWebImage/Core'
     gif.dependency 'FLAnimatedImage', '~> 1.0'
     gif.xcconfig = {
+      'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_GIF=1',
       'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/FLAnimatedImage/FLAnimatedImage'
     }
   end

--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -47,7 +47,6 @@ Pod::Spec.new do |s|
     gif.dependency 'SDWebImage/Core'
     gif.dependency 'FLAnimatedImage', '~> 1.0'
     gif.xcconfig = {
-      'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) SD_GIF=1',
       'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/FLAnimatedImage/FLAnimatedImage'
     }
   end

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -54,8 +54,13 @@
                        setImageBlock:^(UIImage *image, NSData *imageData) {
                            SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
                            if (imageFormat == SDImageFormatGIF) {
-                               weakSelf.animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
-                               weakSelf.image = nil;
+                               dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+                                   FLAnimatedImage *animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
+                                   dispatch_main_async_safe(^{
+                                       weakSelf.animatedImage = animatedImage;
+                                       weakSelf.image = nil;
+                                   });
+                               });
                            } else {
                                weakSelf.image = image;
                                weakSelf.animatedImage = nil;

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -69,7 +69,8 @@
                            });
                        }
                             progress:progressBlock
-                           completed:completedBlock];
+                           completed:completedBlock
+                             context:@{SDWebImageInternalSetImageInGlobalQueueKey: @(YES)}];
 }
 
 @end

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -52,19 +52,21 @@
                              options:options
                         operationKey:nil
                        setImageBlock:^(UIImage *image, NSData *imageData) {
+                           // This setImageBlock may not called from main queue
                            SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
+                           FLAnimatedImage *animatedImage;
                            if (imageFormat == SDImageFormatGIF) {
-                               dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-                                   FLAnimatedImage *animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
-                                   dispatch_main_async_safe(^{
-                                       weakSelf.animatedImage = animatedImage;
-                                       weakSelf.image = nil;
-                                   });
-                               });
-                           } else {
-                               weakSelf.image = image;
-                               weakSelf.animatedImage = nil;
+                               animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
                            }
+                           dispatch_main_async_safe(^{
+                               if (animatedImage) {
+                                   weakSelf.animatedImage = animatedImage;
+                                   weakSelf.image = nil;
+                               } else {
+                                   weakSelf.image = image;
+                                   weakSelf.animatedImage = nil;
+                               }
+                           });
                        }
                             progress:progressBlock
                            completed:completedBlock];

--- a/SDWebImage/SDWebImageCodersManager.h
+++ b/SDWebImage/SDWebImageCodersManager.h
@@ -11,13 +11,13 @@
 
 /**
  Global object holding the array of coders, so that we avoid passing them from object to object.
- Uses a priority queue behind scenes, which means the latest added coders have priority.
+ Uses a priority queue behind scenes, which means the latest added coders have the highest priority.
  This is done so when encoding/decoding something, we go through the list and ask each coder if they can handle the current data.
  That way, users can add their custom coders while preserving our existing prebuilt ones
  
  Note: the `coders` getter will return the coders in their reversed order
  Example:
- - by default we internally set coders = `IOCoder`, `WebPCoder`
+ - by default we internally set coders = `IOCoder`, `WebPCoder`. (`GIFCoder` is not recommended to add only if you want to get GIF support without `FLAnimatedImage`)
  - calling `coders` will return `@[WebPCoder, IOCoder]`
  - call `[addCoder:[MyCrazyCoder new]]`
  - calling `coders` now returns `@[MyCrazyCoder, WebPCoder, IOCoder]`

--- a/SDWebImage/SDWebImageGIFCoder.h
+++ b/SDWebImage/SDWebImageGIFCoder.h
@@ -13,7 +13,8 @@
  Built in coder using ImageIO that supports GIF encoding/decoding
  @note `SDWebImageIOCoder` supports GIF but only as static (will use the 1st frame).
  @note Use `SDWebImageGIFCoder` for fully animated GIFs - less performant than `FLAnimatedImage`
- @note The recommended approach for animated GIFs is using `FLAnimatedImage`
+ @note If you decide to make all `UIImageView`(including `FLAnimatedImageView`) instance support GIF. You should add this coder to `SDWebImageCodersManager` and make sure that it has a higher priority than `SDWebImageIOCoder`
+ @note The recommended approach for animated GIFs is using `FLAnimatedImage`. It's more performant than `UIImageView` for GIF displaying
  */
 @interface SDWebImageGIFCoder : NSObject <SDWebImageCoder>
 

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -100,7 +100,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     
     SDImageFormat format = [NSData sd_imageFormatForImageData:data];
     if (format == SDImageFormatGIF) {
-        // static single GIF need to be created animated for FLAnimatedImageView logic
+        // static single GIF need to be created animated for `FLAnimatedImage` logic
         // GIF does not support EXIF image orientation
         image = [UIImage animatedImageWithImages:@[image] duration:image.duration];
         return image;

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -12,6 +12,8 @@
 
 #import "SDWebImageManager.h"
 
+FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageInGlobalQueueKey;
+
 typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable imageData);
 
 @interface UIView (WebCache)
@@ -49,6 +51,34 @@ typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable ima
                      setImageBlock:(nullable SDSetImageBlock)setImageBlock
                           progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                          completed:(nullable SDExternalCompletionBlock)completedBlock;
+
+/**
+ * Set the imageView `image` with an `url` and optionally a placeholder image.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url            The url for the image.
+ * @param placeholder    The image to be set initially, until the image request finishes.
+ * @param options        The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param operationKey   A string to be used as the operation key. If nil, will use the class name
+ * @param setImageBlock  Block used for custom set image code
+ * @param progressBlock  A block called while image is downloading
+ *                       @note the progress block is executed on a background queue
+ * @param completedBlock A block called when operation has been completed. This block has no return value
+ *                       and takes the requested UIImage as first parameter. In case of error the image parameter
+ *                       is nil and the second parameter may contain an NSError. The third parameter is a Boolean
+ *                       indicating if the image was retrieved from the local cache or from the network.
+ *                       The fourth parameter is the original image url.
+ * @param context        A context with extra information to perform specify changes or processes.
+ */
+- (void)sd_internalSetImageWithURL:(nullable NSURL *)url
+                  placeholderImage:(nullable UIImage *)placeholder
+                           options:(SDWebImageOptions)options
+                      operationKey:(nullable NSString *)operationKey
+                     setImageBlock:(nullable SDSetImageBlock)setImageBlock
+                          progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                         completed:(nullable SDExternalCompletionBlock)completedBlock
+                           context:(nullable NSDictionary *)context;
 
 /**
  * Cancel the current download

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -68,6 +68,7 @@ static char TAG_ACTIVITY_SHOW;
             __strong __typeof (wself) sself = wself;
             [sself sd_removeActivityIndicator];
             if (!sself) { return; }
+            BOOL shouldCallCompletedBlock = finished || (options & SDWebImageAvoidAutoSetImage);
             BOOL shouldNotSetImage = ((image && (options & SDWebImageAvoidAutoSetImage)) ||
                                       (!image && !(options & SDWebImageDelayPlaceholder)));
             SDWebImageNoParamsBlock callCompletedBlockClojure = ^{
@@ -75,7 +76,7 @@ static char TAG_ACTIVITY_SHOW;
                 if (!shouldNotSetImage) {
                     [sself sd_setNeedsLayout];
                 }
-                if (completedBlock && (shouldNotSetImage || finished)) {
+                if (completedBlock && shouldCallCompletedBlock) {
                     completedBlock(image, error, cacheType, url);
                 }
             };

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -13,12 +13,6 @@
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 
-#if __has_include(<FLAnimatedImage/FLAnimatedImage.h>)
-#import <FLAnimatedImage/FLAnimatedImage.h>
-#else
-#import "FLAnimatedImage.h"
-#endif
-
 static char imageURLKey;
 
 #if SD_UIKIT
@@ -83,7 +77,7 @@ static char TAG_ACTIVITY_SHOW;
                 targetImage = placeholder;
                 targetData = nil;
             }
-            if ([sself isKindOfClass:[FLAnimatedImageView class]]) {
+            if ([sself isKindOfClass:NSClassFromString(@"FLAnimatedImageView")]) {
                 // performance enhancement for `FLAnimatedImage`
                 dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
                     [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -65,13 +65,14 @@ static char TAG_ACTIVITY_SHOW;
             if (!sself) {
                 return;
             }
+            BOOL shouldCallCompletedBlock = finished || (options & SDWebImageAvoidAutoSetImage);
             if ((image && (options & SDWebImageAvoidAutoSetImage)) || (!image && !(options & SDWebImageDelayPlaceholder))) {
                 // no need to call setImageBlock and layout, then return
                 dispatch_main_async_safe(^{
                     if (!sself) {
                         return;
                     }
-                    if (completedBlock) {
+                    if (completedBlock && shouldCallCompletedBlock) {
                         completedBlock(image, error, cacheType, url);
                     }
                 });
@@ -102,7 +103,7 @@ static char TAG_ACTIVITY_SHOW;
                         return;
                     }
                     [sself sd_setNeedsLayout];
-                    if (completedBlock && finished) {
+                    if (completedBlock && shouldCallCompletedBlock) {
                         completedBlock(image, error, cacheType, url);
                     }
                 });

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -13,6 +13,14 @@
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 
+#ifdef SD_GIF
+#if __has_include(<FLAnimatedImage/FLAnimatedImage.h>)
+#import <FLAnimatedImage/FLAnimatedImage.h>
+#else
+#import "FLAnimatedImage.h"
+#endif
+#endif
+
 static char imageURLKey;
 
 #if SD_UIKIT
@@ -79,13 +87,13 @@ static char TAG_ACTIVITY_SHOW;
                 targetImage = placeholder;
                 targetData = nil;
             }
-            dispatch_queue_t targetQueue;
-            if ([sself isKindOfClass:NSClassFromString(@"FLAnimatedImageView")]) {
+            dispatch_queue_t targetQueue = dispatch_get_main_queue();
+#ifdef SD_GIF
+            if ([sself isKindOfClass:[FLAnimatedImageView class]]) {
                 // performance enhancement for `FLAnimatedImage`
                 targetQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
-            } else {
-                targetQueue = dispatch_get_main_queue();
             }
+#endif
             
             dispatch_async(targetQueue, ^{
                 [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues:  #1901

### Pull Request Description

@Silence-GitHub 
When using FLAnimatedImageView in table view cell, displaying too many
GIF images may lead to performance problem. Creating FLAnimatedImage in
global queue (not in main queue) solves the problem, and makes
scrolling smoothly.
