### PR TITLE
Fix progressive WebP decoding by creating data provider with actual data size

### DIFF
--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -169,8 +169,9 @@
     // last_y may be 0, means no enough bitmap data to decode, ignore this
     if (width + height > 0 && last_y > 0 && height >= last_y) {
         // Construct a UIImage from the decoded RGBA value array
+        size_t rgbaSize = last_y * stride;
         CGDataProviderRef provider =
-        CGDataProviderCreateWithData(NULL, rgba, 0, NULL);
+        CGDataProviderCreateWithData(NULL, rgba, rgbaSize, NULL);
         CGColorSpaceRef colorSpaceRef = SDCGColorSpaceGetDeviceRGB();
         
         CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2130 

### Pull Request Description

Apple change that `CGDataProviderCreateWithData` function behavior, it will return a `NULL` when the `size` argument is 0. (Previously it will return a valid data provider instance with size set to 0). The previous version code is also written by me. But at that time I didn't realize this because it just works without any issue.

So now, we need to calculate the rgba size and create this data provider. :)