### PR TITLE
Add image format detect of HEIC (One type of HEIF which use HEVC codec). This is supported natively in iOS 11 & macOS 10.13

### DIFF
--- a/SDWebImage/NSData+ImageContentType.h
+++ b/SDWebImage/NSData+ImageContentType.h
@@ -16,7 +16,8 @@ typedef NS_ENUM(NSInteger, SDImageFormat) {
     SDImageFormatPNG,
     SDImageFormatGIF,
     SDImageFormatTIFF,
-    SDImageFormatWebP
+    SDImageFormatWebP,
+    SDImageFormatHEIC
 };
 
 @interface NSData (ImageContentType)

--- a/SDWebImage/NSData+ImageContentType.m
+++ b/SDWebImage/NSData+ImageContentType.m
@@ -21,6 +21,7 @@
         return SDImageFormatUndefined;
     }
     
+    // File signatures table: http://www.garykessler.net/library/file_sigs.html
     uint8_t c;
     [data getBytes:&c length:1];
     switch (c) {
@@ -33,16 +34,26 @@
         case 0x49:
         case 0x4D:
             return SDImageFormatTIFF;
-        case 0x52:
-            // R as RIFF for WEBP
-            if (data.length < 12) {
-                return SDImageFormatUndefined;
+        case 0x52: {
+            if (data.length >= 12) {
+                //RIFF....WEBP
+                NSString *testString = [[NSString alloc] initWithData:[data subdataWithRange:NSMakeRange(0, 12)] encoding:NSASCIIStringEncoding];
+                if ([testString hasPrefix:@"RIFF"] && [testString hasSuffix:@"WEBP"]) {
+                    return SDImageFormatWebP;
+                }
             }
-            
-            NSString *testString = [[NSString alloc] initWithData:[data subdataWithRange:NSMakeRange(0, 12)] encoding:NSASCIIStringEncoding];
-            if ([testString hasPrefix:@"RIFF"] && [testString hasSuffix:@"WEBP"]) {
-                return SDImageFormatWebP;
+            break;
+        }
+        case 0x00: {
+            if (data.length >= 12) {
+                //....ftypheic
+                NSString *testString = [[NSString alloc] initWithData:[data subdataWithRange:NSMakeRange(4, 8)] encoding:NSASCIIStringEncoding];
+                if ([testString hasPrefix:@"ftyp"] && [testString hasSuffix:@"heic"]) {
+                    return SDImageFormatHEIC;
+                }
             }
+            break;
+        }
     }
     return SDImageFormatUndefined;
 }

--- a/SDWebImage/NSData+ImageContentType.m
+++ b/SDWebImage/NSData+ImageContentType.m
@@ -14,6 +14,11 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #endif
 
+// Currently Image/IO does not support WebP
+#define kSDUTTypeWebP ((__bridge CFStringRef)@"public.webp")
+// AVFileTypeHEIC is defined in AVFoundation via iOS 11, we use this without import AVFoundation
+#define kSDUTTypeHEIC ((__bridge CFStringRef)@"public.heic")
+
 @implementation NSData (ImageContentType)
 
 + (SDImageFormat)sd_imageFormatForImageData:(nullable NSData *)data {
@@ -48,7 +53,7 @@
             if (data.length >= 12) {
                 //....ftypheic
                 NSString *testString = [[NSString alloc] initWithData:[data subdataWithRange:NSMakeRange(4, 8)] encoding:NSASCIIStringEncoding];
-                if ([testString hasPrefix:@"ftyp"] && [testString hasSuffix:@"heic"]) {
+                if ([testString isEqualToString:@"ftypheic"]) {
                     return SDImageFormatHEIC;
                 }
             }
@@ -72,6 +77,12 @@
             break;
         case SDImageFormatTIFF:
             UTType = kUTTypeTIFF;
+            break;
+        case SDImageFormatWebP:
+            UTType = kSDUTTypeWebP;
+            break;
+        case SDImageFormatHEIC:
+            UTType = kSDUTTypeHEIC;
             break;
         default:
             // default is kUTTypePNG

--- a/SDWebImage/SDWebImageCoder.h
+++ b/SDWebImage/SDWebImageCoder.h
@@ -33,10 +33,12 @@ CG_EXTERN BOOL SDCGImageRefContainsAlpha(_Nullable CGImageRef imageRef);
 
 /**
  This is the image coder protocol to provide custom image decoding/encoding.
+ These methods are all required to implement.
  @note Pay attention that these methods are not called from main queue.
  */
 @protocol SDWebImageCoder <NSObject>
 
+@required
 #pragma mark - Decoding
 /**
  Returns YES if this coder can decode some data. Otherwise, the data should be passed to another coder.
@@ -90,10 +92,12 @@ CG_EXTERN BOOL SDCGImageRefContainsAlpha(_Nullable CGImageRef imageRef);
 
 /**
  This is the image coder protocol to provide custom progressive image decoding.
+ These methods are all required to implement.
  @note Pay attention that these methods are not called from main queue.
  */
 @protocol SDWebImageProgressiveCoder <SDWebImageCoder>
 
+@required
 /**
  Returns YES if this coder can incremental decode some data. Otherwise, it should be passed to another coder.
  

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -397,6 +397,8 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         // Do not support WebP encoding
         case SDImageFormatWebP:
             return NO;
+        case SDImageFormatHEIC:
+            return [[self class] canEncodeToHEICFormat];
         default:
             return YES;
     }
@@ -467,6 +469,28 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     }
     
     return YES;
+}
+
++ (BOOL)canEncodeToHEICFormat
+{
+    static BOOL canEncode = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSMutableData *imageData = [NSMutableData data];
+        CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatHEIC];
+        
+        // Create an image destination.
+        CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, 1, NULL);
+        if (!imageDestination) {
+            // Can encode to HEIC
+            canEncode = NO;
+        } else {
+            // Can't encode to HEIF
+            CFRelease(imageDestination);
+            canEncode = YES;
+        }
+    });
+    return canEncode;
 }
 
 #if SD_UIKIT || SD_WATCH

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -66,8 +66,8 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 #pragma mark - Decode
 - (BOOL)canDecodeFromData:(nullable NSData *)data {
     switch ([NSData sd_imageFormatForImageData:data]) {
-        // Do not support WebP decoding
         case SDImageFormatWebP:
+            // Do not support WebP decoding
             return NO;
         default:
             return YES;
@@ -76,8 +76,8 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 
 - (BOOL)canIncrementallyDecodeFromData:(NSData *)data {
     switch ([NSData sd_imageFormatForImageData:data]) {
-        // Support static GIF progressive decoding
         case SDImageFormatWebP:
+            // Do not support WebP progressive decoding
             return NO;
         default:
             return YES;
@@ -394,10 +394,11 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 #pragma mark - Encode
 - (BOOL)canEncodeToFormat:(SDImageFormat)format {
     switch (format) {
-        // Do not support WebP encoding
         case SDImageFormatWebP:
+            // Do not support WebP encoding
             return NO;
         case SDImageFormatHEIC:
+            // Check HEIC encoding compatibility
             return [[self class] canEncodeToHEICFormat];
         default:
             return YES;
@@ -482,10 +483,10 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         // Create an image destination.
         CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, 1, NULL);
         if (!imageDestination) {
-            // Can encode to HEIC
+            // Can't encode to HEIC
             canEncode = NO;
         } else {
-            // Can't encode to HEIF
+            // Can encode to HEIC
             CFRelease(imageDestination);
             canEncode = YES;
         }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1853 #2038 

### Pull Request Description

HEIC, Which is a type of [HEIF](https://en.wikipedia.org/wiki/High_Efficiency_Image_File_Format) with that HEVC codec. (Like WebP is used VP8 codec). This is a [ISO standard](https://www.iso.org/standard/66067.html). Attension, HEIF is a **Superset** and HEIC is specify the image use HEVC codec. HEIC image format is **Natively** support on iOS 11, tvOS 11 & macOS 10.13. But HEIF with other codec is currently not supported.

The `Natively` means all that interface does not need any changes and transparently support this image format. Apple implement this under Image/IO layer(UIKit/CoreImage -> Core Graphics ->Image/IO). So that previous version SDWebImage also be benefited from this support decoding this kind of type to `UIImage`.

So I add a extra image format type in our `SDImageFormat` enum. I want to update ImageIOCoder's UTType as well. But from [WWDC's introduction](https://devstreaming-cdn.apple.com/videos/wwdc/2017/511tj33587vdhds/511/511_working_with_heif_and_hevc.pdf), it currently support encoding on all Macs but iPhone 7 and above 😢 . 

~~~So we could not simply add this to our ImageIO recognized format to allow encode. Or we need something like if (@avaliable(iOS 11, macOS 10.13) && [self MacOriPhoneCPUIsA10FusionAbove]) check code. If you need this , consider our your custom coder which is our 4.2 version's big feature. 😄~~~

I just add this image format enum to our lib. But this decoding need iOS 11 & macOS 10.13 above device but without iPhone simulator (Good Apple :D). You should check your target device system version to allow download this kind of image format.
