### PR TITLE
Fix #1941 by placing a lock to avoid multi-thread issue for SDWebImageCombinedOperation cancelBlock

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -228,11 +228,14 @@
                     [self safelyRemoveOperationFromRunning:strongOperation];
                 }
             }];
-            operation.cancelBlock = ^{
-                [self.imageDownloader cancel:subOperationToken];
-                __strong __typeof(weakOperation) strongOperation = weakOperation;
-                [self safelyRemoveOperationFromRunning:strongOperation];
-            };
+            @synchronized(operation) {
+                // Need same lock to ensure cancelBlock called because cancel method can be called in different queue
+                operation.cancelBlock = ^{
+                    [self.imageDownloader cancel:subOperationToken];
+                    __strong __typeof(weakOperation) strongOperation = weakOperation;
+                    [self safelyRemoveOperationFromRunning:strongOperation];
+                };
+            }
         } else if (cachedImage) {
             __strong __typeof(weakOperation) strongOperation = weakOperation;
             [self callCompletionBlockForOperation:strongOperation completion:completedBlock image:cachedImage data:cachedData error:nil cacheType:cacheType finished:YES url:url];
@@ -319,18 +322,16 @@
 }
 
 - (void)cancel {
-    self.cancelled = YES;
-    if (self.cacheOperation) {
-        [self.cacheOperation cancel];
-        self.cacheOperation = nil;
-    }
-    if (self.cancelBlock) {
-        self.cancelBlock();
-        
-        // TODO: this is a temporary fix to #809.
-        // Until we can figure the exact cause of the crash, going with the ivar instead of the setter
-//        self.cancelBlock = nil;
-        _cancelBlock = nil;
+    @synchronized(self) {
+        self.cancelled = YES;
+        if (self.cacheOperation) {
+            [self.cacheOperation cancel];
+            self.cacheOperation = nil;
+        }
+        if (self.cancelBlock) {
+            self.cancelBlock();
+            self.cancelBlock = nil;
+        }
     }
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1941 

### Pull Request Description

This is an non thread-safe issue related to `SDWebImageManager`.

Our SDWebImageManager have a `- (void)cancel` method and it can be called through any queue. But we also have `operation.cancelBlock` this setter method during the `queryCacheOperationForKey:done:` block. 

Assume this situation:
1. Queue2: cancel method called and `self.cancelled = YES;`
2. Queue1: done block call `setCancelBlock:` setter method and `if (self.isCancelled)` passed
3. Queue1: setter method hit `_cancelBlock = nil;`
4. Queue2: cancel method hit `self.cancelBlock();`

This will cause a crash. 

Moreover, beside crash, current code has another race condition which will cause logic error. So this could not solved by simply change property attribute from **nonatomic** to **atomic**. 

Assume this situation:
1. Queue1: done block call `setCancelBlock:` setter method and `if (self.isCancelled)` failed
2. Queue2: cancel method called and set `self.cancelled = YES;`
3. Queue1: setter method hit `_cancelBlock = nil;`
4. Queue2: cancel method hit `if (self.cancelBlock)` and will fail

Then the cancelBlock will never been called. This is also a big problem(memory leak and so on).

So a better and seems easier solution is to place a lock in this two methods. Synchronized is fast enough since these methods will not be called very frequently.

