### PR TITLE
Add targets for core frameworks without MapKit, WebP and FLAnimatedImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ script:
     - xcodebuild clean build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage iOS static' -sdk iphonesimulator PLATFORM_NAME=iphonesimulator -configuration Debug | xcpretty -c
     - xcodebuild clean build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage watchOS static' -sdk watchsimulator -configuration Debug | xcpretty -c
 
+    - echo Build as dynamic core framework
+    - xcodebuild clean build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage Core OSX' -sdk macosx -configuration Debug | xcpretty -c
+    - xcodebuild clean build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage Core iOS' -sdk iphonesimulator PLATFORM_NAME=iphonesimulator -configuration Debug | xcpretty -c
+    - xcodebuild clean build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage Core tvOS' -sdk appletvsimulator -configuration Debug | xcpretty -c
+    - xcodebuild clean build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage Core watchOS' -sdk watchsimulator -configuration Debug | xcpretty -c
+
     - echo Build as dynamic framework
     - xcodebuild clean build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage OSX' -sdk macosx -configuration Debug | xcpretty -c
     - xcodebuild clean build -workspace SDWebImage.xcworkspace -scheme 'SDWebImage iOS' -sdk iphonesimulator PLATFORM_NAME=iphonesimulator -configuration Debug | xcpretty -c

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -758,6 +758,22 @@
 		621517FD1FA0E06000D73275 /* UIImageView+HighlightedWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = ABBE71A618C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m */; };
 		621517FE1FA0E06000D73275 /* UIImageView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D96148C56230056699D /* UIImageView+WebCache.m */; };
 		621517FF1FA0E06000D73275 /* UIView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4369C2761D9807EC007E863A /* UIView+WebCache.m */; };
+		629D1C711FAB7A9F00FBFD8E /* SDWebImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		629D1C721FAB7A9F00FBFD8E /* SDWebImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		629D1C731FAB7AA000FBFD8E /* SDWebImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		629D1C741FAB7AA000FBFD8E /* SDWebImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		629D1C751FAB7ADC00FBFD8E /* SDWebImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDWebImageFrame.m */; };
+		629D1C761FAB7ADC00FBFD8E /* SDWebImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDWebImageFrame.m */; };
+		629D1C771FAB7ADC00FBFD8E /* SDWebImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDWebImageFrame.m */; };
+		629D1C781FAB7ADD00FBFD8E /* SDWebImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDWebImageFrame.m */; };
+		629D1C791FAB7AE400FBFD8E /* SDWebImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDWebImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		629D1C7A1FAB7AE500FBFD8E /* SDWebImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDWebImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		629D1C7B1FAB7AE500FBFD8E /* SDWebImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDWebImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		629D1C7C1FAB7AE500FBFD8E /* SDWebImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDWebImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		629D1C7D1FAB7AF300FBFD8E /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
+		629D1C7E1FAB7AF500FBFD8E /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
+		629D1C7F1FAB7AF500FBFD8E /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
+		629D1C801FAB7AF600FBFD8E /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
 		80377BF81F2F665300F89830 /* bit_reader_inl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 80377BDE1F2F665300F89830 /* bit_reader_inl_utils.h */; };
 		80377BF91F2F665300F89830 /* bit_reader_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 80377BDF1F2F665300F89830 /* bit_reader_utils.c */; };
 		80377BFA1F2F665300F89830 /* bit_reader_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 80377BE01F2F665300F89830 /* bit_reader_utils.h */; };
@@ -2666,6 +2682,7 @@
 				621514E61FA0CEC400D73275 /* SDWebImageGIFCoder.h in Headers */,
 				621514EE1FA0CEC400D73275 /* NSImage+WebCache.h in Headers */,
 				621514EB1FA0CEC400D73275 /* UIImage+MultiFormat.h in Headers */,
+				629D1C711FAB7A9F00FBFD8E /* SDWebImageCoderHelper.h in Headers */,
 				621514F11FA0CEC400D73275 /* UIImageView+WebCache.h in Headers */,
 				621514E41FA0CEC400D73275 /* SDWebImageCoder.h in Headers */,
 				621514ED1FA0CEC400D73275 /* UIView+WebCacheOperation.h in Headers */,
@@ -2678,6 +2695,7 @@
 				621514EF1FA0CEC400D73275 /* UIButton+WebCache.h in Headers */,
 				621514E11FA0CEC400D73275 /* SDImageCache.h in Headers */,
 				621514E71FA0CEC400D73275 /* SDWebImageManager.h in Headers */,
+				629D1C791FAB7AE400FBFD8E /* SDWebImageFrame.h in Headers */,
 				621514F51FA0D19100D73275 /* SDWebImageCore.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2696,6 +2714,7 @@
 				621517941FA0DED500D73275 /* UIView+WebCache.h in Headers */,
 				621517861FA0DED500D73275 /* SDWebImageCoder.h in Headers */,
 				621517831FA0DED500D73275 /* SDImageCache.h in Headers */,
+				629D1C721FAB7A9F00FBFD8E /* SDWebImageCoderHelper.h in Headers */,
 				6215177F1FA0DED500D73275 /* SDWebImageCompat.h in Headers */,
 				6215178F1FA0DED500D73275 /* UIView+WebCacheOperation.h in Headers */,
 				621517851FA0DED500D73275 /* SDWebImageCodersManager.h in Headers */,
@@ -2708,6 +2727,7 @@
 				621517921FA0DED500D73275 /* UIImageView+HighlightedWebCache.h in Headers */,
 				621517931FA0DED500D73275 /* UIImageView+WebCache.h in Headers */,
 				621517811FA0DED500D73275 /* SDWebImageDownloader.h in Headers */,
+				629D1C7A1FAB7AE500FBFD8E /* SDWebImageFrame.h in Headers */,
 				621517841FA0DED500D73275 /* SDImageCacheConfig.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2726,6 +2746,7 @@
 				621517AA1FA0DED500D73275 /* UIView+WebCache.h in Headers */,
 				6215179C1FA0DED500D73275 /* SDWebImageCoder.h in Headers */,
 				621517991FA0DED500D73275 /* SDImageCache.h in Headers */,
+				629D1C731FAB7AA000FBFD8E /* SDWebImageCoderHelper.h in Headers */,
 				621517951FA0DED500D73275 /* SDWebImageCompat.h in Headers */,
 				621517A51FA0DED500D73275 /* UIView+WebCacheOperation.h in Headers */,
 				6215179B1FA0DED500D73275 /* SDWebImageCodersManager.h in Headers */,
@@ -2738,6 +2759,7 @@
 				621517A81FA0DED500D73275 /* UIImageView+HighlightedWebCache.h in Headers */,
 				621517A91FA0DED500D73275 /* UIImageView+WebCache.h in Headers */,
 				621517971FA0DED500D73275 /* SDWebImageDownloader.h in Headers */,
+				629D1C7B1FAB7AE500FBFD8E /* SDWebImageFrame.h in Headers */,
 				6215179A1FA0DED500D73275 /* SDImageCacheConfig.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2756,6 +2778,7 @@
 				621517C01FA0DED600D73275 /* UIView+WebCache.h in Headers */,
 				621517B21FA0DED600D73275 /* SDWebImageCoder.h in Headers */,
 				621517AF1FA0DED600D73275 /* SDImageCache.h in Headers */,
+				629D1C741FAB7AA000FBFD8E /* SDWebImageCoderHelper.h in Headers */,
 				621517AB1FA0DED600D73275 /* SDWebImageCompat.h in Headers */,
 				621517BB1FA0DED600D73275 /* UIView+WebCacheOperation.h in Headers */,
 				621517B11FA0DED600D73275 /* SDWebImageCodersManager.h in Headers */,
@@ -2768,6 +2791,7 @@
 				621517BE1FA0DED600D73275 /* UIImageView+HighlightedWebCache.h in Headers */,
 				621517BF1FA0DED600D73275 /* UIImageView+WebCache.h in Headers */,
 				621517AD1FA0DED600D73275 /* SDWebImageDownloader.h in Headers */,
+				629D1C7C1FAB7AE500FBFD8E /* SDWebImageFrame.h in Headers */,
 				621517B01FA0DED600D73275 /* SDImageCacheConfig.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3980,11 +4004,13 @@
 				621514D11FA0CE6000D73275 /* SDWebImageManager.m in Sources */,
 				621514D21FA0CE6000D73275 /* SDWebImagePrefetcher.m in Sources */,
 				621514D51FA0CE6000D73275 /* UIImage+MultiFormat.m in Sources */,
+				629D1C751FAB7ADC00FBFD8E /* SDWebImageFrame.m in Sources */,
 				621514CB1FA0CE6000D73275 /* SDImageCache.m in Sources */,
 				621514D71FA0CE6000D73275 /* UIView+WebCacheOperation.m in Sources */,
 				621514D31FA0CE6000D73275 /* NSData+ImageContentType.m in Sources */,
 				621514D61FA0CE6000D73275 /* UIImage+ForceDecode.m in Sources */,
 				621514CE1FA0CE6000D73275 /* SDWebImageCoder.m in Sources */,
+				629D1C801FAB7AF600FBFD8E /* SDWebImageCoderHelper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4007,11 +4033,13 @@
 				621517CA1FA0E05F00D73275 /* SDWebImageManager.m in Sources */,
 				621517CB1FA0E05F00D73275 /* SDWebImagePrefetcher.m in Sources */,
 				621517CE1FA0E05F00D73275 /* UIImage+MultiFormat.m in Sources */,
+				629D1C761FAB7ADC00FBFD8E /* SDWebImageFrame.m in Sources */,
 				621517C41FA0E05F00D73275 /* SDImageCache.m in Sources */,
 				621517D01FA0E05F00D73275 /* UIView+WebCacheOperation.m in Sources */,
 				621517CC1FA0E05F00D73275 /* NSData+ImageContentType.m in Sources */,
 				621517CF1FA0E05F00D73275 /* UIImage+ForceDecode.m in Sources */,
 				621517C71FA0E05F00D73275 /* SDWebImageCoder.m in Sources */,
+				629D1C7E1FAB7AF500FBFD8E /* SDWebImageCoderHelper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4034,11 +4062,13 @@
 				621517DF1FA0E05F00D73275 /* SDWebImageManager.m in Sources */,
 				621517E01FA0E05F00D73275 /* SDWebImagePrefetcher.m in Sources */,
 				621517E31FA0E05F00D73275 /* UIImage+MultiFormat.m in Sources */,
+				629D1C771FAB7ADC00FBFD8E /* SDWebImageFrame.m in Sources */,
 				621517D91FA0E05F00D73275 /* SDImageCache.m in Sources */,
 				621517E51FA0E05F00D73275 /* UIView+WebCacheOperation.m in Sources */,
 				621517E11FA0E05F00D73275 /* NSData+ImageContentType.m in Sources */,
 				621517E41FA0E05F00D73275 /* UIImage+ForceDecode.m in Sources */,
 				621517DC1FA0E05F00D73275 /* SDWebImageCoder.m in Sources */,
+				629D1C7F1FAB7AF500FBFD8E /* SDWebImageCoderHelper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4047,12 +4077,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				621517F71FA0E06000D73275 /* UIImage+GIF.m in Sources */,
+				629D1C781FAB7ADD00FBFD8E /* SDWebImageFrame.m in Sources */,
 				621517FD1FA0E06000D73275 /* UIImageView+HighlightedWebCache.m in Sources */,
 				621517FF1FA0E06000D73275 /* UIView+WebCache.m in Sources */,
 				621517FE1FA0E06000D73275 /* UIImageView+WebCache.m in Sources */,
 				621517EF1FA0E06000D73275 /* SDImageCacheConfig.m in Sources */,
 				621517ED1FA0E06000D73275 /* SDWebImageDownloaderOperation.m in Sources */,
 				621517EC1FA0E06000D73275 /* SDWebImageDownloader.m in Sources */,
+				629D1C7D1FAB7AF300FBFD8E /* SDWebImageCoderHelper.m in Sources */,
 				621517F31FA0E06000D73275 /* SDWebImageGIFCoder.m in Sources */,
 				621517F21FA0E06000D73275 /* SDWebImageImageIOCoder.m in Sources */,
 				621517F01FA0E06000D73275 /* SDWebImageCodersManager.m in Sources */,

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -561,6 +561,179 @@
 		53EDFB8C17623F7C00698166 /* UIImage+MultiFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 53EDFB8917623F7C00698166 /* UIImage+MultiFormat.m */; };
 		5D5B9142188EE8DD006D06BD /* NSData+ImageContentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D5B9140188EE8DD006D06BD /* NSData+ImageContentType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D5B9145188EE8DD006D06BD /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
+		621514C81FA0CE6000D73275 /* SDWebImageCompat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5340674F167780C40042B59E /* SDWebImageCompat.m */; };
+		621514C91FA0CE6000D73275 /* SDWebImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8C148C56230056699D /* SDWebImageDownloader.m */; };
+		621514CA1FA0CE6000D73275 /* SDWebImageDownloaderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 530E49E416460AE2002868E7 /* SDWebImageDownloaderOperation.m */; };
+		621514CB1FA0CE6000D73275 /* SDImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D86148C56230056699D /* SDImageCache.m */; };
+		621514CC1FA0CE6000D73275 /* SDImageCacheConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A918631D8308FE00B3925F /* SDImageCacheConfig.m */; };
+		621514CD1FA0CE6000D73275 /* SDWebImageCodersManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 807A12271F89636300EC2A9B /* SDWebImageCodersManager.m */; };
+		621514CE1FA0CE6000D73275 /* SDWebImageCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60851F38E8C800405457 /* SDWebImageCoder.m */; };
+		621514CF1FA0CE6000D73275 /* SDWebImageImageIOCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60931F38E8ED00405457 /* SDWebImageImageIOCoder.m */; };
+		621514D01FA0CE6000D73275 /* SDWebImageGIFCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60A11F38E8F600405457 /* SDWebImageGIFCoder.m */; };
+		621514D11FA0CE6000D73275 /* SDWebImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8F148C56230056699D /* SDWebImageManager.m */; };
+		621514D21FA0CE6000D73275 /* SDWebImagePrefetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D92148C56230056699D /* SDWebImagePrefetcher.m */; };
+		621514D31FA0CE6000D73275 /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
+		621514D41FA0CE6000D73275 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
+		621514D51FA0CE6000D73275 /* UIImage+MultiFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 53EDFB8917623F7C00698166 /* UIImage+MultiFormat.m */; };
+		621514D61FA0CE6000D73275 /* UIImage+ForceDecode.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60BD1F38E91700405457 /* UIImage+ForceDecode.m */; };
+		621514D71FA0CE6000D73275 /* UIView+WebCacheOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = AB615302192DA24600A2D8E9 /* UIView+WebCacheOperation.m */; };
+		621514D91FA0CE6000D73275 /* UIButton+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D94148C56230056699D /* UIButton+WebCache.m */; };
+		621514DA1FA0CE6000D73275 /* UIImageView+HighlightedWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = ABBE71A618C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m */; };
+		621514DB1FA0CE6000D73275 /* UIImageView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D96148C56230056699D /* UIImageView+WebCache.m */; };
+		621514DC1FA0CE6000D73275 /* UIView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4369C2761D9807EC007E863A /* UIView+WebCache.m */; };
+		621514DD1FA0CEC400D73275 /* SDWebImageCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D88148C56230056699D /* SDWebImageCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514DE1FA0CEC400D73275 /* SDWebImageOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E71646388E002868E7 /* SDWebImageOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514DF1FA0CEC400D73275 /* SDWebImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8B148C56230056699D /* SDWebImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514E01FA0CEC400D73275 /* SDWebImageDownloaderOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E316460AE2002868E7 /* SDWebImageDownloaderOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514E11FA0CEC400D73275 /* SDImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D85148C56230056699D /* SDImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514E21FA0CEC400D73275 /* SDImageCacheConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 43A918621D8308FE00B3925F /* SDImageCacheConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514E31FA0CEC400D73275 /* SDWebImageCodersManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 807A12261F89636300EC2A9B /* SDWebImageCodersManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514E41FA0CEC400D73275 /* SDWebImageCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60841F38E8C800405457 /* SDWebImageCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514E51FA0CEC400D73275 /* SDWebImageImageIOCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60921F38E8ED00405457 /* SDWebImageImageIOCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514E61FA0CEC400D73275 /* SDWebImageGIFCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60A01F38E8F600405457 /* SDWebImageGIFCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514E71FA0CEC400D73275 /* SDWebImageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8E148C56230056699D /* SDWebImageManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514E81FA0CEC400D73275 /* SDWebImagePrefetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D91148C56230056699D /* SDWebImagePrefetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514E91FA0CEC400D73275 /* NSData+ImageContentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D5B9140188EE8DD006D06BD /* NSData+ImageContentType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514EA1FA0CEC400D73275 /* UIImage+GIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A18A6CC5172DC28500419892 /* UIImage+GIF.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514EB1FA0CEC400D73275 /* UIImage+MultiFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53EDFB8817623F7C00698166 /* UIImage+MultiFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514EC1FA0CEC400D73275 /* UIImage+ForceDecode.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60BC1F38E91700405457 /* UIImage+ForceDecode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514ED1FA0CEC400D73275 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514EE1FA0CEC400D73275 /* NSImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4397D2F41D0DE2DF00BB2784 /* NSImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514EF1FA0CEC400D73275 /* UIButton+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D93148C56230056699D /* UIButton+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514F01FA0CEC400D73275 /* UIImageView+HighlightedWebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = ABBE71A518C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514F11FA0CEC400D73275 /* UIImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D95148C56230056699D /* UIImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514F21FA0CEC400D73275 /* UIView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4369C2751D9807EC007E863A /* UIView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621514F51FA0D19100D73275 /* SDWebImageCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 621514F41FA0D19100D73275 /* SDWebImageCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215177C1FA0DEB100D73275 /* SDWebImageCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 621514F41FA0D19100D73275 /* SDWebImageCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215177D1FA0DEB100D73275 /* SDWebImageCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 621514F41FA0D19100D73275 /* SDWebImageCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215177E1FA0DEB200D73275 /* SDWebImageCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 621514F41FA0D19100D73275 /* SDWebImageCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215177F1FA0DED500D73275 /* SDWebImageCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D88148C56230056699D /* SDWebImageCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517801FA0DED500D73275 /* SDWebImageOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E71646388E002868E7 /* SDWebImageOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517811FA0DED500D73275 /* SDWebImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8B148C56230056699D /* SDWebImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517821FA0DED500D73275 /* SDWebImageDownloaderOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E316460AE2002868E7 /* SDWebImageDownloaderOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517831FA0DED500D73275 /* SDImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D85148C56230056699D /* SDImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517841FA0DED500D73275 /* SDImageCacheConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 43A918621D8308FE00B3925F /* SDImageCacheConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517851FA0DED500D73275 /* SDWebImageCodersManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 807A12261F89636300EC2A9B /* SDWebImageCodersManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517861FA0DED500D73275 /* SDWebImageCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60841F38E8C800405457 /* SDWebImageCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517871FA0DED500D73275 /* SDWebImageImageIOCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60921F38E8ED00405457 /* SDWebImageImageIOCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517881FA0DED500D73275 /* SDWebImageGIFCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60A01F38E8F600405457 /* SDWebImageGIFCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517891FA0DED500D73275 /* SDWebImageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8E148C56230056699D /* SDWebImageManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215178A1FA0DED500D73275 /* SDWebImagePrefetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D91148C56230056699D /* SDWebImagePrefetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215178B1FA0DED500D73275 /* NSData+ImageContentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D5B9140188EE8DD006D06BD /* NSData+ImageContentType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215178C1FA0DED500D73275 /* UIImage+GIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A18A6CC5172DC28500419892 /* UIImage+GIF.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215178D1FA0DED500D73275 /* UIImage+MultiFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53EDFB8817623F7C00698166 /* UIImage+MultiFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215178E1FA0DED500D73275 /* UIImage+ForceDecode.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60BC1F38E91700405457 /* UIImage+ForceDecode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215178F1FA0DED500D73275 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517901FA0DED500D73275 /* NSImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4397D2F41D0DE2DF00BB2784 /* NSImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517911FA0DED500D73275 /* UIButton+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D93148C56230056699D /* UIButton+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517921FA0DED500D73275 /* UIImageView+HighlightedWebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = ABBE71A518C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517931FA0DED500D73275 /* UIImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D95148C56230056699D /* UIImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517941FA0DED500D73275 /* UIView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4369C2751D9807EC007E863A /* UIView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517951FA0DED500D73275 /* SDWebImageCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D88148C56230056699D /* SDWebImageCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517961FA0DED500D73275 /* SDWebImageOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E71646388E002868E7 /* SDWebImageOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517971FA0DED500D73275 /* SDWebImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8B148C56230056699D /* SDWebImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517981FA0DED500D73275 /* SDWebImageDownloaderOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E316460AE2002868E7 /* SDWebImageDownloaderOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517991FA0DED500D73275 /* SDImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D85148C56230056699D /* SDImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215179A1FA0DED500D73275 /* SDImageCacheConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 43A918621D8308FE00B3925F /* SDImageCacheConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215179B1FA0DED500D73275 /* SDWebImageCodersManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 807A12261F89636300EC2A9B /* SDWebImageCodersManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215179C1FA0DED500D73275 /* SDWebImageCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60841F38E8C800405457 /* SDWebImageCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215179D1FA0DED500D73275 /* SDWebImageImageIOCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60921F38E8ED00405457 /* SDWebImageImageIOCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215179E1FA0DED500D73275 /* SDWebImageGIFCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60A01F38E8F600405457 /* SDWebImageGIFCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6215179F1FA0DED500D73275 /* SDWebImageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8E148C56230056699D /* SDWebImageManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517A01FA0DED500D73275 /* SDWebImagePrefetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D91148C56230056699D /* SDWebImagePrefetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517A11FA0DED500D73275 /* NSData+ImageContentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D5B9140188EE8DD006D06BD /* NSData+ImageContentType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517A21FA0DED500D73275 /* UIImage+GIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A18A6CC5172DC28500419892 /* UIImage+GIF.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517A31FA0DED500D73275 /* UIImage+MultiFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53EDFB8817623F7C00698166 /* UIImage+MultiFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517A41FA0DED500D73275 /* UIImage+ForceDecode.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60BC1F38E91700405457 /* UIImage+ForceDecode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517A51FA0DED500D73275 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517A61FA0DED500D73275 /* NSImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4397D2F41D0DE2DF00BB2784 /* NSImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517A71FA0DED500D73275 /* UIButton+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D93148C56230056699D /* UIButton+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517A81FA0DED500D73275 /* UIImageView+HighlightedWebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = ABBE71A518C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517A91FA0DED500D73275 /* UIImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D95148C56230056699D /* UIImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517AA1FA0DED500D73275 /* UIView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4369C2751D9807EC007E863A /* UIView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517AB1FA0DED600D73275 /* SDWebImageCompat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D88148C56230056699D /* SDWebImageCompat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517AC1FA0DED600D73275 /* SDWebImageOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E71646388E002868E7 /* SDWebImageOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517AD1FA0DED600D73275 /* SDWebImageDownloader.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8B148C56230056699D /* SDWebImageDownloader.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517AE1FA0DED600D73275 /* SDWebImageDownloaderOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 530E49E316460AE2002868E7 /* SDWebImageDownloaderOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517AF1FA0DED600D73275 /* SDImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D85148C56230056699D /* SDImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517B01FA0DED600D73275 /* SDImageCacheConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 43A918621D8308FE00B3925F /* SDImageCacheConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517B11FA0DED600D73275 /* SDWebImageCodersManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 807A12261F89636300EC2A9B /* SDWebImageCodersManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517B21FA0DED600D73275 /* SDWebImageCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60841F38E8C800405457 /* SDWebImageCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517B31FA0DED600D73275 /* SDWebImageImageIOCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60921F38E8ED00405457 /* SDWebImageImageIOCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517B41FA0DED600D73275 /* SDWebImageGIFCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60A01F38E8F600405457 /* SDWebImageGIFCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517B51FA0DED600D73275 /* SDWebImageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D8E148C56230056699D /* SDWebImageManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517B61FA0DED600D73275 /* SDWebImagePrefetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D91148C56230056699D /* SDWebImagePrefetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517B71FA0DED600D73275 /* NSData+ImageContentType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D5B9140188EE8DD006D06BD /* NSData+ImageContentType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517B81FA0DED600D73275 /* UIImage+GIF.h in Headers */ = {isa = PBXBuildFile; fileRef = A18A6CC5172DC28500419892 /* UIImage+GIF.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517B91FA0DED600D73275 /* UIImage+MultiFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 53EDFB8817623F7C00698166 /* UIImage+MultiFormat.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517BA1FA0DED600D73275 /* UIImage+ForceDecode.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60BC1F38E91700405457 /* UIImage+ForceDecode.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517BB1FA0DED600D73275 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517BC1FA0DED600D73275 /* NSImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4397D2F41D0DE2DF00BB2784 /* NSImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517BD1FA0DED600D73275 /* UIButton+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D93148C56230056699D /* UIButton+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517BE1FA0DED600D73275 /* UIImageView+HighlightedWebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = ABBE71A518C43B4D00B75E91 /* UIImageView+HighlightedWebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517BF1FA0DED600D73275 /* UIImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D95148C56230056699D /* UIImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517C01FA0DED600D73275 /* UIView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4369C2751D9807EC007E863A /* UIView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		621517C11FA0E05F00D73275 /* SDWebImageCompat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5340674F167780C40042B59E /* SDWebImageCompat.m */; };
+		621517C21FA0E05F00D73275 /* SDWebImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8C148C56230056699D /* SDWebImageDownloader.m */; };
+		621517C31FA0E05F00D73275 /* SDWebImageDownloaderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 530E49E416460AE2002868E7 /* SDWebImageDownloaderOperation.m */; };
+		621517C41FA0E05F00D73275 /* SDImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D86148C56230056699D /* SDImageCache.m */; };
+		621517C51FA0E05F00D73275 /* SDImageCacheConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A918631D8308FE00B3925F /* SDImageCacheConfig.m */; };
+		621517C61FA0E05F00D73275 /* SDWebImageCodersManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 807A12271F89636300EC2A9B /* SDWebImageCodersManager.m */; };
+		621517C71FA0E05F00D73275 /* SDWebImageCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60851F38E8C800405457 /* SDWebImageCoder.m */; };
+		621517C81FA0E05F00D73275 /* SDWebImageImageIOCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60931F38E8ED00405457 /* SDWebImageImageIOCoder.m */; };
+		621517C91FA0E05F00D73275 /* SDWebImageGIFCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60A11F38E8F600405457 /* SDWebImageGIFCoder.m */; };
+		621517CA1FA0E05F00D73275 /* SDWebImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8F148C56230056699D /* SDWebImageManager.m */; };
+		621517CB1FA0E05F00D73275 /* SDWebImagePrefetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D92148C56230056699D /* SDWebImagePrefetcher.m */; };
+		621517CC1FA0E05F00D73275 /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
+		621517CD1FA0E05F00D73275 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
+		621517CE1FA0E05F00D73275 /* UIImage+MultiFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 53EDFB8917623F7C00698166 /* UIImage+MultiFormat.m */; };
+		621517CF1FA0E05F00D73275 /* UIImage+ForceDecode.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60BD1F38E91700405457 /* UIImage+ForceDecode.m */; };
+		621517D01FA0E05F00D73275 /* UIView+WebCacheOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = AB615302192DA24600A2D8E9 /* UIView+WebCacheOperation.m */; };
+		621517D21FA0E05F00D73275 /* UIButton+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D94148C56230056699D /* UIButton+WebCache.m */; };
+		621517D31FA0E05F00D73275 /* UIImageView+HighlightedWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = ABBE71A618C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m */; };
+		621517D41FA0E05F00D73275 /* UIImageView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D96148C56230056699D /* UIImageView+WebCache.m */; };
+		621517D51FA0E05F00D73275 /* UIView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4369C2761D9807EC007E863A /* UIView+WebCache.m */; };
+		621517D61FA0E05F00D73275 /* SDWebImageCompat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5340674F167780C40042B59E /* SDWebImageCompat.m */; };
+		621517D71FA0E05F00D73275 /* SDWebImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8C148C56230056699D /* SDWebImageDownloader.m */; };
+		621517D81FA0E05F00D73275 /* SDWebImageDownloaderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 530E49E416460AE2002868E7 /* SDWebImageDownloaderOperation.m */; };
+		621517D91FA0E05F00D73275 /* SDImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D86148C56230056699D /* SDImageCache.m */; };
+		621517DA1FA0E05F00D73275 /* SDImageCacheConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A918631D8308FE00B3925F /* SDImageCacheConfig.m */; };
+		621517DB1FA0E05F00D73275 /* SDWebImageCodersManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 807A12271F89636300EC2A9B /* SDWebImageCodersManager.m */; };
+		621517DC1FA0E05F00D73275 /* SDWebImageCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60851F38E8C800405457 /* SDWebImageCoder.m */; };
+		621517DD1FA0E05F00D73275 /* SDWebImageImageIOCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60931F38E8ED00405457 /* SDWebImageImageIOCoder.m */; };
+		621517DE1FA0E05F00D73275 /* SDWebImageGIFCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60A11F38E8F600405457 /* SDWebImageGIFCoder.m */; };
+		621517DF1FA0E05F00D73275 /* SDWebImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8F148C56230056699D /* SDWebImageManager.m */; };
+		621517E01FA0E05F00D73275 /* SDWebImagePrefetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D92148C56230056699D /* SDWebImagePrefetcher.m */; };
+		621517E11FA0E05F00D73275 /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
+		621517E21FA0E05F00D73275 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
+		621517E31FA0E05F00D73275 /* UIImage+MultiFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 53EDFB8917623F7C00698166 /* UIImage+MultiFormat.m */; };
+		621517E41FA0E05F00D73275 /* UIImage+ForceDecode.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60BD1F38E91700405457 /* UIImage+ForceDecode.m */; };
+		621517E51FA0E05F00D73275 /* UIView+WebCacheOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = AB615302192DA24600A2D8E9 /* UIView+WebCacheOperation.m */; };
+		621517E71FA0E05F00D73275 /* UIButton+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D94148C56230056699D /* UIButton+WebCache.m */; };
+		621517E81FA0E05F00D73275 /* UIImageView+HighlightedWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = ABBE71A618C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m */; };
+		621517E91FA0E05F00D73275 /* UIImageView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D96148C56230056699D /* UIImageView+WebCache.m */; };
+		621517EA1FA0E05F00D73275 /* UIView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4369C2761D9807EC007E863A /* UIView+WebCache.m */; };
+		621517EB1FA0E06000D73275 /* SDWebImageCompat.m in Sources */ = {isa = PBXBuildFile; fileRef = 5340674F167780C40042B59E /* SDWebImageCompat.m */; };
+		621517EC1FA0E06000D73275 /* SDWebImageDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8C148C56230056699D /* SDWebImageDownloader.m */; };
+		621517ED1FA0E06000D73275 /* SDWebImageDownloaderOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 530E49E416460AE2002868E7 /* SDWebImageDownloaderOperation.m */; };
+		621517EE1FA0E06000D73275 /* SDImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D86148C56230056699D /* SDImageCache.m */; };
+		621517EF1FA0E06000D73275 /* SDImageCacheConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 43A918631D8308FE00B3925F /* SDImageCacheConfig.m */; };
+		621517F01FA0E06000D73275 /* SDWebImageCodersManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 807A12271F89636300EC2A9B /* SDWebImageCodersManager.m */; };
+		621517F11FA0E06000D73275 /* SDWebImageCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60851F38E8C800405457 /* SDWebImageCoder.m */; };
+		621517F21FA0E06000D73275 /* SDWebImageImageIOCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60931F38E8ED00405457 /* SDWebImageImageIOCoder.m */; };
+		621517F31FA0E06000D73275 /* SDWebImageGIFCoder.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60A11F38E8F600405457 /* SDWebImageGIFCoder.m */; };
+		621517F41FA0E06000D73275 /* SDWebImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D8F148C56230056699D /* SDWebImageManager.m */; };
+		621517F51FA0E06000D73275 /* SDWebImagePrefetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D92148C56230056699D /* SDWebImagePrefetcher.m */; };
+		621517F61FA0E06000D73275 /* NSData+ImageContentType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */; };
+		621517F71FA0E06000D73275 /* UIImage+GIF.m in Sources */ = {isa = PBXBuildFile; fileRef = A18A6CC6172DC28500419892 /* UIImage+GIF.m */; };
+		621517F81FA0E06000D73275 /* UIImage+MultiFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 53EDFB8917623F7C00698166 /* UIImage+MultiFormat.m */; };
+		621517F91FA0E06000D73275 /* UIImage+ForceDecode.m in Sources */ = {isa = PBXBuildFile; fileRef = 321E60BD1F38E91700405457 /* UIImage+ForceDecode.m */; };
+		621517FA1FA0E06000D73275 /* UIView+WebCacheOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = AB615302192DA24600A2D8E9 /* UIView+WebCacheOperation.m */; };
+		621517FB1FA0E06000D73275 /* NSImage+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4397D2F51D0DE2DF00BB2784 /* NSImage+WebCache.m */; };
+		621517FC1FA0E06000D73275 /* UIButton+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D94148C56230056699D /* UIButton+WebCache.m */; };
+		621517FD1FA0E06000D73275 /* UIImageView+HighlightedWebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = ABBE71A618C43B4D00B75E91 /* UIImageView+HighlightedWebCache.m */; };
+		621517FE1FA0E06000D73275 /* UIImageView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 53922D96148C56230056699D /* UIImageView+WebCache.m */; };
+		621517FF1FA0E06000D73275 /* UIView+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4369C2761D9807EC007E863A /* UIView+WebCache.m */; };
 		80377BF81F2F665300F89830 /* bit_reader_inl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 80377BDE1F2F665300F89830 /* bit_reader_inl_utils.h */; };
 		80377BF91F2F665300F89830 /* bit_reader_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 80377BDF1F2F665300F89830 /* bit_reader_utils.c */; };
 		80377BFA1F2F665300F89830 /* bit_reader_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 80377BE01F2F665300F89830 /* bit_reader_utils.h */; };
@@ -1343,6 +1516,11 @@
 		53FB894814D35E9E0020B787 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		5D5B9140188EE8DD006D06BD /* NSData+ImageContentType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+ImageContentType.h"; sourceTree = "<group>"; };
 		5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+ImageContentType.m"; sourceTree = "<group>"; };
+		621514C61FA0CCB300D73275 /* SDWebImageCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		621514F41FA0D19100D73275 /* SDWebImageCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDWebImageCore.h; sourceTree = "<group>"; };
+		621515D01FA0D52100D73275 /* SDWebImageCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		621516A31FA0D52400D73275 /* SDWebImageCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6215177A1FA0D53900D73275 /* SDWebImageCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		80377BDE1F2F665300F89830 /* bit_reader_inl_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_reader_inl_utils.h; sourceTree = "<group>"; };
 		80377BDF1F2F665300F89830 /* bit_reader_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bit_reader_utils.c; sourceTree = "<group>"; };
 		80377BE01F2F665300F89830 /* bit_reader_utils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bit_reader_utils.h; sourceTree = "<group>"; };
@@ -1520,6 +1698,34 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		621514791FA0CCB300D73275 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		621515831FA0D52100D73275 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6215165A1FA0D52400D73275 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6215172F1FA0D53900D73275 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -1651,6 +1857,7 @@
 			isa = PBXGroup;
 			children = (
 				4A2CAE031AB4BB5400B6BC39 /* SDWebImage.h */,
+				621514F41FA0D19100D73275 /* SDWebImageCore.h */,
 				4A2CAE011AB4BB5400B6BC39 /* Supporting Files */,
 			);
 			path = WebImage;
@@ -1684,6 +1891,10 @@
 				431BB7031D06D2C1006A3455 /* SDWebImage.framework */,
 				4397D2F21D0DDD8C00BB2784 /* SDWebImage.framework */,
 				4314D1991D0E0E3B004B36C9 /* libSDWebImage watchOS static.a */,
+				621514C61FA0CCB300D73275 /* SDWebImageCore.framework */,
+				621515D01FA0D52100D73275 /* SDWebImageCore.framework */,
+				621516A31FA0D52400D73275 /* SDWebImageCore.framework */,
+				6215177A1FA0D53900D73275 /* SDWebImageCore.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2397,6 +2608,126 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6215147A1FA0CCB300D73275 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				621514E21FA0CEC400D73275 /* SDImageCacheConfig.h in Headers */,
+				621514E91FA0CEC400D73275 /* NSData+ImageContentType.h in Headers */,
+				621514E51FA0CEC400D73275 /* SDWebImageImageIOCoder.h in Headers */,
+				621514F01FA0CEC400D73275 /* UIImageView+HighlightedWebCache.h in Headers */,
+				621514DF1FA0CEC400D73275 /* SDWebImageDownloader.h in Headers */,
+				621514E01FA0CEC400D73275 /* SDWebImageDownloaderOperation.h in Headers */,
+				621514E31FA0CEC400D73275 /* SDWebImageCodersManager.h in Headers */,
+				621514E61FA0CEC400D73275 /* SDWebImageGIFCoder.h in Headers */,
+				621514EE1FA0CEC400D73275 /* NSImage+WebCache.h in Headers */,
+				621514EB1FA0CEC400D73275 /* UIImage+MultiFormat.h in Headers */,
+				621514F11FA0CEC400D73275 /* UIImageView+WebCache.h in Headers */,
+				621514E41FA0CEC400D73275 /* SDWebImageCoder.h in Headers */,
+				621514ED1FA0CEC400D73275 /* UIView+WebCacheOperation.h in Headers */,
+				621514DE1FA0CEC400D73275 /* SDWebImageOperation.h in Headers */,
+				621514EC1FA0CEC400D73275 /* UIImage+ForceDecode.h in Headers */,
+				621514F21FA0CEC400D73275 /* UIView+WebCache.h in Headers */,
+				621514E81FA0CEC400D73275 /* SDWebImagePrefetcher.h in Headers */,
+				621514DD1FA0CEC400D73275 /* SDWebImageCompat.h in Headers */,
+				621514EA1FA0CEC400D73275 /* UIImage+GIF.h in Headers */,
+				621514EF1FA0CEC400D73275 /* UIButton+WebCache.h in Headers */,
+				621514E11FA0CEC400D73275 /* SDImageCache.h in Headers */,
+				621514E71FA0CEC400D73275 /* SDWebImageManager.h in Headers */,
+				621514F51FA0D19100D73275 /* SDWebImageCore.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		621515841FA0D52100D73275 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6215178A1FA0DED500D73275 /* SDWebImagePrefetcher.h in Headers */,
+				6215178E1FA0DED500D73275 /* UIImage+ForceDecode.h in Headers */,
+				621517901FA0DED500D73275 /* NSImage+WebCache.h in Headers */,
+				621517891FA0DED500D73275 /* SDWebImageManager.h in Headers */,
+				621517871FA0DED500D73275 /* SDWebImageImageIOCoder.h in Headers */,
+				6215178C1FA0DED500D73275 /* UIImage+GIF.h in Headers */,
+				6215178B1FA0DED500D73275 /* NSData+ImageContentType.h in Headers */,
+				621517941FA0DED500D73275 /* UIView+WebCache.h in Headers */,
+				621517861FA0DED500D73275 /* SDWebImageCoder.h in Headers */,
+				621517831FA0DED500D73275 /* SDImageCache.h in Headers */,
+				6215177F1FA0DED500D73275 /* SDWebImageCompat.h in Headers */,
+				6215178F1FA0DED500D73275 /* UIView+WebCacheOperation.h in Headers */,
+				621517851FA0DED500D73275 /* SDWebImageCodersManager.h in Headers */,
+				621517911FA0DED500D73275 /* UIButton+WebCache.h in Headers */,
+				621517821FA0DED500D73275 /* SDWebImageDownloaderOperation.h in Headers */,
+				621517881FA0DED500D73275 /* SDWebImageGIFCoder.h in Headers */,
+				6215178D1FA0DED500D73275 /* UIImage+MultiFormat.h in Headers */,
+				6215177C1FA0DEB100D73275 /* SDWebImageCore.h in Headers */,
+				621517801FA0DED500D73275 /* SDWebImageOperation.h in Headers */,
+				621517921FA0DED500D73275 /* UIImageView+HighlightedWebCache.h in Headers */,
+				621517931FA0DED500D73275 /* UIImageView+WebCache.h in Headers */,
+				621517811FA0DED500D73275 /* SDWebImageDownloader.h in Headers */,
+				621517841FA0DED500D73275 /* SDImageCacheConfig.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6215165B1FA0D52400D73275 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				621517A01FA0DED500D73275 /* SDWebImagePrefetcher.h in Headers */,
+				621517A41FA0DED500D73275 /* UIImage+ForceDecode.h in Headers */,
+				621517A61FA0DED500D73275 /* NSImage+WebCache.h in Headers */,
+				6215179F1FA0DED500D73275 /* SDWebImageManager.h in Headers */,
+				6215179D1FA0DED500D73275 /* SDWebImageImageIOCoder.h in Headers */,
+				621517A21FA0DED500D73275 /* UIImage+GIF.h in Headers */,
+				621517A11FA0DED500D73275 /* NSData+ImageContentType.h in Headers */,
+				621517AA1FA0DED500D73275 /* UIView+WebCache.h in Headers */,
+				6215179C1FA0DED500D73275 /* SDWebImageCoder.h in Headers */,
+				621517991FA0DED500D73275 /* SDImageCache.h in Headers */,
+				621517951FA0DED500D73275 /* SDWebImageCompat.h in Headers */,
+				621517A51FA0DED500D73275 /* UIView+WebCacheOperation.h in Headers */,
+				6215179B1FA0DED500D73275 /* SDWebImageCodersManager.h in Headers */,
+				621517A71FA0DED500D73275 /* UIButton+WebCache.h in Headers */,
+				621517981FA0DED500D73275 /* SDWebImageDownloaderOperation.h in Headers */,
+				6215179E1FA0DED500D73275 /* SDWebImageGIFCoder.h in Headers */,
+				621517A31FA0DED500D73275 /* UIImage+MultiFormat.h in Headers */,
+				6215177D1FA0DEB100D73275 /* SDWebImageCore.h in Headers */,
+				621517961FA0DED500D73275 /* SDWebImageOperation.h in Headers */,
+				621517A81FA0DED500D73275 /* UIImageView+HighlightedWebCache.h in Headers */,
+				621517A91FA0DED500D73275 /* UIImageView+WebCache.h in Headers */,
+				621517971FA0DED500D73275 /* SDWebImageDownloader.h in Headers */,
+				6215179A1FA0DED500D73275 /* SDImageCacheConfig.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		621517301FA0D53900D73275 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				621517B61FA0DED600D73275 /* SDWebImagePrefetcher.h in Headers */,
+				621517BA1FA0DED600D73275 /* UIImage+ForceDecode.h in Headers */,
+				621517BC1FA0DED600D73275 /* NSImage+WebCache.h in Headers */,
+				621517B51FA0DED600D73275 /* SDWebImageManager.h in Headers */,
+				621517B31FA0DED600D73275 /* SDWebImageImageIOCoder.h in Headers */,
+				621517B81FA0DED600D73275 /* UIImage+GIF.h in Headers */,
+				621517B71FA0DED600D73275 /* NSData+ImageContentType.h in Headers */,
+				621517C01FA0DED600D73275 /* UIView+WebCache.h in Headers */,
+				621517B21FA0DED600D73275 /* SDWebImageCoder.h in Headers */,
+				621517AF1FA0DED600D73275 /* SDImageCache.h in Headers */,
+				621517AB1FA0DED600D73275 /* SDWebImageCompat.h in Headers */,
+				621517BB1FA0DED600D73275 /* UIView+WebCacheOperation.h in Headers */,
+				621517B11FA0DED600D73275 /* SDWebImageCodersManager.h in Headers */,
+				621517BD1FA0DED600D73275 /* UIButton+WebCache.h in Headers */,
+				621517AE1FA0DED600D73275 /* SDWebImageDownloaderOperation.h in Headers */,
+				621517B41FA0DED600D73275 /* SDWebImageGIFCoder.h in Headers */,
+				621517B91FA0DED600D73275 /* UIImage+MultiFormat.h in Headers */,
+				6215177E1FA0DEB200D73275 /* SDWebImageCore.h in Headers */,
+				621517AC1FA0DED600D73275 /* SDWebImageOperation.h in Headers */,
+				621517BE1FA0DED600D73275 /* UIImageView+HighlightedWebCache.h in Headers */,
+				621517BF1FA0DED600D73275 /* UIImageView+WebCache.h in Headers */,
+				621517AD1FA0DED600D73275 /* SDWebImageDownloader.h in Headers */,
+				621517B01FA0DED600D73275 /* SDImageCacheConfig.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -2508,6 +2839,78 @@
 			productReference = 53761325155AD0D5005750A4 /* libSDWebImage iOS static.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		621513ED1FA0CCB300D73275 /* SDWebImage Core iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 621514C31FA0CCB300D73275 /* Build configuration list for PBXNativeTarget "SDWebImage Core iOS" */;
+			buildPhases = (
+				621513EE1FA0CCB300D73275 /* Sources */,
+				621514791FA0CCB300D73275 /* Frameworks */,
+				6215147A1FA0CCB300D73275 /* Headers */,
+				621514C21FA0CCB300D73275 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SDWebImage Core iOS";
+			productName = WebImage;
+			productReference = 621514C61FA0CCB300D73275 /* SDWebImageCore.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		621514F71FA0D52100D73275 /* SDWebImage Core tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 621515CD1FA0D52100D73275 /* Build configuration list for PBXNativeTarget "SDWebImage Core tvOS" */;
+			buildPhases = (
+				621514F81FA0D52100D73275 /* Sources */,
+				621515831FA0D52100D73275 /* Frameworks */,
+				621515841FA0D52100D73275 /* Headers */,
+				621515CC1FA0D52100D73275 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SDWebImage Core tvOS";
+			productName = "WebImage tvOS";
+			productReference = 621515D01FA0D52100D73275 /* SDWebImageCore.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		621515D21FA0D52400D73275 /* SDWebImage Core watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 621516A01FA0D52400D73275 /* Build configuration list for PBXNativeTarget "SDWebImage Core watchOS" */;
+			buildPhases = (
+				621515D31FA0D52400D73275 /* Sources */,
+				6215165A1FA0D52400D73275 /* Frameworks */,
+				6215165B1FA0D52400D73275 /* Headers */,
+				6215169F1FA0D52400D73275 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SDWebImage Core watchOS";
+			productName = "WebImage tvOS";
+			productReference = 621516A31FA0D52400D73275 /* SDWebImageCore.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		621516A51FA0D53900D73275 /* SDWebImage Core OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 621517771FA0D53900D73275 /* Build configuration list for PBXNativeTarget "SDWebImage Core OSX" */;
+			buildPhases = (
+				621516A61FA0D53900D73275 /* Sources */,
+				6215172F1FA0D53900D73275 /* Frameworks */,
+				621517301FA0D53900D73275 /* Headers */,
+				621517761FA0D53900D73275 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SDWebImage Core OSX";
+			productName = WebImage;
+			productReference = 6215177A1FA0D53900D73275 /* SDWebImageCore.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -2539,6 +2942,10 @@
 			targets = (
 				53761307155AD0D5005750A4 /* SDWebImage iOS static */,
 				4314D11B1D0E0E3B004B36C9 /* SDWebImage watchOS static */,
+				621513ED1FA0CCB300D73275 /* SDWebImage Core iOS */,
+				621514F71FA0D52100D73275 /* SDWebImage Core tvOS */,
+				621515D21FA0D52400D73275 /* SDWebImage Core watchOS */,
+				621516A51FA0D53900D73275 /* SDWebImage Core OSX */,
 				4A2CADFE1AB4BB5300B6BC39 /* SDWebImage iOS */,
 				00733A4B1BC487C000A5A117 /* SDWebImage tvOS */,
 				431BB6891D06D2C1006A3455 /* SDWebImage watchOS */,
@@ -2570,6 +2977,34 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4A2CADFD1AB4BB5300B6BC39 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		621514C21FA0CCB300D73275 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		621515CC1FA0D52100D73275 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6215169F1FA0D52400D73275 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		621517761FA0D53900D73275 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3470,6 +3905,115 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		621513EE1FA0CCB300D73275 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				621514D41FA0CE6000D73275 /* UIImage+GIF.m in Sources */,
+				621514DA1FA0CE6000D73275 /* UIImageView+HighlightedWebCache.m in Sources */,
+				621514DC1FA0CE6000D73275 /* UIView+WebCache.m in Sources */,
+				621514DB1FA0CE6000D73275 /* UIImageView+WebCache.m in Sources */,
+				621514CC1FA0CE6000D73275 /* SDImageCacheConfig.m in Sources */,
+				621514CA1FA0CE6000D73275 /* SDWebImageDownloaderOperation.m in Sources */,
+				621514C91FA0CE6000D73275 /* SDWebImageDownloader.m in Sources */,
+				621514D01FA0CE6000D73275 /* SDWebImageGIFCoder.m in Sources */,
+				621514CF1FA0CE6000D73275 /* SDWebImageImageIOCoder.m in Sources */,
+				621514CD1FA0CE6000D73275 /* SDWebImageCodersManager.m in Sources */,
+				621514D91FA0CE6000D73275 /* UIButton+WebCache.m in Sources */,
+				621514C81FA0CE6000D73275 /* SDWebImageCompat.m in Sources */,
+				621514D11FA0CE6000D73275 /* SDWebImageManager.m in Sources */,
+				621514D21FA0CE6000D73275 /* SDWebImagePrefetcher.m in Sources */,
+				621514D51FA0CE6000D73275 /* UIImage+MultiFormat.m in Sources */,
+				621514CB1FA0CE6000D73275 /* SDImageCache.m in Sources */,
+				621514D71FA0CE6000D73275 /* UIView+WebCacheOperation.m in Sources */,
+				621514D31FA0CE6000D73275 /* NSData+ImageContentType.m in Sources */,
+				621514D61FA0CE6000D73275 /* UIImage+ForceDecode.m in Sources */,
+				621514CE1FA0CE6000D73275 /* SDWebImageCoder.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		621514F81FA0D52100D73275 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				621517CD1FA0E05F00D73275 /* UIImage+GIF.m in Sources */,
+				621517D31FA0E05F00D73275 /* UIImageView+HighlightedWebCache.m in Sources */,
+				621517D51FA0E05F00D73275 /* UIView+WebCache.m in Sources */,
+				621517D41FA0E05F00D73275 /* UIImageView+WebCache.m in Sources */,
+				621517C51FA0E05F00D73275 /* SDImageCacheConfig.m in Sources */,
+				621517C31FA0E05F00D73275 /* SDWebImageDownloaderOperation.m in Sources */,
+				621517C21FA0E05F00D73275 /* SDWebImageDownloader.m in Sources */,
+				621517C91FA0E05F00D73275 /* SDWebImageGIFCoder.m in Sources */,
+				621517C81FA0E05F00D73275 /* SDWebImageImageIOCoder.m in Sources */,
+				621517C61FA0E05F00D73275 /* SDWebImageCodersManager.m in Sources */,
+				621517D21FA0E05F00D73275 /* UIButton+WebCache.m in Sources */,
+				621517C11FA0E05F00D73275 /* SDWebImageCompat.m in Sources */,
+				621517CA1FA0E05F00D73275 /* SDWebImageManager.m in Sources */,
+				621517CB1FA0E05F00D73275 /* SDWebImagePrefetcher.m in Sources */,
+				621517CE1FA0E05F00D73275 /* UIImage+MultiFormat.m in Sources */,
+				621517C41FA0E05F00D73275 /* SDImageCache.m in Sources */,
+				621517D01FA0E05F00D73275 /* UIView+WebCacheOperation.m in Sources */,
+				621517CC1FA0E05F00D73275 /* NSData+ImageContentType.m in Sources */,
+				621517CF1FA0E05F00D73275 /* UIImage+ForceDecode.m in Sources */,
+				621517C71FA0E05F00D73275 /* SDWebImageCoder.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		621515D31FA0D52400D73275 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				621517E21FA0E05F00D73275 /* UIImage+GIF.m in Sources */,
+				621517E81FA0E05F00D73275 /* UIImageView+HighlightedWebCache.m in Sources */,
+				621517EA1FA0E05F00D73275 /* UIView+WebCache.m in Sources */,
+				621517E91FA0E05F00D73275 /* UIImageView+WebCache.m in Sources */,
+				621517DA1FA0E05F00D73275 /* SDImageCacheConfig.m in Sources */,
+				621517D81FA0E05F00D73275 /* SDWebImageDownloaderOperation.m in Sources */,
+				621517D71FA0E05F00D73275 /* SDWebImageDownloader.m in Sources */,
+				621517DE1FA0E05F00D73275 /* SDWebImageGIFCoder.m in Sources */,
+				621517DD1FA0E05F00D73275 /* SDWebImageImageIOCoder.m in Sources */,
+				621517DB1FA0E05F00D73275 /* SDWebImageCodersManager.m in Sources */,
+				621517E71FA0E05F00D73275 /* UIButton+WebCache.m in Sources */,
+				621517D61FA0E05F00D73275 /* SDWebImageCompat.m in Sources */,
+				621517DF1FA0E05F00D73275 /* SDWebImageManager.m in Sources */,
+				621517E01FA0E05F00D73275 /* SDWebImagePrefetcher.m in Sources */,
+				621517E31FA0E05F00D73275 /* UIImage+MultiFormat.m in Sources */,
+				621517D91FA0E05F00D73275 /* SDImageCache.m in Sources */,
+				621517E51FA0E05F00D73275 /* UIView+WebCacheOperation.m in Sources */,
+				621517E11FA0E05F00D73275 /* NSData+ImageContentType.m in Sources */,
+				621517E41FA0E05F00D73275 /* UIImage+ForceDecode.m in Sources */,
+				621517DC1FA0E05F00D73275 /* SDWebImageCoder.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		621516A61FA0D53900D73275 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				621517F71FA0E06000D73275 /* UIImage+GIF.m in Sources */,
+				621517FD1FA0E06000D73275 /* UIImageView+HighlightedWebCache.m in Sources */,
+				621517FF1FA0E06000D73275 /* UIView+WebCache.m in Sources */,
+				621517FE1FA0E06000D73275 /* UIImageView+WebCache.m in Sources */,
+				621517EF1FA0E06000D73275 /* SDImageCacheConfig.m in Sources */,
+				621517ED1FA0E06000D73275 /* SDWebImageDownloaderOperation.m in Sources */,
+				621517EC1FA0E06000D73275 /* SDWebImageDownloader.m in Sources */,
+				621517F31FA0E06000D73275 /* SDWebImageGIFCoder.m in Sources */,
+				621517F21FA0E06000D73275 /* SDWebImageImageIOCoder.m in Sources */,
+				621517F01FA0E06000D73275 /* SDWebImageCodersManager.m in Sources */,
+				621517FC1FA0E06000D73275 /* UIButton+WebCache.m in Sources */,
+				621517EB1FA0E06000D73275 /* SDWebImageCompat.m in Sources */,
+				621517FB1FA0E06000D73275 /* NSImage+WebCache.m in Sources */,
+				621517F41FA0E06000D73275 /* SDWebImageManager.m in Sources */,
+				621517F51FA0E06000D73275 /* SDWebImagePrefetcher.m in Sources */,
+				621517F81FA0E06000D73275 /* UIImage+MultiFormat.m in Sources */,
+				621517EE1FA0E06000D73275 /* SDImageCache.m in Sources */,
+				621517FA1FA0E06000D73275 /* UIView+WebCacheOperation.m in Sources */,
+				621517F61FA0E06000D73275 /* NSData+ImageContentType.m in Sources */,
+				621517F91FA0E06000D73275 /* UIImage+ForceDecode.m in Sources */,
+				621517F11FA0E06000D73275 /* SDWebImageCoder.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
@@ -3640,7 +4184,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).ios";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).osx";
 				PRODUCT_NAME = SDWebImage;
 				SDKROOT = macosx;
 			};
@@ -3661,7 +4205,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).ios";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).osx";
 				PRODUCT_NAME = SDWebImage;
 				SDKROOT = macosx;
 			};
@@ -3865,6 +4409,220 @@
 			};
 			name = Release;
 		};
+		621514C41FA0CCB300D73275 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = WebImage/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dailymotion.SDWebImageCore.ios;
+				PRODUCT_NAME = SDWebImageCore;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		621514C51FA0CCB300D73275 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = WebImage/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dailymotion.SDWebImageCore.ios;
+				PRODUCT_NAME = SDWebImageCore;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		621515CE1FA0D52100D73275 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = WebImage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dailymotion.SDWebImageCore.tvos;
+				PRODUCT_NAME = SDWebImageCore;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		621515CF1FA0D52100D73275 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = WebImage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dailymotion.SDWebImageCore.tvos;
+				PRODUCT_NAME = SDWebImageCore;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		621516A11FA0D52400D73275 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = WebImage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dailymotion.SDWebImageCore.watchos;
+				PRODUCT_NAME = SDWebImageCore;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		621516A21FA0D52400D73275 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = WebImage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.dailymotion.SDWebImageCore.watchos;
+				PRODUCT_NAME = SDWebImageCore;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		621517781FA0D53900D73275 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = WebImage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).osx";
+				PRODUCT_NAME = SDWebImageCore;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		621517791FA0D53900D73275 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "";
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = WebImage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).osx";
+				PRODUCT_NAME = SDWebImageCore;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -3927,6 +4685,42 @@
 			buildConfigurations = (
 				53922D7A148C55820056699D /* Debug */,
 				53922D7B148C55820056699D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		621514C31FA0CCB300D73275 /* Build configuration list for PBXNativeTarget "SDWebImage Core iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				621514C41FA0CCB300D73275 /* Debug */,
+				621514C51FA0CCB300D73275 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		621515CD1FA0D52100D73275 /* Build configuration list for PBXNativeTarget "SDWebImage Core tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				621515CE1FA0D52100D73275 /* Debug */,
+				621515CF1FA0D52100D73275 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		621516A01FA0D52400D73275 /* Build configuration list for PBXNativeTarget "SDWebImage Core watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				621516A11FA0D52400D73275 /* Debug */,
+				621516A21FA0D52400D73275 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		621517771FA0D53900D73275 /* Build configuration list for PBXNativeTarget "SDWebImage Core OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				621517781FA0D53900D73275 /* Debug */,
+				621517791FA0D53900D73275 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage Core OSX.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage Core OSX.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "621516A51FA0D53900D73275"
+               BuildableName = "SDWebImageCore.framework"
+               BlueprintName = "SDWebImage Core OSX"
+               ReferencedContainer = "container:SDWebImage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "621516A51FA0D53900D73275"
+            BuildableName = "SDWebImageCore.framework"
+            BlueprintName = "SDWebImage Core OSX"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "621516A51FA0D53900D73275"
+            BuildableName = "SDWebImageCore.framework"
+            BlueprintName = "SDWebImage Core OSX"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage Core iOS.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage Core iOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "621513ED1FA0CCB300D73275"
+               BuildableName = "SDWebImageCore.framework"
+               BlueprintName = "SDWebImage Core iOS"
+               ReferencedContainer = "container:SDWebImage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "621513ED1FA0CCB300D73275"
+            BuildableName = "SDWebImageCore.framework"
+            BlueprintName = "SDWebImage Core iOS"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "621513ED1FA0CCB300D73275"
+            BuildableName = "SDWebImageCore.framework"
+            BlueprintName = "SDWebImage Core iOS"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage Core tvOS.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage Core tvOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "621514F71FA0D52100D73275"
+               BuildableName = "SDWebImageCore.framework"
+               BlueprintName = "SDWebImage Core tvOS"
+               ReferencedContainer = "container:SDWebImage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "621514F71FA0D52100D73275"
+            BuildableName = "SDWebImageCore.framework"
+            BlueprintName = "SDWebImage Core tvOS"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "621514F71FA0D52100D73275"
+            BuildableName = "SDWebImageCore.framework"
+            BlueprintName = "SDWebImage Core tvOS"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage Core watchOS.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage Core watchOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "621515D21FA0D52400D73275"
+               BuildableName = "SDWebImageCore.framework"
+               BlueprintName = "SDWebImage Core watchOS"
+               ReferencedContainer = "container:SDWebImage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "621515D21FA0D52400D73275"
+            BuildableName = "SDWebImageCore.framework"
+            BlueprintName = "SDWebImage Core watchOS"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "621515D21FA0D52400D73275"
+            BuildableName = "SDWebImageCore.framework"
+            BlueprintName = "SDWebImage Core watchOS"
+            ReferencedContainer = "container:SDWebImage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WebImage/SDWebImageCore.h
+++ b/WebImage/SDWebImageCore.h
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ * (c) Florent Vilmart
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import <SDWebImage/SDWebImageCompat.h>
+
+#if SD_UIKIT
+#import <UIKit/UIKit.h>
+#endif
+
+//! Project version number for WebImageCore.
+FOUNDATION_EXPORT double WebImageCoreVersionNumber;
+
+//! Project version string for WebImageCore.
+FOUNDATION_EXPORT const unsigned char WebImageCoreVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <WebImageCore/PublicHeader.h>
+
+#import <SDWebImage/SDWebImageManager.h>
+#import <SDWebImage/SDImageCacheConfig.h>
+#import <SDWebImage/SDImageCache.h>
+#import <SDWebImage/UIView+WebCache.h>
+#import <SDWebImage/UIImageView+WebCache.h>
+#import <SDWebImage/UIImageView+HighlightedWebCache.h>
+#import <SDWebImage/SDWebImageDownloaderOperation.h>
+#import <SDWebImage/UIButton+WebCache.h>
+#import <SDWebImage/SDWebImagePrefetcher.h>
+#import <SDWebImage/UIView+WebCacheOperation.h>
+#import <SDWebImage/UIImage+MultiFormat.h>
+#import <SDWebImage/SDWebImageOperation.h>
+#import <SDWebImage/SDWebImageDownloader.h>
+
+#import <SDWebImage/SDWebImageCodersManager.h>
+#import <SDWebImage/SDWebImageCoder.h>
+#import <SDWebImage/SDWebImageGIFCoder.h>
+#import <SDWebImage/SDWebImageImageIOCoder.h>
+#import <SDWebImage/UIImage+GIF.h>
+#import <SDWebImage/UIImage+ForceDecode.h>
+#import <SDWebImage/NSData+ImageContentType.h>
+
+#if SD_MAC
+    #import <SDWebImage/NSImage+WebCache.h>
+#endif

--- a/WebImage/SDWebImageCore.h
+++ b/WebImage/SDWebImageCore.h
@@ -1,5 +1,5 @@
 /*
- * This file is part of the SDWebImage package.
+ * This file is part of the SDWebImageCore package.
  * (c) Olivier Poitrey <rs@dailymotion.com>
  * (c) Florent Vilmart
  *
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-#import <SDWebImage/SDWebImageCompat.h>
+#import <SDWebImageCore/SDWebImageCompat.h>
 
 #if SD_UIKIT
 #import <UIKit/UIKit.h>
@@ -21,28 +21,30 @@ FOUNDATION_EXPORT const unsigned char WebImageCoreVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <WebImageCore/PublicHeader.h>
 
-#import <SDWebImage/SDWebImageManager.h>
-#import <SDWebImage/SDImageCacheConfig.h>
-#import <SDWebImage/SDImageCache.h>
-#import <SDWebImage/UIView+WebCache.h>
-#import <SDWebImage/UIImageView+WebCache.h>
-#import <SDWebImage/UIImageView+HighlightedWebCache.h>
-#import <SDWebImage/SDWebImageDownloaderOperation.h>
-#import <SDWebImage/UIButton+WebCache.h>
-#import <SDWebImage/SDWebImagePrefetcher.h>
-#import <SDWebImage/UIView+WebCacheOperation.h>
-#import <SDWebImage/UIImage+MultiFormat.h>
-#import <SDWebImage/SDWebImageOperation.h>
-#import <SDWebImage/SDWebImageDownloader.h>
+#import <SDWebImageCore/SDWebImageManager.h>
+#import <SDWebImageCore/SDImageCacheConfig.h>
+#import <SDWebImageCore/SDImageCache.h>
+#import <SDWebImageCore/UIView+WebCache.h>
+#import <SDWebImageCore/UIImageView+WebCache.h>
+#import <SDWebImageCore/UIImageView+HighlightedWebCache.h>
+#import <SDWebImageCore/SDWebImageDownloaderOperation.h>
+#import <SDWebImageCore/UIButton+WebCache.h>
+#import <SDWebImageCore/SDWebImagePrefetcher.h>
+#import <SDWebImageCore/UIView+WebCacheOperation.h>
+#import <SDWebImageCore/UIImage+MultiFormat.h>
+#import <SDWebImageCore/SDWebImageOperation.h>
+#import <SDWebImageCore/SDWebImageDownloader.h>
 
-#import <SDWebImage/SDWebImageCodersManager.h>
-#import <SDWebImage/SDWebImageCoder.h>
-#import <SDWebImage/SDWebImageGIFCoder.h>
-#import <SDWebImage/SDWebImageImageIOCoder.h>
-#import <SDWebImage/UIImage+GIF.h>
-#import <SDWebImage/UIImage+ForceDecode.h>
-#import <SDWebImage/NSData+ImageContentType.h>
+#import <SDWebImageCore/SDWebImageCodersManager.h>
+#import <SDWebImageCore/SDWebImageCoder.h>
+#import <SDWebImageCore/SDWebImageGIFCoder.h>
+#import <SDWebImageCore/SDWebImageImageIOCoder.h>
+#import <SDWebImageCore/SDWebImageFrame.h>
+#import <SDWebImageCore/SDWebImageCoderHelper.h>
+#import <SDWebImageCore/UIImage+GIF.h>
+#import <SDWebImageCore/UIImage+ForceDecode.h>
+#import <SDWebImageCore/NSData+ImageContentType.h>
 
 #if SD_MAC
-    #import <SDWebImage/NSImage+WebCache.h>
+    #import <SDWebImageCore/NSImage+WebCache.h>
 #endif


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [X] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [X] I have added the required tests to prove the fix/feature I am adding
* [X] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2056

### Pull Request Description
Add targets for core frameworks without MapKit, WebP and FLAnimatedImage.
The new targets allow developers to use the [core parts](https://github.com/rs/SDWebImage/blob/master/SDWebImage.podspec#L29) of SDWebImage in combination with Carthage without the need to include MapKit.

