### PR TITLE
Update the spec file to define the dependency version for libwebp

### DIFF
--- a/SDWebImage.podspec
+++ b/SDWebImage.podspec
@@ -62,6 +62,6 @@ Pod::Spec.new do |s|
       'USER_HEADER_SEARCH_PATHS' => '$(inherited) $(SRCROOT)/libwebp/src'
     }
     webp.dependency 'SDWebImage/Core'
-    webp.dependency 'libwebp'
+    webp.dependency 'libwebp', '~> 0.5'
   end
 end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2167 

### Pull Request Description

We previously have no version limit for `libwebp` dependency. However, we actually use the API(`WebPFree`) from `libwebp` 0.5.0 and our submodule version is already 0.6.0. So we should add the version limit but not leave it empty.

