### PR TITLE
Attempt for #1901 follow up to #2047 - trying to warm the image on a background queue and not call the completion before setting the image.

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -47,14 +47,20 @@
                   progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                  completed:(nullable SDExternalCompletionBlock)completedBlock {
     __weak typeof(self)weakSelf = self;
+    __block FLAnimatedImage *animatedImage = nil;
     [self sd_internalSetImageWithURL:url
                     placeholderImage:placeholder
                              options:options
                         operationKey:nil
+                      warmImageBlock:^(UIImage *image, NSData *imageData) {
+                          SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
+                          if (imageFormat == SDImageFormatGIF) {
+                              animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
+                          }
+                      }
                        setImageBlock:^(UIImage *image, NSData *imageData) {
-                           SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
-                           if (imageFormat == SDImageFormatGIF) {
-                               weakSelf.animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
+                           if (animatedImage != nil) {
+                               weakSelf.animatedImage = animatedImage;
                                weakSelf.image = nil;
                            } else {
                                weakSelf.image = image;

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -13,6 +13,7 @@
 #import "SDWebImageManager.h"
 
 typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable imageData);
+typedef void(^SDWarmImageBlock)(UIImage * _Nullable image, NSData * _Nullable imageData);
 
 @interface UIView (WebCache)
 
@@ -46,6 +47,15 @@ typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable ima
                   placeholderImage:(nullable UIImage *)placeholder
                            options:(SDWebImageOptions)options
                       operationKey:(nullable NSString *)operationKey
+                     setImageBlock:(nullable SDSetImageBlock)setImageBlock
+                          progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                         completed:(nullable SDExternalCompletionBlock)completedBlock;
+
+- (void)sd_internalSetImageWithURL:(nullable NSURL *)url
+                  placeholderImage:(nullable UIImage *)placeholder
+                           options:(SDWebImageOptions)options
+                      operationKey:(nullable NSString *)operationKey
+                    warmImageBlock:(nullable SDWarmImageBlock)warmImageBlock
                      setImageBlock:(nullable SDSetImageBlock)setImageBlock
                           progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                          completed:(nullable SDExternalCompletionBlock)completedBlock;


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [X] I have added the required tests to prove the fix/feature I am adding
* [X] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1901 #2047

### Attempt to fix #1901 follow up to #2047 - trying to warm the image on a background queue and not call the completion before setting the image.

- had to add another block param to `sd_internalSetImageWithURL` that allows a warm image block called on a background queue
- the `warmImageBlock` is executed on a background NSOperation, after completion returns to main queue and calls `setImageBlock` and then the `completedBlock`
- had to pass the `completedBlock` from `sd_internalSetImageWithURL` to `sd_setImage` so that we can call it right after `setImageBlock`, which can be called async
- overall looks too complicated, not sure if we want such code
- also, I think the overall GIF performance problem can be worked around by just using `SDWebImageAvoidAutoSetImage` and using the completion block to create the `FLAnimatedImage` on a background thread.