### PR TITLE
Upgrade deployment target version

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -2,8 +2,8 @@ Pod::Spec.new do |s|
   s.name = 'SDWebImage'
   s.version = '4.2.3'
 
-  s.osx.deployment_target = '10.8'
-  s.ios.deployment_target = '7.0'
+  s.osx.deployment_target = '10.10'
+  s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
@@ -33,8 +33,8 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'MapKit' do |mk|
-    mk.osx.deployment_target = '10.8'
-    mk.ios.deployment_target = '7.0'
+    mk.osx.deployment_target = '10.10'
+    mk.ios.deployment_target = '8.0'
     mk.tvos.deployment_target = '9.0'
     mk.source_files = 'SDWebImage/MKAnnotationView+WebCache.*'
     mk.framework = 'MapKit'
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'GIF' do |gif|
-    gif.ios.deployment_target = '7.0'
+    gif.ios.deployment_target = '8.0'
     gif.source_files = 'SDWebImage/FLAnimatedImage/*.{h,m}'
     gif.dependency 'SDWebImage/Core'
     gif.dependency 'FLAnimatedImage', '~> 1.0'

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -3694,7 +3694,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				INFOPLIST_FILE = WebImage/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).ios";
 				PRODUCT_NAME = SDWebImage;
@@ -3715,7 +3715,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				INFOPLIST_FILE = WebImage/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.dailymotion.$(PRODUCT_NAME:rfc1034identifier).ios";
 				PRODUCT_NAME = SDWebImage;

--- a/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
+++ b/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
@@ -234,7 +234,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		85E5D3885A03BFC23B050908 /* [CP] Copy Pods Resources */ = {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues:

### Pull Request Description

# Suggest change for SDK version and Xcode version

Xcode 8.0 and above

iOS 8.0+ / macOS 10.10+ / tvOS 9.0+(not change) / watchOS 2.0+(not change)

# Reason
I want to import APNG support for build-in coder. This is introduced during iOS 8+ and macOS 10.10+ into Image/IO framework and it;s gradually adopted by many social media app such as LINE, instagram, imgur. (And Safari 8, Chrome 59 also support this kind of animated image format).  And other image library has already support it by default such as YYImage .

Since iOS 7 support is really not the main minimum version of current iOS develop industry. After we update the minimum deployment to iOS 8, we can also have these benefits:

+ `CGImagePropertyOrientation`: which can be used in `imageOrientationFromEXIFOrientation:` and `imageOrientationFromEXIFOrientation` instead that hard-code number
+ Add APNG coder which is nearly the same as GIF coder(many I can use a subclass) but need `kCGImagePropertyAPNGDelayTime`, `kCGImagePropertyAPNGLoopCount`, `kCGImagePropertyAPNGUnclampedDelayTime` constant.
+ We can specify our download operation priority through `NSURLSessionTask.priority`
+ We can have the ability to use [Background Transfer Service](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/URLLoadingSystem/Articles/UsingNSURLSession.html#//apple_ref/doc/uid/TP40013509-SW44) in NSURLSession instead of current application background task(This can also be used on watchOS)
+ We can use `storeCachedResponse:forDataTask` to directlly store NSURLcache. This is more suitable for our `SDWebImageDownloaderIgnoreCachedResponse` this *crazy* options. (Currently not all response was cached into NSURLCache even the image data is same, when you provide `SDWebImageRefreshCached`, you'll sometimes re-download the same image data everytime. See our demo with that `joy.gif`, even the server reponse a `Cache-Control`)
+ We can replace our trick `SD_MAC` define macro, with the build-in `TARGET_OS_OSX` from Xcode 8(This macro is not available in Xcode 7 because its defined on `TargetCondition.h` from iOS 10 Developer SDK)
