### PR TITLE
Fix nil crash if GIF single frame decoding failed

### DIFF
--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -45,7 +45,9 @@
         CGImageRef CGImage = CGImageSourceCreateImageAtIndex(source, 0, NULL);
 #if SD_UIKIT || SD_WATCH
         UIImage *frameImage = [UIImage imageWithCGImage:CGImage scale:scale orientation:UIImageOrientationUp];
-        staticImage = [UIImage animatedImageWithImages:@[frameImage] duration:0.0f];
+        if (frameImage) {
+            staticImage = [UIImage animatedImageWithImages:@[frameImage] duration:0.0f];
+        }
 #endif
         CGImageRelease(CGImage);
     }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1837

### Pull Request Description

`CGImageSourceCreateImageAtIndex` is nullable. So if GIF single frame decoding failed, the image will be nil. And then the `@[frameImage]` will cause exception because attempting to insert nil into NSArray.

