### PR TITLE
[IOCoder] Avoid using `animatedImageWithImages:duration:` for a GIF image

### DIFF
--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -107,9 +107,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     
     SDImageFormat format = [NSData sd_imageFormatForImageData:data];
     if (format == SDImageFormatGIF) {
-        // static single GIF need to be created animated for `FLAnimatedImage` logic
         // GIF does not support EXIF image orientation
-        image = [UIImage animatedImageWithImages:@[image] duration:image.duration];
         return image;
     }
     UIImageOrientation orientation = [[self class] sd_imageOrientationFromImageData:data];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] ~~I have added the required tests to prove the fix/feature I am adding~~
* [ ] ~~I have updated the documentation (if necessary)~~
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: https://github.com/rs/SDWebImage/issues/1732#issuecomment-356193885

May be related to #2155.

### Pull Request Description

Looks like that is problematic for `UIButton` integration.