### PR TITLE
Remove operation from view's dictionary after it finished

### DIFF
--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -79,6 +79,9 @@ static char TAG_ACTIVITY_SHOW;
                 if (completedBlock && shouldCallCompletedBlock) {
                     completedBlock(image, error, cacheType, url);
                 }
+                
+                // break retain cycle, see #2125
+                [self sd_removeImageLoadOperationWithKey:validOperationKey];
             };
             
             // case 1a: we got an image, but the SDWebImageAvoidAutoSetImage flag is set


### PR DESCRIPTION
### New Pull Request Checklist

* [*] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

After the operation finished, remove it from view's dictionary to break the retain cycle. Then needn't use ```weakSelf``` or ```strongSelf``` in completion block.