### PR TITLE
Move that `maxMemoryCost` and `maxMemoryCountLimit` to config property. Add sync version API `diskImageDataExistsWithKey`

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -57,16 +57,6 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  */
 @property (nonatomic, nonnull, readonly) SDImageCacheConfig *config;
 
-/**
- * The maximum "total cost" of the in-memory image cache. The cost function is the number of pixels held in memory.
- */
-@property (assign, nonatomic) NSUInteger maxMemoryCost;
-
-/**
- * The maximum number of objects the cache should hold.
- */
-@property (assign, nonatomic) NSUInteger maxMemoryCountLimit;
-
 #pragma mark - Singleton and initialization
 
 /**
@@ -133,7 +123,7 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  *
  * @param image           The image to store
  * @param key             The unique image cache key, usually it's image absolute URL
- * @param toDisk          Store the image to disk cache if YES
+ * @param toDisk          Store the image to disk cache if YES. If NO, the completion block is called synchronously
  * @param completionBlock A block executed after the operation is finished
  */
 - (void)storeImage:(nullable UIImage *)image
@@ -149,7 +139,7 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  *                        instead of converting the given image object into a storable/compressed image format in order
  *                        to save quality and CPU
  * @param key             The unique image cache key, usually it's image absolute URL
- * @param toDisk          Store the image to disk cache if YES
+ * @param toDisk          Store the image to disk cache if YES. If NO, the completion block is called synchronously
  * @param completionBlock A block executed after the operation is finished
  */
 - (void)storeImage:(nullable UIImage *)image
@@ -173,7 +163,7 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 #pragma mark - Query and Retrieve Ops
 
 /**
- *  Async check if image exists in disk cache already (does not load the image)
+ *  Asynchronously check if image exists in disk cache already (does not load the image)
  *
  *  @param key             the key describing the url
  *  @param completionBlock the block to be executed when the check is done.
@@ -182,7 +172,14 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 - (void)diskImageExistsWithKey:(nullable NSString *)key completion:(nullable SDWebImageCheckCacheCompletionBlock)completionBlock;
 
 /**
- * Operation that queries the cache asynchronously and call the completion when done.
+ *  Synchronously check if image data exists in disk cache already (does not load the image)
+ *
+ *  @param key             the key describing the url
+ */
+- (BOOL)diskImageDataExistsWithKey:(nullable NSString *)key;
+
+/**
+ * Asynchronously queries the cache with operation and call the completion when done.
  *
  * @param key       The unique key used to store the wanted image
  * @param doneBlock The completion block. Will not get called if the operation is cancelled
@@ -192,7 +189,7 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 - (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key done:(nullable SDCacheQueryCompletedBlock)doneBlock;
 
 /**
- * Operation that queries the cache asynchronously and call the completion when done.
+ * Asynchronously queries the cache with operation and call the completion when done.
  *
  * @param key       The unique key used to store the wanted image
  * @param options   A mask to specify options to use for this cache query
@@ -203,21 +200,21 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 - (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDCacheQueryCompletedBlock)doneBlock;
 
 /**
- * Query the memory cache synchronously.
+ * Synchronously query the memory cache.
  *
  * @param key The unique key used to store the image
  */
 - (nullable UIImage *)imageFromMemoryCacheForKey:(nullable NSString *)key;
 
 /**
- * Query the disk cache synchronously.
+ * Synchronously query the disk cache.
  *
  * @param key The unique key used to store the image
  */
 - (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key;
 
 /**
- * Query the cache (memory and or disk) synchronously after checking the memory cache.
+ * Synchronously query the cache (memory and or disk) after checking the memory cache.
  *
  * @param key The unique key used to store the image
  */
@@ -226,7 +223,7 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 #pragma mark - Remove Ops
 
 /**
- * Remove the image from memory and disk cache asynchronously
+ * Asynchronously remove the image from memory and disk cache
  *
  * @param key             The unique image cache key
  * @param completion      A block that should be executed after the image has been removed (optional)
@@ -234,10 +231,10 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 - (void)removeImageForKey:(nullable NSString *)key withCompletion:(nullable SDWebImageNoParamsBlock)completion;
 
 /**
- * Remove the image from memory and optionally disk cache asynchronously
+ * Asynchronously remove the image from memory and optionally disk cache
  *
  * @param key             The unique image cache key
- * @param fromDisk        Also remove cache entry from disk if YES
+ * @param fromDisk        Also remove cache entry from disk if YES. If NO, the completion block is called synchronously
  * @param completion      A block that should be executed after the image has been removed (optional)
  */
 - (void)removeImageForKey:(nullable NSString *)key fromDisk:(BOOL)fromDisk withCompletion:(nullable SDWebImageNoParamsBlock)completion;
@@ -245,18 +242,18 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 #pragma mark - Cache clean Ops
 
 /**
- * Clear all memory cached images
+ * Synchronously Clear all memory cached images
  */
 - (void)clearMemory;
 
 /**
- * Async clear all disk cached images. Non-blocking method - returns immediately.
+ * Asynchronously clear all disk cached images. Non-blocking method - returns immediately.
  * @param completion    A block that should be executed after cache expiration completes (optional)
  */
 - (void)clearDiskOnCompletion:(nullable SDWebImageNoParamsBlock)completion;
 
 /**
- * Async remove all expired cached image from disk. Non-blocking method - returns immediately.
+ * Asynchronously remove all expired cached image from disk. Non-blocking method - returns immediately.
  * @param completionBlock A block that should be executed after cache expiration completes (optional)
  */
 - (void)deleteOldFilesWithCompletionBlock:(nullable SDWebImageNoParamsBlock)completionBlock;

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -12,18 +12,20 @@
 @interface SDImageCacheConfig : NSObject
 
 /**
- * Decompressing images that are downloaded and cached can improve performance but can consume lot of memory.
+ * Decompressing images means pre-decoding the image that are downloaded and cached on background queue. This can avoid image view decode it on main queue when rendering. This can improve performance but can consume more memory.
  * Defaults to YES. Set this to NO if you are experiencing a crash due to excessive memory consumption.
  */
 @property (assign, nonatomic) BOOL shouldDecompressImages;
 
 /**
- * disable iCloud backup [defaults to YES]
+ * Whether or not to disable iCloud backup
+ * Defaults to YES.
  */
 @property (assign, nonatomic) BOOL shouldDisableiCloud;
 
 /**
- * use memory cache [defaults to YES]
+ * Whether or not to use memory cache
+ * Defaults to YES.
  */
 @property (assign, nonatomic) BOOL shouldCacheImagesInMemory;
 
@@ -41,12 +43,26 @@
 
 /**
  * The maximum length of time to keep an image in the cache, in seconds.
+ * Defaults to 1 weak.
  */
 @property (assign, nonatomic) NSInteger maxCacheAge;
 
 /**
  * The maximum size of the cache, in bytes.
+ * Defaults to 0. Which means there is no cache size limit.
  */
 @property (assign, nonatomic) NSUInteger maxCacheSize;
+
+/**
+ * The maximum "total cost" of the in-memory image cache. The cost function is the number of pixels held in memory.
+ * Defaults to 0. Which means there is no memory cost limit.
+ */
+@property (assign, nonatomic) NSUInteger maxMemoryCost;
+
+/**
+ * The maximum number of objects the cache should hold.
+ * Defaults to 0. Which means there is no memory count limit.
+ */
+@property (assign, nonatomic) NSUInteger maxMemoryCount;
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1818 

### Pull Request Description

During SD 3.x -> 4.x, we remove that `diskImageExistsWithKey` sync version API and replaced with a async version API. This may because #781 deadlock

However, this change's pain is large than the gain. Sometimes we need to build something based on SDImageCache and need a sync version check. We have no choice to `force` to **simulate** a sync version API, see #1448.

For the deadlock, the reason is that previously, we expose our inner `ioQueue` to user, so if the user call `dispatch_sync` on the outside with the `ioQueue`, the deadlock occur.

But now, we do not expose that to the user, so this issue no longer happend. We should give back the sync version API.


And, I also copied some refactor code from 5.x branch. Including  `diskCacheWritingOptions` and replace `-[NSFileManager createFileAtPath]` with `-[NSData writeToURL:]`. For more information ,see #2148 


For thread-safe issue, see Apple Docs:

> The methods of the shared NSFileManager object can be called from multiple threads safely. However, if you use a delegate to receive notifications about the status of move, copy, remove, and link operations, you should create a unique instance of the file manager object, assign your delegate to that object, and use that file manager to initiate your operations.


  
  