### PR TITLE
Byte Alignment to 64 bytes to reduce memory usage

### DIFF
--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -160,7 +160,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         if (partialImageRef) {
             const size_t partialHeight = CGImageGetHeight(partialImageRef);
             CGColorSpaceRef colorSpace = SDCGColorSpaceGetDeviceRGB();
-            CGContextRef bmContext = CGBitmapContextCreate(NULL, _width, _height, 8, _width * 4, colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
+            CGContextRef bmContext = CGBitmapContextCreate(NULL, _width, _height, 8, SDCGByteAlign(_width * 4, 64), colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
             if (bmContext) {
                 CGContextDrawImage(bmContext, (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = _width, .size.height = partialHeight}, partialImageRef);
                 CGImageRelease(partialImageRef);
@@ -252,7 +252,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
                                                      width,
                                                      height,
                                                      kBitsPerComponent,
-                                                     bytesPerRow,
+                                                     SDCGByteAlign(bytesPerRow, 64),
                                                      colorspaceRef,
                                                      kCGBitmapByteOrderDefault|kCGImageAlphaNoneSkipLast);
         if (context == NULL) {
@@ -313,7 +313,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
                                             destResolution.width,
                                             destResolution.height,
                                             kBitsPerComponent,
-                                            bytesPerRow,
+                                            SDCGByteAlign(bytesPerRow, 64),
                                             colorspaceRef,
                                             kCGBitmapByteOrderDefault|kCGImageAlphaNoneSkipLast);
         
@@ -553,5 +553,10 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     return colorspaceRef;
 }
 #endif
+
+// 64 bytes align to avoid extra `CA::Render::aligned_malloc` call
+static inline size_t SDCGByteAlign(size_t size, size_t alignment) {
+    return ((size + (alignment - 1)) / alignment) * alignment;
+}
 
 @end

--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -77,7 +77,7 @@
     } else {
         bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast;
     }
-    CGContextRef canvas = CGBitmapContextCreate(NULL, canvasWidth, canvasHeight, 8, 0, SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
+    CGContextRef canvas = CGBitmapContextCreate(NULL, canvasWidth, canvasHeight, 8, SDCGByteAlign(canvasWidth * 4, 64), SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
     if (!canvas) {
         WebPDemuxDelete(demuxer);
         return nil;
@@ -190,7 +190,7 @@
             return nil;
         }
         
-        CGContextRef canvas = CGBitmapContextCreate(NULL, width, height, 8, 0, SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
+        CGContextRef canvas = CGBitmapContextCreate(NULL, width, height, 8, SDCGByteAlign(width * 4, 64), SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
         if (!canvas) {
             CGImageRelease(imageRef);
             return nil;
@@ -415,6 +415,11 @@
 
 static void FreeImageData(void *info, const void *data, size_t size) {
     free((void *)data);
+}
+
+// 64 bytes align to avoid extra `CA::Render::aligned_malloc` call
+static inline size_t SDCGByteAlign(size_t size, size_t alignment) {
+    return ((size + (alignment - 1)) / alignment) * alignment;
 }
 
 @end


### PR DESCRIPTION
let Core Animation not to call extra `aligned_malloc`

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Core Animation will try to realign bitmap buffer for `CALayer` if the bitmap is not 64-bytes alignment. It will call `CA::Render::aligned_malloc` to copy your bitmap data. This will increate extra memory usage. For our WebP and Image/IO Coder, we should keep byte-aligned to enhance performance since it's really easy to do.

Tested with our demo and can reduce nearly 3MB. I also test that if we pass `bytePerRow` to 0, Core Graphics will automatically calculate and align. Maybe I can change all these args to 0 ?

References: https://github.com/path/FastImageCache#byte-alignment

