### PR TITLE
Use SRGB colorspace for bitmap context when available to avoid Color Copied Images issue

### DIFF
--- a/SDWebImage/SDWebImageCoder.m
+++ b/SDWebImage/SDWebImageCoder.m
@@ -14,7 +14,17 @@ CGColorSpaceRef SDCGColorSpaceGetDeviceRGB(void) {
     static CGColorSpaceRef colorSpace;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        colorSpace = CGColorSpaceCreateDeviceRGB();
+        BOOL shouldUseSRGB;
+#if SD_MAC
+        shouldUseSRGB = NO;
+#else
+        shouldUseSRGB = NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_8_x_Max;
+#endif
+        if (shouldUseSRGB) {
+            colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+        } else {
+            colorSpace = CGColorSpaceCreateDeviceRGB();
+        }
     });
     return colorSpace;
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

For iOS device which above iOS 9, use `CGColorSpaceCreateDeviceRGB` colorspace will cause being mark as `Color Copied Image` in Instuments for Core Animation. This may cause extra bitmap data copying when Core Animtation rendering.

This can only happened if you directly use a CGImage from `CGImageCreate` without rendering it on a bitmap context. Notes our build-in WebP coder have force draw images on a bitmap context in any cases(From 4.1.2). You can reproduce this by commenting code in `SDWebImageWebPCoder` from line89-line102.

![simulator screen shot - iphone 8 - 2017-12-01 at 19 49 01](https://user-images.githubusercontent.com/6919743/33481797-01287ebc-d6d1-11e7-9e3c-fc9f7064ec44.png)

This issue can be solved when you use SRGB to create colorspace, the `Color Copied Image` mark disappear. So we'd better take this for usage and let other custom coder benefit from this.