### PR TITLE
Use a thread-safe mutable dictionary for operation key accessing to avoid multi-thread problem

### DIFF
--- a/SDWebImage/UIView+WebCacheOperation.m
+++ b/SDWebImage/UIView+WebCacheOperation.m
@@ -11,21 +11,102 @@
 #if SD_UIKIT || SD_MAC
 
 #import "objc/runtime.h"
+#import "pthread.h"
+
+#define LOCKED(...) pthread_mutex_lock(&_lock); \
+__VA_ARGS__; \
+pthread_mutex_unlock(&_lock);
 
 static char loadOperationKey;
 
-typedef NSMutableDictionary<NSString *, id> SDOperationsDictionary;
+// A NSMutableDictionary subclass which basic operation is thread-safe, NSFastEnumeration is not thread-safe
+@interface SDThreadSafeMutableDictionary<KeyType, ObjectType> : NSMutableDictionary<KeyType, ObjectType>
+@end
+
+@implementation SDThreadSafeMutableDictionary {
+    pthread_mutex_t _lock;
+    NSMutableDictionary *_dictionary; // NSMutableDictionary is class cluster, you should override all primitive methods from Apple's doc
+}
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _dictionary = [[NSMutableDictionary alloc] initWithCapacity:0];
+        pthread_mutex_init(&_lock, NULL);
+    }
+    return self;
+}
+
+- (instancetype)initWithCapacity:(NSUInteger)numItems {
+    if ((self = [super init])) {
+        _dictionary = [[NSMutableDictionary alloc] initWithCapacity:numItems];
+        pthread_mutex_init(&_lock, NULL);
+    }
+    return self;
+}
+
+- (instancetype)initWithObjects:(NSArray *)objects forKeys:(NSArray<id<NSCopying>> *)keys {
+    if ((self = [self initWithCapacity:objects.count])) {
+        [objects enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+            _dictionary[keys[idx]] = obj;
+        }];
+    }
+    return self;
+}
+
+- (void)setObject:(id)anObject forKey:(id<NSCopying>)aKey {
+    LOCKED([_dictionary setObject:anObject forKey:aKey])
+}
+
+- (void)removeObjectForKey:(id)aKey {
+    LOCKED([_dictionary removeObjectForKey:aKey])
+}
+
+- (NSUInteger)count {
+    LOCKED(NSUInteger count = _dictionary.count)
+    return count;
+}
+
+- (id)objectForKey:(id)aKey {
+    LOCKED(id obj = [_dictionary objectForKey:aKey])
+    return obj;
+}
+
+- (NSEnumerator *)keyEnumerator {
+    LOCKED(NSEnumerator *keyEnumerator = [_dictionary keyEnumerator])
+    return keyEnumerator;
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    LOCKED(id copiedDictionary = [[NSDictionary allocWithZone:zone] initWithDictionary:_dictionary])
+    return copiedDictionary;
+}
+
+- (id)mutableCopyWithZone:(NSZone *)zone {
+    LOCKED(id copiedDictionary = [[self.class allocWithZone:zone] initWithDictionary:_dictionary])
+    return copiedDictionary;
+}
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(id  _Nullable __unsafe_unretained [])buffer count:(NSUInteger)len {
+    LOCKED(NSUInteger count = [[_dictionary copy] countByEnumeratingWithState:state objects:buffer count:len])
+    return count;
+}
+
+@end
+
+typedef SDThreadSafeMutableDictionary<NSString *, id> SDOperationsDictionary;
 
 @implementation UIView (WebCacheOperation)
 
 - (SDOperationsDictionary *)operationDictionary {
-    SDOperationsDictionary *operations = objc_getAssociatedObject(self, &loadOperationKey);
-    if (operations) {
+    @synchronized(self) {
+        SDOperationsDictionary *operations = objc_getAssociatedObject(self, &loadOperationKey);
+        if (operations) {
+            return operations;
+        }
+        operations = [SDThreadSafeMutableDictionary dictionary];
+        objc_setAssociatedObject(self, &loadOperationKey, operations, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         return operations;
     }
-    operations = [NSMutableDictionary dictionary];
-    objc_setAssociatedObject(self, &loadOperationKey, operations, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-    return operations;
 }
 
 - (void)sd_setImageLoadOperation:(nullable id)operation forKey:(nullable NSString *)key {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2113 

### Pull Request Description

The methods in `UIView+WebCacheOperation` is not thread-safe because it use a `NSMutableDictionary` wihtout any lock synchonized method or dispatch queue guard. These methods can be acessed from different queue by user(when user call `UIView+WebCache` methods). And this will cause crash when different queue acess the `NSMutableDictionary` at the same time.

So we should make these methods thread-safe. Instead lock and unlock everywhere to aceess that `NSMutableDictionary`, I advice to create one `SDThreadSafeMutableDictionary` which subclass `NSMutableDictionary` and provide basic thread-safe. The implementation follow apple's doc and get inspiration from PSPDFKit's blog. We use `pthread_mutex` instead of `OSSpinLock` to avoid that priority inversion in newer iOS version.