### PR TITLE
Feature addtional http headers and response

### DIFF
--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -20,3 +20,8 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextSetIma
  A SDWebImageManager instance to control the image download and cache process using in UIImageView+WebCache category and likes. If not provided, use the shared manager (SDWebImageManager)
  */
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextCustomManager;
+
+/**
+ A dictionary to add addtional HTTP request headers when downloading the image. (NSDictionary)
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextAddtionalHTTPHeaders;

--- a/SDWebImage/SDWebImageDefine.m
+++ b/SDWebImage/SDWebImageDefine.m
@@ -10,3 +10,4 @@
 
 SDWebImageContextOption const SDWebImageContextSetImageGroup = @"setImageGroup";
 SDWebImageContextOption const SDWebImageContextCustomManager = @"customManager";
+SDWebImageContextOption const SDWebImageContextAddtionalHTTPHeaders = @"addtionalHTTPHeaders";

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -86,14 +86,18 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
 @interface SDWebImageDownloadToken : NSObject <SDWebImageOperation>
 
 /**
- The download's URL. This should be readonly and you should not modify
+ The download's URL.
  */
-@property (nonatomic, strong, nullable) NSURL *url;
+@property (nonatomic, strong, nullable, readonly) NSURL *url;
 /**
- The cancel token taken from `addHandlersForProgress:completed`. This should be readonly and you should not modify
+ The doenload's response
+ */
+@property (nonatomic, strong, nullable, readonly) NSURLResponse *response;
+/**
+ The cancel token taken from `addHandlersForProgress:completed`.
  @note use `-[SDWebImageDownloadToken cancel]` to cancel the token
  */
-@property (nonatomic, strong, nullable) id downloadOperationCancelToken;
+@property (nonatomic, strong, nullable, readonly) id downloadOperationCancelToken;
 
 @end
 

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -8,17 +8,37 @@
 
 #import "SDWebImageDownloader.h"
 #import "SDWebImageDownloaderOperation.h"
+#import "UIView+WebCache.h"
 
 #define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
 #define UNLOCK(lock) dispatch_semaphore_signal(lock);
 
 @interface SDWebImageDownloadToken ()
 
+@property (nonatomic, strong, nullable, readwrite) NSURL *url;
+@property (nonatomic, strong, nullable, readwrite) NSURLResponse *response;
+@property (nonatomic, strong, nullable, readwrite) id downloadOperationCancelToken;
 @property (nonatomic, weak, nullable) NSOperation<SDWebImageDownloaderOperationInterface> *downloadOperation;
 
 @end
 
 @implementation SDWebImageDownloadToken
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:SDWebImageDownloadReceiveResponseNotification object:nil];
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(downloadReceiveResponse:) name:SDWebImageDownloadReceiveResponseNotification object:nil];
+    }
+    return self;
+}
+
+- (void)downloadReceiveResponse:(NSNotification *)notification {
+    self.response = self.downloadOperation.response;
+}
 
 - (void)cancel {
     if (self.downloadOperation) {
@@ -219,11 +239,15 @@
         
         request.HTTPShouldHandleCookies = (options & SDWebImageDownloaderHandleCookies);
         request.HTTPShouldUsePipelining = YES;
-        if (sself.headersFilter) {
-            request.allHTTPHeaderFields = sself.headersFilter(url, [sself allHTTPHeaderFields]);
+        NSMutableDictionary *allHTTPHeaderFields = [NSMutableDictionary dictionary];
+        [allHTTPHeaderFields addEntriesFromDictionary:[sself allHTTPHeaderFields]];
+        if ([context valueForKey:SDWebImageContextAddtionalHTTPHeaders]) {
+            [allHTTPHeaderFields addEntriesFromDictionary:[context valueForKey:SDWebImageContextAddtionalHTTPHeaders]];
         }
-        else {
-            request.allHTTPHeaderFields = [sself allHTTPHeaderFields];
+        if (sself.headersFilter) {
+            request.allHTTPHeaderFields = sself.headersFilter(url, [allHTTPHeaderFields copy]);
+        } else {
+            request.allHTTPHeaderFields = [allHTTPHeaderFields copy];
         }
         SDWebImageDownloaderOperation *operation = [[sself.operationClass alloc] initWithRequest:request inSession:sself.session options:options context:context];
         operation.shouldDecompressImages = sself.shouldDecompressImages;

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -41,6 +41,10 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 - (nullable NSURLCredential *)credential;
 - (void)setCredential:(nullable NSURLCredential *)value;
 
+- (NSInteger)expectedSize;
+
+- (nullable NSURLResponse *)response;
+
 - (BOOL)cancel:(nullable id)token;
 
 @end
@@ -87,7 +91,7 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 @property (assign, nonatomic, readonly) NSInteger expectedSize;
 
 /**
- * The response returned by the operation's connection.
+ * The response returned by the operation's task.
  */
 @property (strong, nonatomic, nullable, readonly) NSURLResponse *response;
 

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -124,6 +124,29 @@ typedef void(^SDInternalCompletionBlock)(UIImage * _Nullable image, NSData * _Nu
 
 typedef NSString * _Nullable (^SDWebImageCacheKeyFilterBlock)(NSURL * _Nullable url);
 
+@interface SDWebImageCombinedOperation : NSObject <SDWebImageOperation>
+
+/**
+ Cancel the current operation, including cache and download process
+ */
+- (void)cancel;
+
+/**
+ A Boolean value indicating whether the operation has been cancelled
+ */
+@property (assign, nonatomic, getter = isCancelled, readonly) BOOL cancelled;
+
+/**
+ The cache operation used for image cache query
+ */
+@property (strong, nonatomic, nullable, readonly) NSOperation *cacheOperation;
+
+/**
+ The download token if the image is download from the network
+ */
+@property (strong, nonatomic, nullable, readonly) SDWebImageDownloadToken *downloadToken;
+
+@end
 
 @class SDWebImageManager;
 
@@ -238,12 +261,12 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
  *
  *   The last parameter is the original image URL
  *
- * @return Returns an NSObject conforming to SDWebImageOperation. Should be an instance of SDWebImageDownloaderOperation
+ * @return Returns an instance of SDWebImageDownloaderOperation which you can cancel the operation
  */
-- (nullable id <SDWebImageOperation>)loadImageWithURL:(nullable NSURL *)url
-                                              options:(SDWebImageOptions)options
-                                             progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
-                                            completed:(nonnull SDInternalCompletionBlock)completedBlock;
+- (nullable SDWebImageCombinedOperation *)loadImageWithURL:(nullable NSURL *)url
+                                                   options:(SDWebImageOptions)options
+                                                  progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                                                 completed:(nonnull SDInternalCompletionBlock)completedBlock;
 
 /**
  * Downloads the image at the given URL if not present in cache or return the cached version otherwise.
@@ -255,13 +278,13 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
  * @param completedBlock A block called when operation has been completed.
  * @param context        A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
  *
- * @return Returns an NSObject conforming to SDWebImageOperation. Should be an instance of SDWebImageDownloaderOperation
+ * @return Returns an instance of SDWebImageDownloaderOperation which you can cancel the operation
  */
-- (nullable id <SDWebImageOperation>)loadImageWithURL:(nullable NSURL *)url
-                                              options:(SDWebImageOptions)options
-                                             progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
-                                            completed:(nonnull SDInternalCompletionBlock)completedBlock
-                                              context:(nullable SDWebImageContext *)context;
+- (nullable SDWebImageCombinedOperation *)loadImageWithURL:(nullable NSURL *)url
+                                                   options:(SDWebImageOptions)options
+                                                  progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                                                 completed:(nonnull SDInternalCompletionBlock)completedBlock
+                                                   context:(nullable SDWebImageContext *)context;
 
 /**
  * Saves image to cache for given URL

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -10,11 +10,11 @@
 #import "NSImage+Additions.h"
 #import <objc/message.h>
 
-@interface SDWebImageCombinedOperation : NSObject <SDWebImageOperation>
+@interface SDWebImageCombinedOperation ()
 
-@property (assign, nonatomic, getter = isCancelled) BOOL cancelled;
+@property (assign, nonatomic, getter = isCancelled, readwrite) BOOL cancelled;
 @property (strong, nonatomic, nullable) SDWebImageDownloadToken *downloadToken;
-@property (strong, nonatomic, nullable) NSOperation *cacheOperation;
+@property (strong, nonatomic, nullable, readwrite) NSOperation *cacheOperation;
 @property (weak, nonatomic, nullable) SDWebImageManager *manager;
 
 @end
@@ -107,15 +107,15 @@
     }];
 }
 
-- (id<SDWebImageOperation>)loadImageWithURL:(NSURL *)url options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDInternalCompletionBlock)completedBlock {
+- (SDWebImageCombinedOperation *)loadImageWithURL:(NSURL *)url options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDInternalCompletionBlock)completedBlock {
     return [self loadImageWithURL:url options:options progress:progressBlock completed:completedBlock context:nil];
 }
 
-- (id<SDWebImageOperation>)loadImageWithURL:(nullable NSURL *)url
-                                    options:(SDWebImageOptions)options
-                                   progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
-                                  completed:(nonnull SDInternalCompletionBlock)completedBlock
-                                    context:(nullable SDWebImageContext *)context {
+- (SDWebImageCombinedOperation *)loadImageWithURL:(nullable NSURL *)url
+                                          options:(SDWebImageOptions)options
+                                         progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                                        completed:(nonnull SDInternalCompletionBlock)completedBlock
+                                          context:(nullable SDWebImageContext *)context {
     // Invoking this method without a completedBlock is pointless
     NSAssert(completedBlock != nil, @"If you mean to prefetch the image, use -[SDWebImagePrefetcher prefetchURLs] instead");
 

--- a/SDWebImage/UIView+WebCacheOperation.h
+++ b/SDWebImage/UIView+WebCacheOperation.h
@@ -17,10 +17,18 @@
 @interface UIView (WebCacheOperation)
 
 /**
+ *  Get the image load operation for key
+ *
+ *  @param key key for identifying the operations
+ *  @return the image load operation
+ */
+- (nullable id<SDWebImageOperation>)sd_imageLoadOperationForKey:(nullable NSString *)key;
+
+/**
  *  Set the image load operation (storage in a UIView based weak map table)
  *
  *  @param operation the operation
- *  @param key       key for storing the operation
+ *  @param key key for storing the operation
  */
 - (void)sd_setImageLoadOperation:(nullable id<SDWebImageOperation>)operation forKey:(nullable NSString *)key;
 

--- a/SDWebImage/UIView+WebCacheOperation.m
+++ b/SDWebImage/UIView+WebCacheOperation.m
@@ -32,6 +32,15 @@ typedef NSMapTable<NSString *, id<SDWebImageOperation>> SDOperationsDictionary;
     }
 }
 
+- (nullable id<SDWebImageOperation>)sd_imageLoadOperationForKey:(nullable NSString *)key  {
+    id<SDWebImageOperation> operation;
+    SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
+    @synchronized (self) {
+        operation = [operationDictionary objectForKey:key];
+    }
+    return operation;
+}
+
 - (void)sd_setImageLoadOperation:(nullable id<SDWebImageOperation>)operation forKey:(nullable NSString *)key {
     if (key) {
         [self sd_cancelImageLoadOperationWithKey:key];

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -33,6 +33,8 @@
 
 @property (nonatomic, assign) BOOL shouldDecompressImages;
 @property (nonatomic, strong, nullable) NSURLCredential *credential;
+@property (nonatomic, assign) NSInteger expectedSize;
+@property (nonatomic, strong, nullable) NSURLResponse *response;
 
 @end
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2020 

### Pull Request Description

This PR introduce the feature to provide custom HTTP addtional headers for each UIView request, and grab the `NSURLResponse` from the download operation to the top entry of our lib. It based on the `context` arg.
