### PR TITLE
Add a shared lock for accessing shared NSURLCache, move the internal define to a private header

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -29,6 +29,7 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |core|
     core.source_files = 'SDWebImage/{NS,SD,UI}*.{h,m}'
     core.exclude_files = 'SDWebImage/UIImage+WebP.{h,m}', 'SDWebImage/SDWebImageWebPCoder.{h,m}'
+    core.private_header_files = 'SDWebImage/SDWebImageInternal.h'
     core.tvos.exclude_files = 'SDWebImage/MKAnnotationView+WebCache.*'
   end
 

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -37,6 +37,12 @@
 		00733A711BC4880E00A5A117 /* UIImageView+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 53922D95148C56230056699D /* UIImageView+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00733A721BC4880E00A5A117 /* UIView+WebCacheOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = AB615301192DA24600A2D8E9 /* UIView+WebCacheOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		00733A731BC4880E00A5A117 /* SDWebImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A2CAE031AB4BB5400B6BC39 /* SDWebImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321C699D1FFFA765002D47FB /* SDWebImageInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 321C699C1FFFA765002D47FB /* SDWebImageInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		321C699E1FFFA765002D47FB /* SDWebImageInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 321C699C1FFFA765002D47FB /* SDWebImageInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		321C699F1FFFA765002D47FB /* SDWebImageInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 321C699C1FFFA765002D47FB /* SDWebImageInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		321C69A01FFFA765002D47FB /* SDWebImageInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 321C699C1FFFA765002D47FB /* SDWebImageInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		321C69A11FFFA765002D47FB /* SDWebImageInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 321C699C1FFFA765002D47FB /* SDWebImageInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		321C69A21FFFA765002D47FB /* SDWebImageInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 321C699C1FFFA765002D47FB /* SDWebImageInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		321E60861F38E8C800405457 /* SDWebImageCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60841F38E8C800405457 /* SDWebImageCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		321E60871F38E8C800405457 /* SDWebImageCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60841F38E8C800405457 /* SDWebImageCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		321E60881F38E8C800405457 /* SDWebImageCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60841F38E8C800405457 /* SDWebImageCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1273,6 +1279,7 @@
 
 /* Begin PBXFileReference section */
 		00733A4C1BC487C000A5A117 /* SDWebImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		321C699C1FFFA765002D47FB /* SDWebImageInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageInternal.h; sourceTree = "<group>"; };
 		321E60841F38E8C800405457 /* SDWebImageCoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDWebImageCoder.h; sourceTree = "<group>"; };
 		321E60851F38E8C800405457 /* SDWebImageCoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageCoder.m; sourceTree = "<group>"; };
 		321E60921F38E8ED00405457 /* SDWebImageImageIOCoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDWebImageImageIOCoder.h; sourceTree = "<group>"; };
@@ -1797,6 +1804,7 @@
 				53922D8F148C56230056699D /* SDWebImageManager.m */,
 				53922D91148C56230056699D /* SDWebImagePrefetcher.h */,
 				53922D92148C56230056699D /* SDWebImagePrefetcher.m */,
+				321C699C1FFFA765002D47FB /* SDWebImageInternal.h */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -2048,6 +2056,7 @@
 				80377EB81F2F66D400F89830 /* alphai_dec.h in Headers */,
 				00733A6D1BC4880E00A5A117 /* UIImage+GIF.h in Headers */,
 				80377C551F2F666300F89830 /* quant_levels_dec_utils.h in Headers */,
+				321C69A01FFFA765002D47FB /* SDWebImageInternal.h in Headers */,
 				80377EC11F2F66D500F89830 /* vp8_dec.h in Headers */,
 				00733A651BC4880E00A5A117 /* SDWebImageDownloader.h in Headers */,
 			);
@@ -2117,6 +2126,7 @@
 				4314D1841D0E0E3B004B36C9 /* SDWebImageOperation.h in Headers */,
 				4314D1851D0E0E3B004B36C9 /* SDWebImageDownloaderOperation.h in Headers */,
 				4314D1861D0E0E3B004B36C9 /* UIImageView+HighlightedWebCache.h in Headers */,
+				321C699E1FFFA765002D47FB /* SDWebImageInternal.h in Headers */,
 				4314D1881D0E0E3B004B36C9 /* format_constants.h in Headers */,
 				323F8B631F38EF770092B609 /* cost_enc.h in Headers */,
 				323F8BF71F38EF770092B609 /* animi.h in Headers */,
@@ -2187,6 +2197,7 @@
 				80377C6F1F2F666400F89830 /* quant_levels_dec_utils.h in Headers */,
 				431BB6F01D06D2C1006A3455 /* SDWebImageOperation.h in Headers */,
 				43A62A201D0E0A800089D7DD /* mux_types.h in Headers */,
+				321C69A11FFFA765002D47FB /* SDWebImageInternal.h in Headers */,
 				43A62A211D0E0A800089D7DD /* types.h in Headers */,
 				80377C641F2F666400F89830 /* bit_writer_utils.h in Headers */,
 				43A62A1E1D0E0A800089D7DD /* format_constants.h in Headers */,
@@ -2247,6 +2258,7 @@
 				80377E641F2F66A800F89830 /* mips_macro.h in Headers */,
 				323F8BDD1F38EF770092B609 /* vp8i_enc.h in Headers */,
 				323F8B671F38EF770092B609 /* cost_enc.h in Headers */,
+				321C69A21FFFA765002D47FB /* SDWebImageInternal.h in Headers */,
 				80377EE11F2F66D500F89830 /* vp8_dec.h in Headers */,
 				80377EE41F2F66D500F89830 /* vp8li_dec.h in Headers */,
 				80377C931F2F666400F89830 /* utils.h in Headers */,
@@ -2357,6 +2369,7 @@
 				4A2CAE2D1AB4BB7500B6BC39 /* UIImage+GIF.h in Headers */,
 				80377C3B1F2F666300F89830 /* quant_levels_dec_utils.h in Headers */,
 				80377EB11F2F66D400F89830 /* vp8_dec.h in Headers */,
+				321C699F1FFFA765002D47FB /* SDWebImageInternal.h in Headers */,
 				4A2CAE291AB4BB7500B6BC39 /* NSData+ImageContentType.h in Headers */,
 				431739531CDFC8B70008FEB9 /* mux_types.h in Headers */,
 			);
@@ -2376,6 +2389,7 @@
 				321E60A21F38E8F600405457 /* SDWebImageGIFCoder.h in Headers */,
 				5D5B9142188EE8DD006D06BD /* NSData+ImageContentType.h in Headers */,
 				80377BFE1F2F665300F89830 /* color_cache_utils.h in Headers */,
+				321C699D1FFFA765002D47FB /* SDWebImageInternal.h in Headers */,
 				431738C11CDFC2660008FEB9 /* mux.h in Headers */,
 				80377D0A1F2F66A100F89830 /* lossless.h in Headers */,
 				53761318155AD0D5005750A4 /* SDWebImageCompat.h in Headers */,

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -7,6 +7,7 @@
  */
 
 #import "FLAnimatedImageView+WebCache.h"
+#import "SDWebImageInternal.h"
 
 #if SD_UIKIT
 #import "objc/runtime.h"

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -15,8 +15,6 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadReceiveResponseNot
 FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadStopNotification;
 FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification;
 
-
-
 /**
  Describes a downloader operation. If one wants to use a custom downloader op, it needs to inherit from `NSOperation` and conform to this protocol
  */

--- a/SDWebImage/SDWebImageInternal.h
+++ b/SDWebImage/SDWebImageInternal.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ * (c) Fabrice Aneche
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#ifndef SDWebImageInternal_h
+#define SDWebImageInternal_h
+
+/**
+ A Dispatch group to maintain setImageBlock and completionBlock. This key should be used only internally and may be changed in the future. (dispatch_group_t)
+ */
+FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupKey;
+
+/**
+ Global lock when accessing shared NSURLCache to avoid thread-safe problem
+
+ @return A lock to used when accessing shared NSURLCache
+ */
+FOUNDATION_EXPORT dispatch_semaphore_t _Nonnull const SDWebImageDownloadSharedCacheLock(void);
+
+
+#endif /* SDWebImageInternal_h */

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -13,10 +13,6 @@
 #import "SDWebImageManager.h"
 
 /**
- A Dispatch group to maintain setImageBlock and completionBlock. This key should be used only internally and may be changed in the future. (dispatch_group_t)
- */
-FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupKey;
-/**
  A SDWebImageManager instance to control the image download and cache process using in UIImageView+WebCache category and likes. If not provided, use the shared manager (SDWebImageManager)
  */
 FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageExternalCustomManagerKey;

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -7,6 +7,7 @@
  */
 
 #import "UIView+WebCache.h"
+#import "SDWebImageInternal.h"
 
 #if SD_UIKIT || SD_MAC
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2156

### Pull Request Description

It seems that `+ [NSURLCache sharedURLCache]` is really dangerous. Any method to call `cachedResponseForRequest:` or `storeCachedResponse: forRequest:` should be synchonized. This call may come from everywhere but not just instance level(even from user's code), so we should have a global lock when accessing it.

We do not want anybody outside our framework to touch the lock to avoid issue, so we should make it private. I found it's really strange that our framework does not have a private header, so I create one and also move any other private defines/macros/global function into this.

  