### PR TITLE
Fix SDWebImageDownloaderOperation not call done when use SDWebImageDownloaderIgnoreCachedResponse

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -480,7 +480,7 @@ didReceiveResponse:(NSURLResponse *)response
                         shouldDecode = NO;
                     } else {
 #ifdef SD_WEBP
-                        SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:self.imageData];
+                        SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
                         if (imageFormat == SDImageFormatWebP) {
                             shouldDecode = NO;
                         }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description
@bpoplauschi  Sorry to bother. In #2032 I adopt the previous behavior and add a cache image check. But there is a mistake that the early return code in line 475 will cause `[self done]` not been called. It will not mark this operation to be completed and may cause problems(such as memory leak, logic error. SD itself will be safe but our users may add KVO to this `NSOperation`. And maybe this is why all the tests is passed with no issues). So I advice to fix it as soon as possible(Maybe another little patch release?). 😢 
