### PR TITLE
capture currentURL instead of using index to access to avoid race condition

### DIFF
--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -57,25 +57,21 @@
 - (void)startPrefetchingAtIndex:(NSUInteger)index {
     if (index >= self.prefetchURLs.count) return;
     self.requestedCount++;
-    [self.manager loadImageWithURL:self.prefetchURLs[index] options:self.options progress:nil completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+    NSURL *currentURL = self.prefetchURLs[index];
+    [self.manager loadImageWithURL:currentURL options:self.options progress:nil completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
         if (!finished) return;
         self.finishedCount++;
 
-        if (image) {
-            if (self.progressBlock) {
-                self.progressBlock(self.finishedCount,(self.prefetchURLs).count);
-            }
+        if (self.progressBlock) {
+            self.progressBlock(self.finishedCount,(self.prefetchURLs).count);
         }
-        else {
-            if (self.progressBlock) {
-                self.progressBlock(self.finishedCount,(self.prefetchURLs).count);
-            }
+        if (!image) {
             // Add last failed
             self.skippedCount++;
         }
         if ([self.delegate respondsToSelector:@selector(imagePrefetcher:didPrefetchURL:finishedCount:totalCount:)]) {
             [self.delegate imagePrefetcher:self
-                            didPrefetchURL:self.prefetchURLs[index]
+                            didPrefetchURL:currentURL
                              finishedCount:self.finishedCount
                                 totalCount:self.prefetchURLs.count
              ];

--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -11,7 +11,7 @@
 @interface SDWebImagePrefetcher ()
 
 @property (strong, nonatomic, nonnull) SDWebImageManager *manager;
-@property (strong, nonatomic, nullable) NSArray<NSURL *> *prefetchURLs;
+@property (strong, atomic, nullable) NSArray<NSURL *> *prefetchURLs; // may be accessed from different queue
 @property (assign, nonatomic) NSUInteger requestedCount;
 @property (assign, nonatomic) NSUInteger skippedCount;
 @property (assign, nonatomic) NSUInteger finishedCount;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2110 

### Pull Request Description

When user call `cancelPrefetching` from different queue, maybe that completion block in `loadImageWithURL:` are still processing. Then the index previously used will pointer to the our of range index. So we should better capture the `NSURL` object and avoid using index again.

