### PR TITLE
Refactor storeImageDataToDisk and support writing options

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -150,15 +150,13 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 /**
  * Synchronously store image NSData into disk cache at the given key.
  *
- * @warning This method is synchronous, make sure to call it from the ioQueue
- *
  * @param imageData  The image data to store
  * @param key        The unique image cache key, usually it's image absolute URL
- * @param errorPtr   NSError pointer. If error occurs then (*errorPtr) != nil.
+ * @param error      NSError pointer, for possible file I/O errors, See FoundationErrors.h
  */
 - (BOOL)storeImageDataToDisk:(nullable NSData *)imageData
                       forKey:(nullable NSString *)key
-                       error:(NSError * _Nullable * _Nullable)errorPtr;
+                       error:(NSError * _Nullable * _Nullable)error;
 
 
 #pragma mark - Query and Retrieve Ops

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -280,7 +280,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     
     // NSFileManager's `createFileAtPath:` is used just for old code compatibility and will not trigger any delegate methods, so it's useless for custom NSFileManager at all.
     // And also, NSFileManager's `createFileAtPath:` can only grab underlying POSIX errno, but NSData can grab errors defined in NSCocoaErrorDomain, which is better for user to check.
-    if (![imageData writeToFile:cachePathForKey options:NSDataWritingAtomic error:error]) {
+    if (![imageData writeToFile:cachePathForKey options:self.config.diskCacheWritingOptions error:error]) {
         return NO;
     }
     

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -29,9 +29,15 @@
 
 /**
  * The reading options while reading cache from disk.
- * Defaults to 0. You can set this to mapped file to improve performance.
+ * Defaults to 0. You can set this to `NSDataReadingMappedIfSafe` to improve performance.
  */
 @property (assign, nonatomic) NSDataReadingOptions diskCacheReadingOptions;
+
+/**
+ * The writing options while writing cache to disk.
+ * Defaults to `NSDataWritingAtomic`. You can set this to `NSDataWritingWithoutOverwriting` to prevent overwriting an existing file.
+ */
+@property (assign, nonatomic) NSDataWritingOptions diskCacheWritingOptions;
 
 /**
  * The maximum length of time to keep an image in the cache, in seconds.

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -18,6 +18,7 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
         _shouldDisableiCloud = YES;
         _shouldCacheImagesInMemory = YES;
         _diskCacheReadingOptions = 0;
+        _diskCacheWritingOptions = NSDataWritingAtomic;
         _maxCacheAge = kDefaultCacheMaxCacheAge;
         _maxCacheSize = 0;
     }

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -540,8 +540,6 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
                 result = [SDWebImageCoderHelper imageOrientationFromEXIFOrientation:exifOrientation];
             } // else - if it's not set it remains at up
             CFRelease((CFTypeRef) properties);
-        } else {
-            //NSLog(@"NO PROPERTIES, FAIL");
         }
         CFRelease(imageSource);
     }

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -309,23 +309,28 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
 
 - (void)test41StoreImageDataToDiskWithError {
     NSData *imageData = [NSData dataWithContentsOfFile:[self testImagePath]];
-    NSError * error = nil;
+    NSError *targetError = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileWriteNoPermissionError userInfo:nil];
+    NSError *error = nil;
+    SDMockFileManager *fileManager = [[SDMockFileManager alloc] init];
+    fileManager.mockSelectors = @{NSStringFromSelector(@selector(createDirectoryAtPath:withIntermediateDirectories:attributes:error:)) : targetError};
     SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"test"
                                                diskCacheDirectory:@"/"
-                                                      fileManager:[[SDMockFileManager alloc] initWithError:EACCES]];
+                                                      fileManager:fileManager];
     [cache storeImageDataToDisk:imageData
                          forKey:kImageTestKey
                           error:&error];
     
-    XCTAssertEqual(error.code, EACCES);
+    XCTAssertEqual(error.code, NSFileWriteNoPermissionError);
 }
 
 - (void)test42StoreImageDataToDiskWithoutError {
     NSData *imageData = [NSData dataWithContentsOfFile:[self testImagePath]];
-    NSError * error = nil;
+    NSError *error = nil;
+    SDMockFileManager *fileManager = [[SDMockFileManager alloc] init];
+    fileManager.mockSelectors = @{NSStringFromSelector(@selector(createDirectoryAtPath:withIntermediateDirectories:attributes:error:)) : [NSNull null]};
     SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"test"
                                                diskCacheDirectory:@"/"
-                                                      fileManager:[[SDMockFileManager alloc] initWithError:0]];
+                                                      fileManager:fileManager];
     [cache storeImageDataToDisk:imageData
                          forKey:kImageTestKey
                           error:&error];

--- a/Tests/Tests/SDMockFileManager.h
+++ b/Tests/Tests/SDMockFileManager.h
@@ -8,8 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
+// This is a mock class to provide custom error for methods
 @interface SDMockFileManager : NSFileManager
 
-- (id)initWithError:(int)errorNumber;
+@property (nonatomic, copy, nullable) NSDictionary<NSString *, NSError *> *mockSelectors; // used to specify mocked selectors which will return NO with specify error instead of normal process. If you specify a NSNull, will use nil instead.
 
 @end

--- a/Tests/Tests/SDMockFileManager.m
+++ b/Tests/Tests/SDMockFileManager.m
@@ -10,24 +10,25 @@
 
 @interface SDMockFileManager ()
 
-@property (nonatomic, assign) int errorNumber;
-
 @end
 
 @implementation SDMockFileManager
 
-- (id)initWithError:(int)errorNumber {
-    self = [super init];
-    if (self) {
-        _errorNumber = errorNumber;
+- (BOOL)createDirectoryAtPath:(NSString *)path withIntermediateDirectories:(BOOL)createIntermediates attributes:(NSDictionary<NSFileAttributeKey,id> *)attributes error:(NSError * _Nullable __autoreleasing *)error {
+    NSError *mockError = [self.mockSelectors objectForKey:NSStringFromSelector(_cmd)];
+    if ([mockError isEqual:[NSNull null]]) {
+        if (error) {
+            *error = nil;
+        }
+        return NO;
+    } else if (mockError) {
+        if (error) {
+            *error = mockError;
+        }
+        return NO;
+    } else {
+        return [super createDirectoryAtPath:path withIntermediateDirectories:createIntermediates attributes:attributes error:error];
     }
-    
-    return self;
-}
-
-- (BOOL)createFileAtPath:(NSString *)path contents:(NSData *)data attributes:(NSDictionary<NSString *,id> *)attr {
-    errno = self.errorNumber;
-    return (self.errorNumber == 0);
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1898 

### Pull Request Description

This is a refactor branch for Image cache. We seperate the image cache refactor commits to this branch.

