### PR TITLE
Fix Clang Static Analyzer warning for number nil check from Xcode 9.2

### DIFF
--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage OSX Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage OSX Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage TV Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage TV Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage Watch Demo.xcscheme
+++ b/Examples/SDWebImage Demo.xcodeproj/xcshareddata/xcschemes/SDWebImage Watch Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage OSX.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS static.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS static.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage tvOS.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage watchOS static.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage watchOS static.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage watchOS.xcscheme
+++ b/SDWebImage.xcodeproj/xcshareddata/xcschemes/SDWebImage watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage.xcworkspace/xcshareddata/xcschemes/SDWebImage iOS Demo.xcscheme
+++ b/SDWebImage.xcworkspace/xcshareddata/xcschemes/SDWebImage iOS Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SDWebImage/SDWebImageGIFCoder.m
+++ b/SDWebImage/SDWebImageGIFCoder.m
@@ -77,7 +77,7 @@
         NSDictionary *gifProperties = [imageProperties valueForKey:(__bridge_transfer NSString *)kCGImagePropertyGIFDictionary];
         if (gifProperties) {
             NSNumber *gifLoopCount = [gifProperties valueForKey:(__bridge_transfer NSString *)kCGImagePropertyGIFLoopCount];
-            if (gifLoopCount) {
+            if (gifLoopCount != nil) {
                 loopCount = gifLoopCount.unsignedIntegerValue;
             }
         }
@@ -99,11 +99,11 @@
     NSDictionary *gifProperties = frameProperties[(NSString *)kCGImagePropertyGIFDictionary];
     
     NSNumber *delayTimeUnclampedProp = gifProperties[(NSString *)kCGImagePropertyGIFUnclampedDelayTime];
-    if (delayTimeUnclampedProp) {
+    if (delayTimeUnclampedProp != nil) {
         frameDuration = [delayTimeUnclampedProp floatValue];
     } else {
         NSNumber *delayTimeProp = gifProperties[(NSString *)kCGImagePropertyGIFDelayTime];
-        if (delayTimeProp) {
+        if (delayTimeProp != nil) {
             frameDuration = [delayTimeProp floatValue];
         }
     }

--- a/Tests/SDWebImage Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Tests/SDWebImage Tests.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2142

### Pull Request Description

Xcode 9.2 introduce new Clang Static Analyzer for number nil check. You should either compare number(`NSNumber, CFNumber, OSNumber`) with `nil/NULL/nullptr` for nil check, or use the `boolValue` to get the bool value to check.

