### PR TITLE
Avoid user accidentally invalidates the session used in shared downloader

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -250,6 +250,7 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
  * Invalidates the managed session, optionally canceling pending operations.
  * @note If you use custom downloader instead of the shared downloader, you need call this method when you do not use it to avoid memory leak
  * @param cancelPendingOperations Whether or not to cancel pending operations.
+ * @note Calling this method on the shared downloader has no effect.
  */
 - (void)invalidateSessionAndCancel:(BOOL)cancelPendingOperations;
 

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -108,6 +108,9 @@
 }
 
 - (void)invalidateSessionAndCancel:(BOOL)cancelPendingOperations {
+    if (self == [SDWebImageDownloader sharedDownloader]) {
+        return;
+    }
     if (cancelPendingOperations) {
         [self.session invalidateAndCancel];
     } else {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

It's obvious that we should not invalid the `URLSession` used in shared downloader, or all the image download will fail. But however, we'd better add a protect to avoid user **accidentally** call `invalidateSessionAndCancel:` on shared downloader instance :) 


  