### PR TITLE
Add a public API to allow user to invalidate URLSession used in SDWebImageDownloader to avoid memory leak on non-singleton instance

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -162,7 +162,7 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
 
 /**
  * Creates an instance of a downloader with specified session configuration.
- * *Note*: `timeoutIntervalForRequest` is going to be overwritten.
+ * @note `timeoutIntervalForRequest` is going to be overwritten.
  * @return new instance of downloader class
  */
 - (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)sessionConfiguration NS_DESIGNATED_INITIALIZER;
@@ -239,8 +239,8 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
 /**
  * Forces SDWebImageDownloader to create and use a new NSURLSession that is
  * initialized with the given configuration.
- * *Note*: All existing download operations in the queue will be cancelled.
- * *Note*: `timeoutIntervalForRequest` is going to be overwritten.
+ * @note All existing download operations in the queue will be cancelled.
+ * @note `timeoutIntervalForRequest` is going to be overwritten.
  *
  * @param sessionConfiguration The configuration to use for the new NSURLSession
  */
@@ -248,7 +248,7 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
 
 /**
  * Invalidates the managed session, optionally canceling pending operations.
- * If you use custom downloader instead of shared downloader, you need call this method when you do not use it to avoid memory leak
+ * @note If you use custom downloader instead of the shared downloader, you need call this method when you do not use it to avoid memory leak
  * @param cancelPendingOperations Whether or not to cancel pending operations.
  */
 - (void)invalidateSessionAndCancel:(BOOL)cancelPendingOperations;

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -246,4 +246,11 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
  */
 - (void)createNewSessionWithConfiguration:(nonnull NSURLSessionConfiguration *)sessionConfiguration;
 
+/**
+ * Invalidates the managed session, optionally canceling pending operations.
+ * If you use custom downloader instead of shared downloader, you need call this method when you do not use it to avoid memory leak
+ * @param cancelPendingOperations Whether or not to cancel pending operations.
+ */
+- (void)invalidateSessionAndCancel:(BOOL)cancelPendingOperations;
+
 @end

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -107,6 +107,14 @@
                                             delegateQueue:nil];
 }
 
+- (void)invalidateSessionAndCancel:(BOOL)cancelPendingOperations {
+    if (cancelPendingOperations) {
+        [self.session invalidateAndCancel];
+    } else {
+        [self.session finishTasksAndInvalidate];
+    }
+}
+
 - (void)dealloc {
     [self.session invalidateAndCancel];
     self.session = nil;

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -61,6 +61,7 @@
 - (void)test01ThatSharedDownloaderIsNotEqualToInitDownloader {
     SDWebImageDownloader *downloader = [[SDWebImageDownloader alloc] init];
     expect(downloader).toNot.equal([SDWebImageDownloader sharedDownloader]);
+    [downloader invalidateSessionAndCancel:YES];
 }
 
 - (void)test02ThatByDefaultDownloaderSetsTheAcceptHTTPHeader {
@@ -377,6 +378,7 @@
     }];
     
     [self waitForExpectationsWithCommonTimeout];
+    [downloader invalidateSessionAndCancel:YES];
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1944 

### Pull Request Description

SDWebImageDownloader set `session` property's delegate to self. So we need to invalidate it to break retain cycle when we do not need it because `NSURLSession` hold a strong reference to delegate. 

For the shared downloader, it's OK since it's all alive during application lifecycle. But for custom instance, sadly we do not have a public API to touch that `session` itself. So we should introduce one to let user call invalidate when they use custom downloader instead of the shared one. 😹 
