### PR TITLE
Deprecate the sd_setImageWithPreviousCachedImageWithURL with the specify options to achieve this usage

### DIFF
--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -155,7 +155,9 @@
                  completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the imageView `image` with an `url` and optionally a placeholder image.
+ * Set the imageView `image` with an `url` and custom options. The placeholder image is from previous cached image and will use the provided one instead if the query failed.
+ * This method was designed to ensure that placeholder and query cache process happened in the same runloop to avoid flashing on cell during two `setImage:` call. But it's really misunderstanding and deprecated.
+ * This can be done by using `sd_setImageWithURL:` with `SDWebImageQueryDiskSync`. But take care that if the memory cache missed, query disk cache synchronously may reduce the frame rate
  *
  * The download is asynchronous and cached.
  *
@@ -169,12 +171,13 @@
  *                       is nil and the second parameter may contain an NSError. The third parameter is a Boolean
  *                       indicating if the image was retrieved from the local cache or from the network.
  *                       The fourth parameter is the original image url.
+ * @deprecated consider using `SDWebImageQueryDiskSync` options with `sd_setImageWithURL:` instead
  */
 - (void)sd_setImageWithPreviousCachedImageWithURL:(nullable NSURL *)url
                                  placeholderImage:(nullable UIImage *)placeholder
                                           options:(SDWebImageOptions)options
                                          progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
-                                        completed:(nullable SDExternalCompletionBlock)completedBlock;
+                                        completed:(nullable SDExternalCompletionBlock)completedBlock __deprecated_msg("This method is misunderstanding and deprecated, consider using `SDWebImageQueryDiskSync` options with `sd_setImageWithURL:` instead");
 
 #if SD_UIKIT
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #793 

### Pull Request Description

This PR deprecate a wrong design API `-[UIImageView(WebCache) sd_setImageWithPreviousCachedImageWithURL:placeholderImage:options:progress:completed:]` with the alternative replacement by using the specify cache options introduced in #2162. This follow the [semver](https://semver.org/#spec-item-7) that just mark it as deprecated, the implementation is not changed and kept compatibility.

This wrong design API is introdueced from #541. It designed to solve the issue:

We always set the placeholder firstly(without `SDWebImageDelayPlaceholder`) to make it works for cell reuse. But if the memory cache missed(By many condition, for example, memory warning, user disable the memory cache), we will query the disk cache, this is a asynchonized operation, so this is not happend on the same runloop for UI rendering. So, if you're using on a tableView cell and specify a placeholder, this will cause the flashing.

1. `UIImageView.image = placeholder`(1th runloop)
2. `UIImageView.image = diskimage`(2nd runloop)

The imageView will firstly show placeholder and then show diskimage, this cause a `flashing`(or `flicking`)

There is one choice to solve this. That is to ensure the `setImage:` is called on the same runloop and UIKit will ignore the temporary states. We need to query the disk cache synchronously. This is just why this API was created and the implementation can do this as well.

1. `UIImageView.image = placeholder`(1th runloop)
2. `UIImageView.image = diskimage`(1th runloop)

The imageView will just show the diskimage without rendering placeholder at all, no flashing.

However, since the disk cache called synchronously, this will block main queue and may cause lag especially on low level device or if you have 5 or more cells. (300 disk query per second on iPhone 6S, means 60 frame rate you can just process 5 imageViews)

For disk cache missing cases, acutally there are really no difference between query disk cache asynchronously and download the image from network because both of this will rendering the placeholder. The only difference may be the placeholder rendering `duration` because long time rendering duration will not called `flashing`, just visual effect :)

1. `UIImageView.image = placeholder`(1th runloop)
2. `UIImageView.image = diskimage`(2th runloop) or `UIImageView.image` = networkimage`(2th runloop)

If you don't want this flashing occur from disk cache at anytime, you can even disable the disk cache with `SDWebImageCacheMemoryOnly` or using a fade animation before image was set :)