### PR TITLE
Fix that completion block and set image block are called asynchronously for UIView+WebCache

### DIFF
--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -99,11 +99,15 @@ typedef void(^SDWebImageNoParamsBlock)(void);
 
 FOUNDATION_EXPORT NSString *const SDWebImageErrorDomain;
 
-#ifndef dispatch_main_async_safe
-#define dispatch_main_async_safe(block)\
-    if (strcmp(dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL), dispatch_queue_get_label(dispatch_get_main_queue())) == 0) {\
+#ifndef dispatch_queue_async_safe
+#define dispatch_queue_async_safe(queue, block)\
+    if (strcmp(dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL), dispatch_queue_get_label(queue)) == 0) {\
         block();\
     } else {\
-        dispatch_async(dispatch_get_main_queue(), block);\
+        dispatch_async(queue, block);\
     }
+#endif
+
+#ifndef dispatch_main_async_safe
+#define dispatch_main_async_safe(block) dispatch_queue_async_safe(dispatch_get_main_queue(), block)
 #endif

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -106,7 +106,7 @@ static char TAG_ACTIVITY_SHOW;
             }
             dispatch_queue_t targetQueue = shouldUseGlobalQueue ? dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0) : dispatch_get_main_queue();
             
-            dispatch_async(targetQueue, ^{
+            dispatch_queue_async_safe(targetQueue, ^{
                 [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
                 dispatch_main_async_safe(callCompletedBlockClojure);
             });


### PR DESCRIPTION
Add a more common macro to do current queue check

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2092

### Pull Request Description
Our use relay on the behavior that completion and set-image block should happend during one run loop without add it to the end of main queue. This means we should use `dispatch_main_async_safe` to dispatch queue when current queue is main queue.

This behavior is changed during #2047. At that time I didn't realized that completion and set-image block should immediately call when current queue is main queue. So we then do code refactor about this logic.

```objectivec
dispatch_queue_t targetQueue = shouldUseGlobalQueue ? dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0) : dispatch_get_main_queue();

dispatch_async(targetQueue, ^{});
```

In fact, we should do like this:

```objectivec
if (shouldUseGlobalQueue) {
    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
        [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
        dispatch_main_async_safe(callCompletedBlockClojure);
    });
} else {
  // If current queue is already main queue, this will become all immediately block call instead of adding block to queue
    dispatch_main_async_safe(^{
        [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
        dispatch_main_async_safe(callCompletedBlockClojure);
    });
}
```

This can work, but not looks well. I think we can create a more common usage macro, like this, to solve this kind of use case:

```objectivec
#define dispatch_queue_async_safe(queue, block)\
    if (strcmp(dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL), dispatch_queue_get_label(queue)) == 0) {\
        block();\
    } else {\
        dispatch_async(queue, block);\
    }

#define dispatch_main_async_safe(block) dispatch_queue_async_safe(dispatch_get_main_queue(), block)
```

Then we just need to change it to this:

```objectivec
dispatch_queue_async_safe(targetQueue, ^{});
```

I don't think this is a break API change. But if someone think this change should not happened on 4.2.2 patch release. I can change back to that first one in description to avoid modify any header file.

Any idea ?
