### PR TITLE
Add a NSProgress property represent the image loading progress, this allow user add KVO on it for complicated logic

### DIFF
--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -21,9 +21,9 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupKey;
  */
 FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageExternalCustomManagerKey;
 /**
- The value specify that the image progress unit count cannot be determined because the progressBlock is not been called. This value is actually 1
+ The value specify that the image progress unit count cannot be determined because the progressBlock is not been called.
  */
-FOUNDATION_EXPORT const int64_t SDWebImageProgressUnitCountUnknown;
+FOUNDATION_EXPORT const int64_t SDWebImageProgressUnitCountUnknown; /* 1LL */
 
 typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable imageData);
 
@@ -37,9 +37,9 @@ typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable ima
 - (nullable NSURL *)sd_imageURL;
 
 /**
- * The current image loading progress associated to the view. The unit count is the received size and excepted size of download
- * The `completedUnitCount` will be reset to 0 after a new image loading start. And `completedUnitCount` will be `SDWebImageProgressUnitCountUnknown` if the progressBlock not been called but the image loading success to mark the progress finished.
- * @note You can use Key-Value Observing on the progress, but you should take care that the change to progress is from a background queue(the same as progressBlock). If you want to using KVO and update the UI, make sure to dispatch on the main queue. And it's recommand to use some KVO libs like KVOController because it's more safe and easy to use.
+ * The current image loading progress associated to the view. The unit count is the received size and excepted size of download.
+ * The `totalUnitCount` and `completedUnitCount` will be reset to 0 after a new image loading start (change from current queue). And they will be set to `SDWebImageProgressUnitCountUnknown` if the progressBlock not been called but the image loading success to mark the progress finished (change from main queue).
+ * @note You can use Key-Value Observing on the progress, but you should take care that the change to progress is from a background queue during download(the same as progressBlock). If you want to using KVO and update the UI, make sure to dispatch on the main queue. And it's recommand to use some KVO libs like KVOController because it's more safe and easy to use.
  * @note The getter will create a progress instance if the value is nil. You can also set a custom progress instance and let it been updated during image loading
  * @note Note that because of the limitations of categories this property can get out of sync if you update the progress directly.
  */
@@ -100,7 +100,7 @@ typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable ima
                            context:(nullable NSDictionary *)context;
 
 /**
- * Cancel the current download
+ * Cancel the current image load
  */
 - (void)sd_cancelCurrentImageLoad;
 

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -20,6 +20,10 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupKey;
  A SDWebImageManager instance to control the image download and cache process using in UIImageView+WebCache category and likes. If not provided, use the shared manager (SDWebImageManager)
  */
 FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageExternalCustomManagerKey;
+/**
+ The value specify that the image progress unit count cannot be determined because the progressBlock is not been called. This value is actually 1
+ */
+FOUNDATION_EXPORT const int64_t SDWebImageProgressUnitCountUnknown;
 
 typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable imageData);
 
@@ -28,10 +32,18 @@ typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable ima
 /**
  * Get the current image URL.
  *
- * Note that because of the limitations of categories this property can get out of sync
- * if you use setImage: directly.
+ * @note Note that because of the limitations of categories this property can get out of sync if you use setImage: directly.
  */
 - (nullable NSURL *)sd_imageURL;
+
+/**
+ * The current image loading progress associated to the view. The unit count is the received size and excepted size of download
+ * The `completedUnitCount` will be reset to 0 after a new image loading start. And `completedUnitCount` will be `SDWebImageProgressUnitCountUnknown` if the progressBlock not been called but the image loading success to mark the progress finished.
+ * @note You can use Key-Value Observing on the progress, but you should take care that the change to progress is from a background queue(the same as progressBlock). If you want to using KVO and update the UI, make sure to dispatch on the main queue. And it's recommand to use some KVO libs like KVOController because it's more safe and easy to use.
+ * @note The getter will create a progress instance if the value is nil. You can also set a custom progress instance and let it been updated during image loading
+ * @note Note that because of the limitations of categories this property can get out of sync if you update the progress directly.
+ */
+@property (nonatomic, strong, null_resettable) NSProgress *sd_imageProgress;
 
 /**
  * Set the imageView `image` with an `url` and optionally a placeholder image.

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -35,7 +35,7 @@ static char TAG_ACTIVITY_SHOW;
 - (NSProgress *)sd_imageProgress {
     NSProgress *progress = objc_getAssociatedObject(self, @selector(sd_imageProgress));
     if (!progress) {
-        progress = [[NSProgress alloc] init];
+        progress = [[NSProgress alloc] initWithParent:nil userInfo:nil];
         self.sd_imageProgress = progress;
     }
     return progress;
@@ -84,6 +84,7 @@ static char TAG_ACTIVITY_SHOW;
         }
         
         // reset the progress
+        self.sd_imageProgress.totalUnitCount = 0;
         self.sd_imageProgress.completedUnitCount = 0;
         
         SDWebImageManager *manager;
@@ -106,7 +107,8 @@ static char TAG_ACTIVITY_SHOW;
             if (!sself) { return; }
             [sself sd_removeActivityIndicator];
             // if the progress not been updated, mark it to complete state
-            if (finished && !error && sself.sd_imageProgress.completedUnitCount == 0) {
+            if (finished && !error && sself.sd_imageProgress.totalUnitCount == 0 && sself.sd_imageProgress.completedUnitCount == 0) {
+                sself.sd_imageProgress.totalUnitCount = SDWebImageProgressUnitCountUnknown;
                 sself.sd_imageProgress.completedUnitCount = SDWebImageProgressUnitCountUnknown;
             }
             BOOL shouldCallCompletedBlock = finished || (options & SDWebImageAvoidAutoSetImage);

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -16,6 +16,8 @@
 NSString * const SDWebImageInternalSetImageGroupKey = @"internalSetImageGroup";
 NSString * const SDWebImageExternalCustomManagerKey = @"externalCustomManager";
 
+const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
+
 static char imageURLKey;
 
 #if SD_UIKIT
@@ -28,6 +30,19 @@ static char TAG_ACTIVITY_SHOW;
 
 - (nullable NSURL *)sd_imageURL {
     return objc_getAssociatedObject(self, &imageURLKey);
+}
+
+- (NSProgress *)sd_imageProgress {
+    NSProgress *progress = objc_getAssociatedObject(self, @selector(sd_imageProgress));
+    if (!progress) {
+        progress = [[NSProgress alloc] init];
+        self.sd_imageProgress = progress;
+    }
+    return progress;
+}
+
+- (void)setSd_imageProgress:(NSProgress *)sd_imageProgress {
+    objc_setAssociatedObject(self, @selector(sd_imageProgress), sd_imageProgress, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 - (void)sd_internalSetImageWithURL:(nullable NSURL *)url
@@ -68,6 +83,9 @@ static char TAG_ACTIVITY_SHOW;
             [self sd_addActivityIndicator];
         }
         
+        // reset the progress
+        self.sd_imageProgress.completedUnitCount = 0;
+        
         SDWebImageManager *manager;
         if ([context valueForKey:SDWebImageExternalCustomManagerKey]) {
             manager = (SDWebImageManager *)[context valueForKey:SDWebImageExternalCustomManagerKey];
@@ -76,10 +94,21 @@ static char TAG_ACTIVITY_SHOW;
         }
         
         __weak __typeof(self)wself = self;
-        id <SDWebImageOperation> operation = [manager loadImageWithURL:url options:options progress:progressBlock completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
+        SDWebImageDownloaderProgressBlock combinedProgressBlock = ^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
+            wself.sd_imageProgress.totalUnitCount = expectedSize;
+            wself.sd_imageProgress.completedUnitCount = receivedSize;
+            if (progressBlock) {
+                progressBlock(receivedSize, expectedSize, targetURL);
+            }
+        };
+        id <SDWebImageOperation> operation = [manager loadImageWithURL:url options:options progress:combinedProgressBlock completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             __strong __typeof (wself) sself = wself;
-            [sself sd_removeActivityIndicator];
             if (!sself) { return; }
+            [sself sd_removeActivityIndicator];
+            // if the progress not been updated, mark it to complete state
+            if (finished && !error && sself.sd_imageProgress.completedUnitCount == 0) {
+                sself.sd_imageProgress.completedUnitCount = SDWebImageProgressUnitCountUnknown;
+            }
             BOOL shouldCallCompletedBlock = finished || (options & SDWebImageAvoidAutoSetImage);
             BOOL shouldNotSetImage = ((image && (options & SDWebImageAvoidAutoSetImage)) ||
                                       (!image && !(options & SDWebImageDelayPlaceholder)));

--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -15,6 +15,8 @@
 #import <SDWebImage/FLAnimatedImageView+WebCache.h>
 #import <SDWebImage/UIView+WebCache.h>
 
+static void * SDCategoriesTestsContext = &SDCategoriesTestsContext;
+
 @interface SDCategoriesTests : SDTestCase
 
 @end
@@ -138,32 +140,35 @@
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)testUIViewImageProgressWorkWithKVO {
+- (void)testUIViewImageProgressKVOWork {
     XCTestExpectation *expectation = [self expectationWithDescription:@"UIView imageProgressKVO failed"];
     UIView *view = [[UIView alloc] init];
     NSURL *originalImageURL = [NSURL URLWithString:kTestJpegURL];
     
-    [view.sd_imageProgress addObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted)) options:NSKeyValueObservingOptionNew context:_cmd];
+    [view.sd_imageProgress addObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted)) options:NSKeyValueObservingOptionNew context:SDCategoriesTestsContext];
     
     // Clear the disk cache to force download from network
     [[SDImageCache sharedImageCache] removeImageForKey:kTestJpegURL withCompletion:^{
         [view sd_internalSetImageWithURL:originalImageURL placeholderImage:nil options:0 operationKey:nil setImageBlock:nil progress:nil completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
             expect(view.sd_imageProgress.fractionCompleted).equal(1.0);
+            expect([view.sd_imageProgress.userInfo[NSStringFromSelector(_cmd)] boolValue]).equal(YES);
             [expectation fulfill];
         }];
     }];
     [self waitForExpectationsWithTimeout:kAsyncTestTimeout handler:^(NSError * _Nullable error) {
-        [view.sd_imageProgress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted)) context:_cmd];
+        [view.sd_imageProgress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted)) context:SDCategoriesTestsContext];
     }];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    if (context == @selector(testUIViewImageProgressWorkWithKVO)) {
+    if (context == SDCategoriesTestsContext) {
         if ([keyPath isEqualToString:NSStringFromSelector(@selector(fractionCompleted))]) {
             NSProgress *progress = object;
             NSNumber *completedValue = change[NSKeyValueChangeNewKey];
             expect(progress.fractionCompleted).equal(completedValue.doubleValue);
+            // mark that KVO is called
+            [progress setUserInfoObject:@(YES) forKey:NSStringFromSelector(@selector(testUIViewImageProgressKVOWork))];
         }
     } else {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];

--- a/Tests/Tests/SDTestCase.h
+++ b/Tests/Tests/SDTestCase.h
@@ -14,6 +14,7 @@
 #import <Expecta/Expecta.h>
 
 FOUNDATION_EXPORT const int64_t kAsyncTestTimeout;
+FOUNDATION_EXPORT const int64_t kMinDelayNanosecond;
 FOUNDATION_EXPORT NSString * _Nonnull const kTestJpegURL;
 FOUNDATION_EXPORT NSString * _Nonnull const kTestPNGURL;
 

--- a/Tests/Tests/SDTestCase.m
+++ b/Tests/Tests/SDTestCase.m
@@ -10,6 +10,7 @@
 #import "SDTestCase.h"
 
 const int64_t kAsyncTestTimeout = 5;
+const int64_t kMinDelayNanosecond = NSEC_PER_MSEC * 100; // 0.1s
 NSString *const kTestJpegURL = @"http://via.placeholder.com/50x50.jpg";
 NSString *const kTestPNGURL = @"http://via.placeholder.com/50x50.png";
 

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -186,7 +186,7 @@
     [[SDWebImageDownloader sharedDownloader] cancel:token];
     
     // doesn't cancel immediately - since it uses dispatch async
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMinDelayNanosecond), dispatch_get_main_queue(), ^{
         expect([SDWebImageDownloader sharedDownloader].currentDownloadCount).to.equal(0);
         [expectation fulfill];
     });

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -100,7 +100,7 @@
     [[SDWebImageManager sharedManager] cancelAll];
     
     // doesn't cancel immediately - since it uses dispatch async
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMinDelayNanosecond), dispatch_get_main_queue(), ^{
         expect([[SDWebImageManager sharedManager] isRunning]).to.equal(NO);
         [expectation fulfill];
     });


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2150 #970

### Pull Request Description

[NSProgress](https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSProgress_Class/index.html#//apple_ref/occ/cl/NSProgress) seems a powerful class to allow you add KVO on it(If you don't use KVO, actually you don't need it at all), and can be used to make a [progress tree](https://developer.apple.com/documentation/foundation/progress#1661088)

Assume this problem: You're building a online image file browser which need to download different images and need calculate the total progress to show on the screen, you'll find it really hard to build by current progressBlock design. You need to synchonized different progressBlock by writting many ugly code, keep thread-safe(the progressBlock queue is different from each other) and it may contains bugs.  But if you use NSProgress, you can simply use `-[NSProgress addChild:]` to build a progress tree and just check the root progress.

#2150 seems provide the NSProgress API by breaking current progressBlock API. But I think it's really not necessary because that for most usage(nearly 99%), the `receivedSize` and `expectedSize` is enough, and it works no difference with `NSProgress.totalUnitCount` and `NSProgress.completedUnitCount`, so the cost is much more than the gain.

And, if you put the NSProgress into the progressBlock, you can not add KVO on it and solve the problem above(Even you say that you call addObserver on first progressBlock called, but sadly the progressBlock will not been called if the image is from cache). I think since we break something, we should soleve something :)

So I create this PR, to make it more easy to use with KVO, and make it more easy to use in all the cases. For example, our current progressBlock `will never been called` if the image is from the cache. So I create a default state (See `SDWebImageProgressUnitCountUnknown`) to mark the progress as finished if the image download success.

I also write a test to simulate the basic usage for KVO. However, since KVO's raw API is really hard to use and may cause crash if you forget to remove the KVO after dealloc, I recommand most users to use [KVOController](https://github.com/facebook/KVOController) or some other good library to do this thing :) 