### PR TITLE
Fix WebP progressive decoding may do extra calculate

### DIFF
--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -166,7 +166,8 @@
     int last_y = 0;
     int stride = 0;
     uint8_t *rgba = WebPIDecGetRGB(_idec, &last_y, &width, &height, &stride);
-    if (width + height > 0 && height >= last_y) {
+    // last_y may be 0, means no enough bitmap data to decode, ignore this
+    if (width + height > 0 && last_y > 0 && height >= last_y) {
         // Construct a UIImage from the decoded RGBA value array
         CGDataProviderRef provider =
         CGDataProviderCreateWithData(NULL, rgba, 0, NULL);


### PR DESCRIPTION
because that libwebp will output last_y to zero, which means current image data is not enough to decode first stride

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

For WebP progressive decoding, libwebp will output last_y to zero, which means current image data is not enough to decode first stride.

So at this case, if we try to create `CGImage`, Image/IO may log an error `Demo[69478:682360] [Unknown process name] CGImageCreate: invalid image size: 1024 x 0.` And then that `CGImage` is NULL, this should return at the beginning instead of let Image/IO log this error.

To say, this will have no distinct performance affect, but a protection is better, right ? 😅 