### PR TITLE
For ImageIO coder, if the image is scaled down, then we need to modify the original image data pointer

### DIFF
--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -213,7 +213,16 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     if (!shouldScaleDown) {
         return [self sd_decompressedImageWithImage:image];
     } else {
-        return [self sd_decompressedAndScaledDownImageWithImage:image];
+        UIImage *scaledDownImage = [self sd_decompressedAndScaledDownImageWithImage:image];
+        if (scaledDownImage && !CGSizeEqualToSize(scaledDownImage.size, image.size)) {
+            // if the image is scaled down, need to modify the data pointer as well
+            SDImageFormat format = [NSData sd_imageFormatForImageData:*data];
+            NSData *imageData = [self encodedDataWithImage:scaledDownImage format:format];
+            if (imageData) {
+                *data = imageData;
+            }
+        }
+        return scaledDownImage;
     }
 #endif
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2026

### Pull Request Description

We should keep previous behavior. So for shouldScaleDown options, we need to modify the original image data after we sucessfully scaled down the image.

