### PR TITLE
Cached image filename are sometimes generated with invalid path extensions

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -171,10 +171,11 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     }
     unsigned char r[CC_MD5_DIGEST_LENGTH];
     CC_MD5(str, (CC_LONG)strlen(str), r);
+    NSURL *keyURL = [NSURL URLWithString:key];
+    NSString *ext = keyURL ? keyURL.pathExtension : key.pathExtension;
     NSString *filename = [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%@",
                           r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10],
-                          r[11], r[12], r[13], r[14], r[15], [key.pathExtension isEqualToString:@""] ? @"" : [NSString stringWithFormat:@".%@", key.pathExtension]];
-
+                          r[11], r[12], r[13], r[14], r[15], ext.length == 0 ? @"" : [NSString stringWithFormat:@".%@", ext]];
     return filename;
 }
 


### PR DESCRIPTION
### New Issue Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar issue in the [project](https://github.com/rs/SDWebImage/issues) and found none

### Issue Info

 Info                    | Value                               |
-------------------------|-------------------------------------|
 Platform Name           | iOS / tvOS
 Platform Version        | All supported
 SDWebImage Version      | e.g. 3.7.0+
 Integration Method      | All supported
 Xcode Version           | All supported
 Repro rate              | 100%
 Repro with our demo prj | With custom URL

### Issue Description and Steps

I have been having issues with `-[SDImageCache cachedFileNameForKey:]`, returning an invalid path when the key contains dots that don't represent a path extension separator, for instance : `https://maps.googleapis.com/maps/api/staticmap?center=48.8566,2.3522&format=png&maptype=roadmap&scale=2&size=375x200&zoom=15`. This is a URL pointing to an image, but the image doesn't have any easily recognisable extension in its URL.

The issue can be fixed by using `-[NSURL pathExtension]` instead of `-[NSString pathExtension]`, which is aware of the URL format and can more accurately return a valid `pathExtension`. This pull request implements the aforementioned fix. 

To prevent keys that wouldn't be URL, the extension is defaulted back to `-[NSString pathExtension]` if a `NSURL` cannot be created from the given `key`. The `pathExtension` property is marked as `nullable`, I also took the liberty to change the ternary test in the filename generation to support the case where it is `nil`.

Thanks for considering this patch!