### PR TITLE
Update NSData+ImageContentType.m

### DIFF
--- a/SDWebImage/NSData+ImageContentType.m
+++ b/SDWebImage/NSData+ImageContentType.m
@@ -16,7 +16,7 @@
 
 // Currently Image/IO does not support WebP
 #define kSDUTTypeWebP ((__bridge CFStringRef)@"public.webp")
-// AVFileTypeHEIC is defined in AVFoundation via iOS 11, we use this without import AVFoundation
+// AVFileTypeHEIC is defined in AVFoundation via iOS 11 and A9 above CPU(iPhone 7 above models), we use this without import AVFoundation
 #define kSDUTTypeHEIC ((__bridge CFStringRef)@"public.heic")
 
 @implementation NSData (ImageContentType)


### PR DESCRIPTION
AVFileTypeHEIC is defined in AVFoundation via iOS 11 and A9 above CPU(iPhone 7 above models). For Example, iPhone SE +iOS11,the photo is not ".heic"

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

...

