### PR TITLE
Implements -[NSImage isGIF] method to return whether current NSImage is GIF representation.

### DIFF
--- a/SDWebImage/NSImage+WebCache.m
+++ b/SDWebImage/NSImage+WebCache.m
@@ -23,7 +23,18 @@
 }
 
 - (BOOL)isGIF {
-    return NO;
+    BOOL isGIF = NO;
+    for (NSImageRep *rep in self.representations) {
+        if ([rep isKindOfClass:[NSBitmapImageRep class]]) {
+            NSBitmapImageRep *bitmapRep = (NSBitmapImageRep *)rep;
+            NSUInteger frameCount = [[bitmapRep valueForProperty:NSImageFrameCount] unsignedIntegerValue];
+            if (frameCount > 1) {
+                isGIF = YES;
+                break;
+            }
+        }
+    }
+    return isGIF;
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Although we introduce this method to integrate FLAnimatedImage from 4.0. (This `isGIF` method is also in UIImage+GIF category). And previously used for some GIF logic but then we directly use `UIImage.images` because it's more clear and easy). And now since we do not rely on UIImage+GIF category, we can implement and open this to user.
