### PR TITLE
Revert changes for FLAnimatedImage performance enhancement.

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -63,18 +63,22 @@
                                    FLAnimatedImage *animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
                                    dispatch_main_async_safe(^{
                                        weakSelf.animatedImage = animatedImage;
-                                       dispatch_group_leave(group);
+                                       if (group) {
+                                           dispatch_group_leave(group);
+                                       }
                                    });
                                });
                            } else {
                                weakSelf.image = image;
                                weakSelf.animatedImage = nil;
-                               dispatch_group_leave(group);
+                               if (group) {
+                                   dispatch_group_leave(group);
+                               }
                            }
                        }
                             progress:progressBlock
                            completed:completedBlock
-                             context:@{SDWebImageInternalSetImageGroupKey : group}];
+                             context:group ? @{SDWebImageInternalSetImageGroupKey : group} : nil];
 }
 
 @end

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -54,8 +54,15 @@
                        setImageBlock:^(UIImage *image, NSData *imageData) {
                            SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
                            if (imageFormat == SDImageFormatGIF) {
-                               weakSelf.animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
-                               weakSelf.image = nil;
+                               // Firstly set the static poster image to avoid flashing
+                               weakSelf.image = image;
+                               dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+                                   // Secondly create FLAnimatedImage in global queue because it's time consuming, then set it back
+                                   FLAnimatedImage *animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
+                                   dispatch_main_async_safe(^{
+                                       weakSelf.animatedImage = animatedImage;
+                                   });
+                               });
                            } else {
                                weakSelf.image = image;
                                weakSelf.animatedImage = nil;

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -56,7 +56,8 @@
                            SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
                            if (imageFormat == SDImageFormatGIF) {
                                // Firstly set the static poster image to avoid flashing
-                               weakSelf.image = image;
+                               UIImage *posterImage = image.images ? image.images.firstObject : image;
+                               weakSelf.image = posterImage;
                                dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
                                    // Secondly create FLAnimatedImage in global queue because it's time consuming, then set it back
                                    FLAnimatedImage *animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -47,6 +47,7 @@
                   progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                  completed:(nullable SDExternalCompletionBlock)completedBlock {
     __weak typeof(self)weakSelf = self;
+    dispatch_group_t group = dispatch_group_create();
     [self sd_internalSetImageWithURL:url
                     placeholderImage:placeholder
                              options:options
@@ -61,15 +62,18 @@
                                    FLAnimatedImage *animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
                                    dispatch_main_async_safe(^{
                                        weakSelf.animatedImage = animatedImage;
+                                       dispatch_group_leave(group);
                                    });
                                });
                            } else {
                                weakSelf.image = image;
                                weakSelf.animatedImage = nil;
+                               dispatch_group_leave(group);
                            }
                        }
                             progress:progressBlock
-                           completed:completedBlock];
+                           completed:completedBlock
+                             context:@{SDWebImageInternalSetImageGroupKey : group}];
 }
 
 @end

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -52,25 +52,17 @@
                              options:options
                         operationKey:nil
                        setImageBlock:^(UIImage *image, NSData *imageData) {
-                           // This setImageBlock may not called from main queue
                            SDImageFormat imageFormat = [NSData sd_imageFormatForImageData:imageData];
-                           FLAnimatedImage *animatedImage;
                            if (imageFormat == SDImageFormatGIF) {
-                               animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
+                               weakSelf.animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
+                               weakSelf.image = nil;
+                           } else {
+                               weakSelf.image = image;
+                               weakSelf.animatedImage = nil;
                            }
-                           dispatch_main_async_safe(^{
-                               if (animatedImage) {
-                                   weakSelf.animatedImage = animatedImage;
-                                   weakSelf.image = nil;
-                               } else {
-                                   weakSelf.image = image;
-                                   weakSelf.animatedImage = nil;
-                               }
-                           });
                        }
                             progress:progressBlock
-                           completed:completedBlock
-                             context:@{SDWebImageInternalSetImageInGlobalQueueKey: @(YES)}];
+                           completed:completedBlock];
 }
 
 @end

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -50,7 +50,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 @property (strong, nonatomic, nonnull) NSCache *memCache;
 @property (strong, nonatomic, nonnull) NSString *diskCachePath;
 @property (strong, nonatomic, nullable) NSMutableArray<NSString *> *customPaths;
-@property (SDDispatchQueueSetterSementics, nonatomic, nullable) dispatch_queue_t ioQueue;
+@property (strong, nonatomic, nullable) dispatch_queue_t ioQueue;
 
 @end
 
@@ -129,7 +129,6 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    SDDispatchQueueRelease(_ioQueue);
 }
 
 - (void)checkIfQueueIsIOQueue {

--- a/SDWebImage/SDWebImageCodersManager.m
+++ b/SDWebImage/SDWebImageCodersManager.m
@@ -15,8 +15,8 @@
 
 @interface SDWebImageCodersManager ()
 
-@property (nonatomic, strong, nonnull) NSMutableArray<SDWebImageCoder>* mutableCoders;
-@property (SDDispatchQueueSetterSementics, nonatomic, nullable) dispatch_queue_t mutableCodersAccessQueue;
+@property (strong, nonatomic, nonnull) NSMutableArray<SDWebImageCoder>* mutableCoders;
+@property (strong, nonatomic, nullable) dispatch_queue_t mutableCodersAccessQueue;
 
 @end
 
@@ -41,10 +41,6 @@
         _mutableCodersAccessQueue = dispatch_queue_create("com.hackemist.SDWebImageCodersManager", DISPATCH_QUEUE_CONCURRENT);
     }
     return self;
-}
-
-- (void)dealloc {
-    SDDispatchQueueRelease(_mutableCodersAccessQueue);
 }
 
 #pragma mark - Coder IO operations

--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -81,18 +81,6 @@
 #define NS_OPTIONS(_type, _name) enum _name : _type _name; enum _name : _type
 #endif
 
-#if OS_OBJECT_USE_OBJC
-    #undef SDDispatchQueueRelease
-    #undef SDDispatchQueueSetterSementics
-    #define SDDispatchQueueRelease(q)
-    #define SDDispatchQueueSetterSementics strong
-#else
-    #undef SDDispatchQueueRelease
-    #undef SDDispatchQueueSetterSementics
-    #define SDDispatchQueueRelease(q) (dispatch_release(q))
-    #define SDDispatchQueueSetterSementics assign
-#endif
-
 FOUNDATION_EXPORT UIImage *SDScaledImageForKey(NSString *key, UIImage *image);
 
 typedef void(^SDWebImageNoParamsBlock)(void);

--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -10,7 +10,11 @@
 #import "UIImage+MultiFormat.h"
 
 #if !__has_feature(objc_arc)
-#error SDWebImage is ARC only. Either turn on ARC for the project or use -fobjc-arc flag
+    #error SDWebImage is ARC only. Either turn on ARC for the project or use -fobjc-arc flag
+#endif
+
+#if !OS_OBJECT_USE_OBJC
+    #error SDWebImage need ARC for dispatch object
 #endif
 
 inline UIImage *SDScaledImageForKey(NSString * _Nullable key, UIImage * _Nullable image) {

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -21,7 +21,7 @@
 @property (strong, nonatomic, nonnull) NSMutableDictionary<NSURL *, SDWebImageDownloaderOperation *> *URLOperations;
 @property (strong, nonatomic, nullable) SDHTTPHeadersMutableDictionary *HTTPHeaders;
 // This queue is used to serialize the handling of the network responses of all the download operation in a single queue
-@property (SDDispatchQueueSetterSementics, nonatomic, nullable) dispatch_queue_t barrierQueue;
+@property (strong, nonatomic, nullable) dispatch_queue_t barrierQueue;
 
 // The session in which data tasks will run
 @property (strong, nonatomic) NSURLSession *session;
@@ -112,7 +112,6 @@
     self.session = nil;
 
     [self.downloadQueue cancelAllOperations];
-    SDDispatchQueueRelease(_barrierQueue);
 }
 
 - (void)setValue:(nullable NSString *)value forHTTPHeaderField:(nullable NSString *)field {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -38,7 +38,7 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 
 @property (strong, nonatomic, readwrite, nullable) NSURLSessionTask *dataTask;
 
-@property (SDDispatchQueueSetterSementics, nonatomic, nullable) dispatch_queue_t barrierQueue;
+@property (strong, nonatomic, nullable) dispatch_queue_t barrierQueue;
 
 #if SD_UIKIT
 @property (assign, nonatomic) UIBackgroundTaskIdentifier backgroundTaskId;
@@ -72,10 +72,6 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
         _barrierQueue = dispatch_queue_create("com.hackemist.SDWebImageDownloaderOperationBarrierQueue", DISPATCH_QUEUE_CONCURRENT);
     }
     return self;
-}
-
-- (void)dealloc {
-    SDDispatchQueueRelease(_barrierQueue);
 }
 
 - (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock

--- a/SDWebImage/SDWebImagePrefetcher.h
+++ b/SDWebImage/SDWebImagePrefetcher.h
@@ -61,7 +61,7 @@ typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger noOfFinishedUrls, 
 /**
  * Queue options for Prefetcher. Defaults to Main Queue.
  */
-@property (SDDispatchQueueSetterSementics, nonatomic, nonnull) dispatch_queue_t prefetcherQueue;
+@property (strong, nonatomic, nonnull) dispatch_queue_t prefetcherQueue;
 
 @property (weak, nonatomic, nullable) id <SDWebImagePrefetcherDelegate> delegate;
 

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -12,7 +12,10 @@
 
 #import "SDWebImageManager.h"
 
-FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageInGlobalQueueKey;
+/**
+ A Dispatch group to maintain setImageBlock and completionBlock. This key should only be used internal and may be changed in the future. (dispatch_group_t)
+ */
+FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupKey;
 
 typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable imageData);
 

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -13,7 +13,7 @@
 #import "SDWebImageManager.h"
 
 /**
- A Dispatch group to maintain setImageBlock and completionBlock. This key should only be used internal and may be changed in the future. (dispatch_group_t)
+ A Dispatch group to maintain setImageBlock and completionBlock. This key should be used only internally and may be changed in the future. (dispatch_group_t)
  */
 FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupKey;
 

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -13,7 +13,7 @@
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 
-NSString * const SDWebImageInternalSetImageGroupKey = @"setImageGroup";
+NSString * const SDWebImageInternalSetImageGroupKey = @"internalSetImageGroup";
 
 static char imageURLKey;
 

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -13,7 +13,7 @@
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 
-NSString * const SDWebImageInternalSetImageInGlobalQueueKey = @"setImageInGlobalQueue";
+NSString * const SDWebImageInternalSetImageGroupKey = @"setImageGroup";
 
 static char imageURLKey;
 
@@ -52,6 +52,10 @@ static char TAG_ACTIVITY_SHOW;
     objc_setAssociatedObject(self, &imageURLKey, url, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     
     if (!(options & SDWebImageDelayPlaceholder)) {
+        if ([context valueForKey:SDWebImageInternalSetImageGroupKey]) {
+            dispatch_group_t group = [context valueForKey:SDWebImageInternalSetImageGroupKey];
+            dispatch_group_enter(group);
+        }
         dispatch_main_async_safe(^{
             [self sd_setImage:placeholder imageData:nil basedOnClassOrViaCustomSetImageBlock:setImageBlock];
         });
@@ -100,16 +104,23 @@ static char TAG_ACTIVITY_SHOW;
                 targetImage = placeholder;
                 targetData = nil;
             }
-            BOOL shouldUseGlobalQueue = NO;
-            if (context && [context valueForKey:SDWebImageInternalSetImageInGlobalQueueKey]) {
-                shouldUseGlobalQueue = [[context valueForKey:SDWebImageInternalSetImageInGlobalQueueKey] boolValue];
-            }
-            dispatch_queue_t targetQueue = shouldUseGlobalQueue ? dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0) : dispatch_get_main_queue();
             
-            dispatch_queue_async_safe(targetQueue, ^{
-                [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
-                dispatch_main_async_safe(callCompletedBlockClojure);
-            });
+            if ([context valueForKey:SDWebImageInternalSetImageGroupKey]) {
+                dispatch_group_t group = [context valueForKey:SDWebImageInternalSetImageGroupKey];
+                dispatch_group_enter(group);
+                dispatch_main_async_safe(^{
+                    [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
+                });
+                dispatch_group_notify(group, dispatch_get_main_queue(), ^{
+                    dispatch_main_async_safe(callCompletedBlockClojure);
+                });
+                return;
+            } else {
+                dispatch_main_async_safe(^{
+                    [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
+                    callCompletedBlockClojure();
+                });
+            }
         }];
         [self sd_setImageLoadOperation:operation forKey:validOperationKey];
     } else {

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -111,10 +111,10 @@ static char TAG_ACTIVITY_SHOW;
                 dispatch_main_async_safe(^{
                     [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
                 });
+                // ensure completion block is called after custom setImage process finish
                 dispatch_group_notify(group, dispatch_get_main_queue(), ^{
-                    dispatch_main_async_safe(callCompletedBlockClojure);
+                    callCompletedBlockClojure();
                 });
-                return;
             } else {
                 dispatch_main_async_safe(^{
                     [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];


### PR DESCRIPTION
Keep the refactored code for future maintain

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2102 

### Pull Request Description

Revert previous performance enhancement #2047 
The detail information is talked on that #2102. Because of that case counld not be solved by currently implementation and design. So we have to revert code.

But our previouly refactored code and that that `SDWebImageInternalSetImageInGlobalQueueKey` can be kept for future usage and may fit some user's custom usage.
