### PR TITLE
Use a copy-weak maptable for operations stored in UIView(WebCacheOperation) category to avoid retain of operation, and also use lock to keep thread-safe

### DIFF
--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -146,16 +146,8 @@ static inline NSString * backgroundImageURLKeyForState(UIControlState state) {
                            completed:completedBlock];
 }
 
-- (void)sd_setImageLoadOperation:(id<SDWebImageOperation>)operation forState:(UIControlState)state {
-    [self sd_setImageLoadOperation:operation forKey:[NSString stringWithFormat:@"UIButtonImageOperation%@", @(state)]];
-}
-
 - (void)sd_cancelImageLoadForState:(UIControlState)state {
     [self sd_cancelImageLoadOperationWithKey:[NSString stringWithFormat:@"UIButtonImageOperation%@", @(state)]];
-}
-
-- (void)sd_setBackgroundImageLoadOperation:(id<SDWebImageOperation>)operation forState:(UIControlState)state {
-    [self sd_setImageLoadOperation:operation forKey:[NSString stringWithFormat:@"UIButtonBackgroundImageOperation%@", @(state)]];
 }
 
 - (void)sd_cancelBackgroundImageLoadForState:(UIControlState)state {

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -134,9 +134,7 @@ static char animationLoadOperationKey;
                     [operation cancel];
                 }
             }
-            for (size_t i = 0; i < operationsArray.count; i++) {
-                [operationsArray removePointerAtIndex:i];
-            }
+            operationsArray.count = 0;
         }
     }
 }

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -73,7 +73,7 @@
     [self sd_cancelCurrentAnimationImagesLoad];
     __weak __typeof(self)wself = self;
 
-    NSMutableArray<id<SDWebImageOperation>> *operationsArray = [[NSMutableArray alloc] init];
+    NSPointerArray *operationsArray = [self sd_animationOperationArray];
 
     [arrayOfURLs enumerateObjectsUsingBlock:^(NSURL *logoImageURL, NSUInteger idx, BOOL * _Nonnull stop) {
         id <SDWebImageOperation> operation = [[SDWebImageManager sharedManager] loadImageWithURL:logoImageURL options:0 progress:nil completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
@@ -103,14 +103,42 @@
                 [sself startAnimating];
             });
         }];
-        [operationsArray addObject:operation];
+        @synchronized (self) {
+            [operationsArray addPointer:(__bridge void *)(operation)];
+        }
     }];
+}
 
-    [self sd_setImageLoadOperation:[operationsArray copy] forKey:@"UIImageViewAnimationImages"];
+static char animationloadOperationKey;
+
+// element is weak because operation instance is retained by SDWebImageManager's runningOperations property
+// we should use lock to keep thread-safe because these method may not be acessed from main queue
+- (NSPointerArray *)sd_animationOperationArray {
+    @synchronized(self) {
+        NSPointerArray *operationsArray = objc_getAssociatedObject(self, &animationloadOperationKey);
+        if (operationsArray) {
+            return operationsArray;
+        }
+        operationsArray = [NSPointerArray weakObjectsPointerArray];
+        objc_setAssociatedObject(self, &animationloadOperationKey, operationsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        return operationsArray;
+    }
 }
 
 - (void)sd_cancelCurrentAnimationImagesLoad {
-    [self sd_cancelImageLoadOperationWithKey:@"UIImageViewAnimationImages"];
+    NSPointerArray *operationsArray = [self sd_animationOperationArray];
+    if (operationsArray) {
+        @synchronized (self) {
+            for (id operation in operationsArray) {
+                if ([operation conformsToProtocol:@protocol(SDWebImageOperation)]) {
+                    [operation cancel];
+                }
+            }
+            for (size_t i = 0; i < operationsArray.count; i++) {
+                [operationsArray removePointerAtIndex:i];
+            }
+        }
+    }
 }
 #endif
 

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -109,18 +109,18 @@
     }];
 }
 
-static char animationloadOperationKey;
+static char animationLoadOperationKey;
 
 // element is weak because operation instance is retained by SDWebImageManager's runningOperations property
 // we should use lock to keep thread-safe because these method may not be acessed from main queue
 - (NSPointerArray *)sd_animationOperationArray {
     @synchronized(self) {
-        NSPointerArray *operationsArray = objc_getAssociatedObject(self, &animationloadOperationKey);
+        NSPointerArray *operationsArray = objc_getAssociatedObject(self, &animationLoadOperationKey);
         if (operationsArray) {
             return operationsArray;
         }
         operationsArray = [NSPointerArray weakObjectsPointerArray];
-        objc_setAssociatedObject(self, &animationloadOperationKey, operationsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self, &animationLoadOperationKey, operationsArray, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
         return operationsArray;
     }
 }

--- a/SDWebImage/UIView+WebCacheOperation.h
+++ b/SDWebImage/UIView+WebCacheOperation.h
@@ -20,7 +20,7 @@
  *  @param operation the operation
  *  @param key       key for storing the operation
  */
-- (void)sd_setImageLoadOperation:(nullable id)operation forKey:(nullable NSString *)key;
+- (void)sd_setImageLoadOperation:(nullable id<SDWebImageOperation>)operation forKey:(nullable NSString *)key;
 
 /**
  *  Cancel all operations for the current UIView and key

--- a/SDWebImage/UIView+WebCacheOperation.h
+++ b/SDWebImage/UIView+WebCacheOperation.h
@@ -12,10 +12,12 @@
 
 #import "SDWebImageManager.h"
 
+// These methods are used to support canceling for UIView image loading, it's designed to be used internal but not external.
+// All the stored operations are weak, so it will be dalloced after image loading finished. If you need to store operations, use your own class to keep a strong reference for them.
 @interface UIView (WebCacheOperation)
 
 /**
- *  Set the image load operation (storage in a UIView based dictionary)
+ *  Set the image load operation (storage in a UIView based weak map table)
  *
  *  @param operation the operation
  *  @param key       key for storing the operation

--- a/SDWebImage/UIView+WebCacheOperation.m
+++ b/SDWebImage/UIView+WebCacheOperation.m
@@ -16,7 +16,7 @@ static char loadOperationKey;
 
 // key is copy, value is weak because operation instance is retained by SDWebImageManager's runningOperations property
 // we should use lock to keep thread-safe because these method may not be acessed from main queue
-typedef NSMapTable<NSString *, id> SDOperationsDictionary;
+typedef NSMapTable<NSString *, id<SDWebImageOperation>> SDOperationsDictionary;
 
 @implementation UIView (WebCacheOperation)
 
@@ -47,13 +47,13 @@ typedef NSMapTable<NSString *, id> SDOperationsDictionary;
 - (void)sd_cancelImageLoadOperationWithKey:(nullable NSString *)key {
     // Cancel in progress downloader from queue
     SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
-    id operation;
+    id<SDWebImageOperation> operation;
     @synchronized (self) {
         operation = [operationDictionary objectForKey:key];
     }
     if (operation) {
         if ([operation conformsToProtocol:@protocol(SDWebImageOperation)]){
-            [(id<SDWebImageOperation>) operation cancel];
+            [operation cancel];
         }
         @synchronized (self) {
             [operationDictionary removeObjectForKey:key];

--- a/SDWebImage/UIView+WebCacheOperation.m
+++ b/SDWebImage/UIView+WebCacheOperation.m
@@ -20,7 +20,7 @@ typedef NSMapTable<NSString *, id> SDOperationsDictionary;
 
 @implementation UIView (WebCacheOperation)
 
-- (SDOperationsDictionary *)operationDictionary {
+- (SDOperationsDictionary *)sd_operationDictionary {
     @synchronized(self) {
         SDOperationsDictionary *operations = objc_getAssociatedObject(self, &loadOperationKey);
         if (operations) {
@@ -32,11 +32,11 @@ typedef NSMapTable<NSString *, id> SDOperationsDictionary;
     }
 }
 
-- (void)sd_setImageLoadOperation:(nullable id)operation forKey:(nullable NSString *)key {
+- (void)sd_setImageLoadOperation:(nullable id<SDWebImageOperation>)operation forKey:(nullable NSString *)key {
     if (key) {
         [self sd_cancelImageLoadOperationWithKey:key];
         if (operation) {
-            SDOperationsDictionary *operationDictionary = [self operationDictionary];
+            SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
             @synchronized (self) {
                 [operationDictionary setObject:operation forKey:key];
             }
@@ -46,20 +46,14 @@ typedef NSMapTable<NSString *, id> SDOperationsDictionary;
 
 - (void)sd_cancelImageLoadOperationWithKey:(nullable NSString *)key {
     // Cancel in progress downloader from queue
-    SDOperationsDictionary *operationDictionary = [self operationDictionary];
-    id operations;
+    SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
+    id operation;
     @synchronized (self) {
-        operations = [operationDictionary objectForKey:key];
+        operation = [operationDictionary objectForKey:key];
     }
-    if (operations) {
-        if ([operations isKindOfClass:[NSArray class]]) {
-            for (id <SDWebImageOperation> operation in operations) {
-                if (operation) {
-                    [operation cancel];
-                }
-            }
-        } else if ([operations conformsToProtocol:@protocol(SDWebImageOperation)]){
-            [(id<SDWebImageOperation>) operations cancel];
+    if (operation) {
+        if ([operation conformsToProtocol:@protocol(SDWebImageOperation)]){
+            [(id<SDWebImageOperation>) operation cancel];
         }
         @synchronized (self) {
             [operationDictionary removeObjectForKey:key];
@@ -69,7 +63,7 @@ typedef NSMapTable<NSString *, id> SDOperationsDictionary;
 
 - (void)sd_removeImageLoadOperationWithKey:(nullable NSString *)key {
     if (key) {
-        SDOperationsDictionary *operationDictionary = [self operationDictionary];
+        SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
         @synchronized (self) {
             [operationDictionary removeObjectForKey:key];
         }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2113 #2125 

### Pull Request Description

Our current implementation in `UIView(WebCacheOperation)` is a little tricky. It use a `NSMutableDictionary` to keep a strong reference to operation instace, so that if we do not remove that, it still alive.

This design may works in previous SD version. But I found that the SDWebImageOperation instance is also retained by SDWebImageManager's `runningOperations` property.

//SDWebImageManager line 142:
    @synchronized (self.runningOperations) {
        [self.runningOperations addObject:operation]; // this is a NSMutableArray, retain the instance
    }

There is no doubt that we should remove that operation after the completion block is called, right ?
(Because we do not have a public API to get the operation back :) ). So use a `NSMapTable` with copy key, weak value will automatically remove that instance after the `SDWebImageManager` remove the operation from it's property. It's more logicable and avoid this memory cost.

And also, This PR keep the thread-safe of these methods through a lock. Previous version may meed a thead-safe problem via #2113 

