### PR TITLE
Add HEIC encode judgment, and bugfix for a memory leak

### DIFF
--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -497,9 +497,9 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
             canEncode = NO;
         } else {
             // Can encode to HEIC
-            CFRelease(imageDestination);
             canEncode = YES;
         }
+        CFRelease(imageDestination);
     });
     return canEncode;
 }

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -70,6 +70,8 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         case SDImageFormatWebP:
             // Do not support WebP decoding
             return NO;
+        case SDImageFormatHEIC:
+            return [[self class] canDecodeHEICFormat];
         default:
             return YES;
     }
@@ -468,6 +470,17 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     }
     
     return YES;
+}
+
++ (BOOL)canDecodeHEICFormat {
+    static BOOL canDecode = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        if ([[UIDevice currentDevice].systemVersion doubleValue] >= 11.0 && !TARGET_IPHONE_SIMULATOR) {
+            canDecode = YES;
+        }
+    });
+    return canDecode;
 }
 
 + (BOOL)canEncodeToHEICFormat {


### PR DESCRIPTION
### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

...

