### PR TITLE
Follow Apple doc and remove that manual calculation of byte alignment…

### DIFF
--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -160,7 +160,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         if (partialImageRef) {
             const size_t partialHeight = CGImageGetHeight(partialImageRef);
             CGColorSpaceRef colorSpace = SDCGColorSpaceGetDeviceRGB();
-            CGContextRef bmContext = CGBitmapContextCreate(NULL, _width, _height, 8, SDCGByteAlign(_width * 4, 64), colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
+            CGContextRef bmContext = CGBitmapContextCreate(NULL, _width, _height, 8, 0, colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
             if (bmContext) {
                 CGContextDrawImage(bmContext, (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = _width, .size.height = partialHeight}, partialImageRef);
                 CGImageRelease(partialImageRef);
@@ -243,7 +243,6 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         
         size_t width = CGImageGetWidth(imageRef);
         size_t height = CGImageGetHeight(imageRef);
-        size_t bytesPerRow = kBytesPerPixel * width;
         
         // kCGImageAlphaNone is not supported in CGBitmapContextCreate.
         // Since the original image here has no alpha info, use kCGImageAlphaNoneSkipLast
@@ -252,7 +251,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
                                                      width,
                                                      height,
                                                      kBitsPerComponent,
-                                                     SDCGByteAlign(bytesPerRow, 64),
+                                                     0,
                                                      colorspaceRef,
                                                      kCGBitmapByteOrderDefault|kCGImageAlphaNoneSkipLast);
         if (context == NULL) {
@@ -304,8 +303,6 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         // current color space
         CGColorSpaceRef colorspaceRef = [[self class] colorSpaceForImageRef:sourceImageRef];
         
-        size_t bytesPerRow = kBytesPerPixel * destResolution.width;
-        
         // kCGImageAlphaNone is not supported in CGBitmapContextCreate.
         // Since the original image here has no alpha info, use kCGImageAlphaNoneSkipLast
         // to create bitmap graphics contexts without alpha info.
@@ -313,7 +310,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
                                             destResolution.width,
                                             destResolution.height,
                                             kBitsPerComponent,
-                                            SDCGByteAlign(bytesPerRow, 64),
+                                            0,
                                             colorspaceRef,
                                             kCGBitmapByteOrderDefault|kCGImageAlphaNoneSkipLast);
         
@@ -553,10 +550,5 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     return colorspaceRef;
 }
 #endif
-
-// 64 bytes align to avoid extra `CA::Render::aligned_malloc` call
-static inline size_t SDCGByteAlign(size_t size, size_t alignment) {
-    return ((size + (alignment - 1)) / alignment) * alignment;
-}
 
 @end

--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -77,7 +77,7 @@
     } else {
         bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast;
     }
-    CGContextRef canvas = CGBitmapContextCreate(NULL, canvasWidth, canvasHeight, 8, SDCGByteAlign(canvasWidth * 4, 64), SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
+    CGContextRef canvas = CGBitmapContextCreate(NULL, canvasWidth, canvasHeight, 8, 0, SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
     if (!canvas) {
         WebPDemuxDelete(demuxer);
         return nil;
@@ -190,7 +190,7 @@
             return nil;
         }
         
-        CGContextRef canvas = CGBitmapContextCreate(NULL, width, height, 8, SDCGByteAlign(width * 4, 64), SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
+        CGContextRef canvas = CGBitmapContextCreate(NULL, width, height, 8, 0, SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
         if (!canvas) {
             CGImageRelease(imageRef);
             return nil;
@@ -415,11 +415,6 @@
 
 static void FreeImageData(void *info, const void *data, size_t size) {
     free((void *)data);
-}
-
-// 64 bytes align to avoid extra `CA::Render::aligned_malloc` call
-static inline size_t SDCGByteAlign(size_t size, size_t alignment) {
-    return ((size + (alignment - 1)) / alignment) * alignment;
 }
 
 @end


### PR DESCRIPTION
… to make it more universal for different architecture device

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2101

### Pull Request Description

Apple doc says:

> bytesPerRow
> The number of bytes of memory to use per row of the bitmap. If the data parameter is NULL, passing a value of 0 causes the value to be calculated automatically.

Since all our currently `CGBitmapContextCreate` pass the data parameter to `NULL`, we do not need calculate the `bytesPerRow` manually and this can works more universally.
