### PR TITLE
Added missing param in storeImage examples

### DIFF
--- a/Docs/HowToUse.md
+++ b/Docs/HowToUse.md
@@ -115,14 +115,16 @@ SDImageCache *imageCache = [[SDImageCache alloc] initWithNamespace:@"myNamespace
 By default SDImageCache will lookup the disk cache if an image can't be found in the memory cache.
 You can prevent this from happening by calling the alternative method `imageFromMemoryCacheForKey:`.
 
-To store an image into the cache, you use the storeImage:forKey: method:
+To store an image into the cache, you use the storeImage:forKey:completion: method:
 
 ```objective-c
-[[SDImageCache sharedImageCache] storeImage:myImage forKey:myCacheKey];
+[[SDImageCache sharedImageCache] storeImage:myImage forKey:myCacheKey completion:^{
+    // image stored
+}];
 ```
 
 By default, the image will be stored in memory cache as well as on disk cache (asynchronously). If
-you want only the memory cache, use the alternative method storeImage:forKey:toDisk: with a negative
+you want only the memory cache, use the alternative method storeImage:forKey:toDisk:completion: with a negative
 third argument.
 
 ### Using cache key filter


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)
