### PR TITLE
Add all 4 standard HEIC brand file signature, ftypheic & ftypheix is for single image, ftyphevc & ftyphevx is for sequence image

### DIFF
--- a/SDWebImage/NSData+ImageContentType.m
+++ b/SDWebImage/NSData+ImageContentType.m
@@ -51,9 +51,12 @@
         }
         case 0x00: {
             if (data.length >= 12) {
-                //....ftypheic
+                //....ftypheic ....ftypheix ....ftyphevc ....ftyphevx
                 NSString *testString = [[NSString alloc] initWithData:[data subdataWithRange:NSMakeRange(4, 8)] encoding:NSASCIIStringEncoding];
-                if ([testString isEqualToString:@"ftypheic"]) {
+                if ([testString isEqualToString:@"ftypheic"]
+                    || [testString isEqualToString:@"ftypheix"]
+                    || [testString isEqualToString:@"ftyphevc"]
+                    || [testString isEqualToString:@"ftyphevx"]) {
                     return SDImageFormatHEIC;
                 }
             }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

According to http://nokiatech.github.io/heif/technical.html, we shoudl also add all 4 standard brand for HEIC images.

