### PR TITLE
Allow user to provide reading options such as mapped file to improve performance in SDImageCache disk cache

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -311,14 +311,14 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (nullable NSData *)diskImageDataBySearchingAllPathsForKey:(nullable NSString *)key {
     NSString *defaultPath = [self defaultCachePathForKey:key];
-    NSData *data = [NSData dataWithContentsOfFile:defaultPath];
+    NSData *data = [NSData dataWithContentsOfFile:defaultPath options:self.config.diskCacheReadingOptions error:nil];
     if (data) {
         return data;
     }
 
     // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
     // checking the key with and without the extension
-    data = [NSData dataWithContentsOfFile:defaultPath.stringByDeletingPathExtension];
+    data = [NSData dataWithContentsOfFile:defaultPath.stringByDeletingPathExtension options:self.config.diskCacheReadingOptions error:nil];
     if (data) {
         return data;
     }
@@ -326,14 +326,14 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     NSArray<NSString *> *customPaths = [self.customPaths copy];
     for (NSString *path in customPaths) {
         NSString *filePath = [self cachePathForKey:key inPath:path];
-        NSData *imageData = [NSData dataWithContentsOfFile:filePath];
+        NSData *imageData = [NSData dataWithContentsOfFile:filePath options:self.config.diskCacheReadingOptions error:nil];
         if (imageData) {
             return imageData;
         }
 
         // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
         // checking the key with and without the extension
-        imageData = [NSData dataWithContentsOfFile:filePath.stringByDeletingPathExtension];
+        imageData = [NSData dataWithContentsOfFile:filePath.stringByDeletingPathExtension options:self.config.diskCacheReadingOptions error:nil];
         if (imageData) {
             return imageData;
         }

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -18,7 +18,7 @@
 @property (assign, nonatomic) BOOL shouldDecompressImages;
 
 /**
- *  disable iCloud backup [defaults to YES]
+ * disable iCloud backup [defaults to YES]
  */
 @property (assign, nonatomic) BOOL shouldDisableiCloud;
 
@@ -28,7 +28,13 @@
 @property (assign, nonatomic) BOOL shouldCacheImagesInMemory;
 
 /**
- * The maximum length of time to keep an image in the cache, in seconds
+ * The reading options while reading cache from disk.
+ * Defaults to 0. You can set this to mapped file to improve performance.
+ */
+@property (assign, nonatomic) NSDataReadingOptions diskCacheReadingOptions;
+
+/**
+ * The maximum length of time to keep an image in the cache, in seconds.
  */
 @property (assign, nonatomic) NSInteger maxCacheAge;
 

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -17,6 +17,7 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
         _shouldDecompressImages = YES;
         _shouldDisableiCloud = YES;
         _shouldCacheImagesInMemory = YES;
+        _diskCacheReadingOptions = 0;
         _maxCacheAge = kDefaultCacheMaxCacheAge;
         _maxCacheSize = 0;
     }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

SDImageCache disk cache use the NSData to load the disk cache. Which provide a reading options such as mapped file(using virtual memory). This can improve performance and reduce memory usage in some cases. I advice to expose this options to user and let them to decide whether to use it or not(default is 0).

This is also related to #1707. After some experiment, I found that why `CGImageSourceCreateWithURL:` is faster that `[UIImage imageWithData:]:` is not so magic(See the comments in #1707 ). The `CGImageSourceCreateWithURL` will always use the mapped file while reading file URL. This feature will not break any public API, current behaviour and I think it's a easier and better ways to improve SDImageCache performance.
