### PR TITLE
Adopt the current requirement, change ImageIO coder's canDeocdeFromHEIC to actual implementation

### DIFF
--- a/SDWebImage/SDWebImageImageIOCoder.h
+++ b/SDWebImage/SDWebImageImageIOCoder.h
@@ -17,8 +17,11 @@
  For a full GIF support, we recommend `FLAnimatedImage` or our less performant `SDWebImageGIFCoder`
  
  HEIC
- This coder also supports HEIC format because ImageIO supports it natively. But it depends on the system capabilities, so it won't work on all devices.
- Hardware works if:  (iOS 11 || macOS 10.13) && (isMac || isIPhoneAndA10FusionChipAbove) && (!Simulator)
+ This coder also supports HEIC format because ImageIO supports it natively. But it depends on the system capabilities, so it won't work on all devices, see: https://devstreaming-cdn.apple.com/videos/wwdc/2017/511tj33587vdhds/511/511_working_with_heif_and_hevc.pdf
+ Decode(Software): !Simulator && (iOS 11 || tvOS 11 || macOS 10.13)
+ Decode(Hardware): !Simulator && ((iOS 11 && A9Chip) || (macOS 10.13 && 6thGenerationIntelCPU))
+ Encode(Software): macOS 10.13
+ Encode(Hardware): !Simulator && ((iOS 11 && A10FusionChip) || (macOS 10.13 && 6thGenerationIntelCPU))
  */
 @interface SDWebImageImageIOCoder : NSObject <SDWebImageProgressiveCoder>
 

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -70,6 +70,9 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         case SDImageFormatWebP:
             // Do not support WebP decoding
             return NO;
+        case SDImageFormatHEIC:
+            // Check HEIC decoding compatibility
+            return [[self class] canDecodeFromHEICFormat];
         default:
             return YES;
     }
@@ -80,6 +83,9 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         case SDImageFormatWebP:
             // Do not support WebP progressive decoding
             return NO;
+        case SDImageFormatHEIC:
+            // Check HEIC decoding compatibility
+            return [[self class] canDecodeFromHEICFormat];
         default:
             return YES;
     }
@@ -468,6 +474,33 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     }
     
     return YES;
+}
+
++ (BOOL)canDecodeFromHEICFormat {
+    static BOOL canDecode = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+#if TARGET_OS_SIMULATOR || SD_WATCH
+        canDecode = NO;
+#elif SD_MAC
+        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+        if ([processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
+            // macOS 10.13+
+            canDecode = processInfo.operatingSystemVersion.minorVersion >= 13;
+        } else {
+            canDecode = NO;
+        }
+#elif SD_UIKIT
+        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+        if ([processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
+            // iOS 11+ && tvOS 11+
+            canDecode = processInfo.operatingSystemVersion.majorVersion >= 11;
+        } else {
+            canDecode = NO;
+        }
+#endif
+    });
+    return canDecode;
 }
 
 + (BOOL)canEncodeToHEICFormat {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2138

### Pull Request Description

Because some user need to place our `SDWebImageImageIOCoder` to a higher priority, so if HEIC images can not be decoded, it should be ignored and `canDecodeFromData` should return YES to let next coder to process it. Currently we will always return YES.

I search for resources, but find there are no ways to directly get the HEIC encoding support with public API. Althrough there is a actually private global variable `gHEIF_HEVC_DecodingSupported` in Image/IO framework through decompilation(:p). But since Apple does not allow you to use private API, So I just give up and use the system version check to get it :)
