### PR TITLE
When store image with no data for SDImageCache, check whether it contains alpha to use PNG or JPEG format

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -217,8 +217,14 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             @autoreleasepool {
                 NSData *data = imageData;
                 if (!data && image) {
-                    // If we do not have any data to detect image format, use PNG format
-                    data = [[SDWebImageCodersManager sharedInstance] encodedDataWithImage:image format:SDImageFormatPNG];
+                    // If we do not have any data to detect image format, check whether it contains alpha channel to use PNG or JPEG format
+                    SDImageFormat format;
+                    if (SDCGImageRefContainsAlpha(image.CGImage)) {
+                        format = SDImageFormatPNG;
+                    } else {
+                        format = SDImageFormatJPEG;
+                    }
+                    data = [[SDWebImageCodersManager sharedInstance] encodedDataWithImage:image format:format];
                 }
                 [self storeImageDataToDisk:data forKey:key];
             }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Since 4.2 coder refactor, we change that `-[SDImageCache storeImage:imageData:forKey:toDisk:completion:]` implementation to use the coder methods. When you store image with valid image but nil data to disk,  it previously will `SDImageFormatUndefined`, and finally will try to encode to PNG when image contains alpha, and JPEG when not.

Maybe this choice is better on performance, and we should also obey this behavior. Since now we have custom coder, we'd better not provide such a `SDImageFormatUndefined` arguments. It's better to copy that check logic to use PNG or JPEG format.
