### PR TITLE
Give back our GIF category animation support since we now use plugin coders

### DIFF
--- a/SDWebImage/SDWebImageCodersManager.h
+++ b/SDWebImage/SDWebImageCodersManager.h
@@ -17,10 +17,10 @@
  
  Note: the `coders` getter will return the coders in their reversed order
  Example:
- - by default we internally set coders = `IOCoder`, `GIFCoder`, `WebPCoder`
- - calling `coders` will return `@[WebPCoder, GIFCoder, IOCoder]`
+ - by default we internally set coders = `IOCoder`, `WebPCoder`
+ - calling `coders` will return `@[WebPCoder, IOCoder]`
  - call `[addCoder:[MyCrazyCoder new]]`
- - calling `coders` now returns `@[MyCrazyCoder, WebPCoder, GIFCoder, IOCoder]`
+ - calling `coders` now returns `@[MyCrazyCoder, WebPCoder, IOCoder]`
  
  Coders
  ------

--- a/SDWebImage/SDWebImageCodersManager.m
+++ b/SDWebImage/SDWebImageCodersManager.m
@@ -34,7 +34,7 @@
 - (instancetype)init {
     if (self = [super init]) {
         // initialize with default coders
-        _mutableCoders = [@[[SDWebImageImageIOCoder sharedCoder], [SDWebImageGIFCoder sharedCoder]] mutableCopy];
+        _mutableCoders = [@[[SDWebImageImageIOCoder sharedCoder]] mutableCopy];
 #ifdef SD_WEBP
         [_mutableCoders addObject:[SDWebImageWebPCoder sharedCoder]];
 #endif

--- a/SDWebImage/SDWebImageGIFCoder.h
+++ b/SDWebImage/SDWebImageGIFCoder.h
@@ -10,7 +10,10 @@
 #import "SDWebImageCoder.h"
 
 /**
- Built in coder that supports GIF
+ Built in coder using ImageIO that supports GIF encoding/decoding
+ @note `SDWebImageIOCoder` supports GIF but only as static (will use the 1st frame).
+ @note Use `SDWebImageGIFCoder` for fully animated GIFs - less performant than `FLAnimatedImage`
+ @note The recommended approach for animated GIFs is using `FLAnimatedImage`
  */
 @interface SDWebImageGIFCoder : NSObject <SDWebImageCoder>
 

--- a/SDWebImage/SDWebImageImageIOCoder.h
+++ b/SDWebImage/SDWebImageImageIOCoder.h
@@ -11,6 +11,8 @@
 
 /**
  Built in coder that supports PNG, JPEG, TIFF, includes support for progressive decoding
+ Also supports static GIF (meaning will only handle the 1st frame).
+ For a full GIF support, we recommend `FLAnimatedImage` or our less performant `SDWebImageGIFCoder`
  */
 @interface SDWebImageImageIOCoder : NSObject <SDWebImageProgressiveCoder>
 

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -67,7 +67,6 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 - (BOOL)canDecodeFromData:(nullable NSData *)data {
     switch ([NSData sd_imageFormatForImageData:data]) {
         // Do not support GIF and WebP decoding
-        case SDImageFormatGIF:
         case SDImageFormatWebP:
             return NO;
         default:
@@ -91,6 +90,17 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     }
     
     UIImage *image = [[UIImage alloc] initWithData:data];
+    if (!image) {
+        return nil;
+    }
+    
+    SDImageFormat format = [NSData sd_imageFormatForImageData:data];
+    if (format == SDImageFormatGIF) {
+        // static single GIF need to be created animated for FLAnimatedImageView logic
+        // GIF does not support EXIF image orientation
+        image = [UIImage animatedImageWithImages:@[image] duration:image.duration];
+        return image;
+    }
 #if SD_UIKIT || SD_WATCH
     UIImageOrientation orientation = [[self class] sd_imageOrientationFromImageData:data];
     if (orientation != UIImageOrientationUp) {
@@ -373,7 +383,6 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 - (BOOL)canEncodeToFormat:(SDImageFormat)format {
     switch (format) {
         // Do not support GIF and WebP encoding
-        case SDImageFormatGIF:
         case SDImageFormatWebP:
             return NO;
         default:

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -66,7 +66,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 #pragma mark - Decode
 - (BOOL)canDecodeFromData:(nullable NSData *)data {
     switch ([NSData sd_imageFormatForImageData:data]) {
-        // Do not support GIF and WebP decoding
+        // Do not support WebP decoding
         case SDImageFormatWebP:
             return NO;
         default:
@@ -382,7 +382,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 #pragma mark - Encode
 - (BOOL)canEncodeToFormat:(SDImageFormat)format {
     switch (format) {
-        // Do not support GIF and WebP encoding
+        // Do not support WebP encoding
         case SDImageFormatWebP:
             return NO;
         default:

--- a/SDWebImage/UIImage+GIF.h
+++ b/SDWebImage/UIImage+GIF.h
@@ -12,12 +12,13 @@
 @interface UIImage (GIF)
 
 /**
- *  Compatibility method - creates an animated UIImage from an NSData, it will only contain the 1st frame image
+ *  Creates an animated UIImage from an NSData.
+ *  For static GIF, will create an UIImage with `images` array set to nil. For animated GIF, will create an UIImage with valid `images` array.
  */
 + (UIImage *)sd_animatedGIFWithData:(NSData *)data;
 
 /**
- *  Checks if an UIImage instance is a GIF. Will use the `images` array
+ *  Checks if an UIImage instance is a GIF. Will use the `images` array.
  */
 - (BOOL)isGIF;
 


### PR DESCRIPTION
Give back our GIF category animation support since we now use plugin coders. 
This will not affect FLAnimatedImageView which just create the first frame.

1. Change default coders to [IOCoder, WebPCoder]
2. Add back our previous GIF decoding code, with loop count support
3. Add GIF encoding code for animation
4. Modify IOCoder for GIF format because FLAnimatedImageView need just use the first frame

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Welcome back our previous `UIImage+GIF` category for animated GIF!
Because we have do refactor and separate the UIImage+XXX category with different coders. And then SD inner will not relay on that `UIImage+GIF` any methods.

This means we can keep our `FLAnimatedImageView` fast but also provide the full version `UIImage+GIF` support. We can let **ImageIOCoder** to just grab the first frame and make `FLAnimatedImageView` behave the same as previous version. And then our `UIImage+GIF` category can use **GIFCoder** to do additional GIF animation support.

Besides just grab the previous version GIF decoding code(From 3.8.2), I add some more such as image loop count(Since now we use a `sd_imageLoopCount` property). And also, I provide the animated GIF encoding method. Our users can now use that category to perform full-functional GIF support.
