### PR TITLE
For each downloader, create a URLCache instead of shared one to avoid thread-safe issue

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -63,7 +63,10 @@
 }
 
 - (nonnull instancetype)init {
-    return [self initWithSessionConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    // Each downloader cache is separated because of NSURLCache's thread-safe issue
+    configuration.URLCache = [[NSURLCache alloc] init];
+    return [self initWithSessionConfiguration:configuration];
 }
 
 - (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)sessionConfiguration {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -135,14 +135,6 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
             }];
         }
 #endif
-        if (self.options & SDWebImageDownloaderIgnoreCachedResponse) {
-            // Grab the cached data for later check
-            NSCachedURLResponse *cachedResponse = [[NSURLCache sharedURLCache] cachedResponseForRequest:self.request];
-            if (cachedResponse) {
-                self.cachedData = cachedResponse.data;
-            }
-        }
-        
         NSURLSession *session = self.unownedSession;
         if (!self.unownedSession) {
             NSURLSessionConfiguration *sessionConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
@@ -157,6 +149,21 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
                                                               delegate:self
                                                          delegateQueue:nil];
             session = self.ownedSession;
+        }
+        
+        if (self.options & SDWebImageDownloaderIgnoreCachedResponse) {
+            // Grab the cached data for later check
+            NSURLCache *URLCache = session.configuration.URLCache;
+            if (URLCache) {
+                // NSURLCache `cachedResponseForRequest:` is not thread-safe
+                NSCachedURLResponse *cachedResponse;
+                @synchronized (URLCache) {
+                    cachedResponse = [URLCache cachedResponseForRequest:self.request];
+                }
+                if (cachedResponse) {
+                    self.cachedData = cachedResponse.data;
+                }
+            }
         }
         
         self.dataTask = [session dataTaskWithRequest:self.request];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2156 #2157

### Pull Request Description

Another way to fix #2156. Since we can't control who acess the `- [NSURLCache sharedCache]`, we can create a new URLCache for each downloader. Then use this to check the cached response. This it's more clear to maintain and do not get the impact from outside code (such as user call something on shared URLCache)

The only potential problem is that the cached response may not be shared across different `SDWebImageDownloader` instance, but since this is rare case and most people who use non-shared downloader prefer to seperate config/cache from each other, this is acceptable.


  