### PR TITLE
Fix the issue that `setAnimationImagesWithURLs` weak reference may dealloc before the animated images was set

### DIFF
--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -71,15 +71,14 @@
 
 - (void)sd_setAnimationImagesWithURLs:(nonnull NSArray<NSURL *> *)arrayOfURLs {
     [self sd_cancelCurrentAnimationImagesLoad];
-    __weak __typeof(self)wself = self;
-
     NSPointerArray *operationsArray = [self sd_animationOperationArray];
-
+    
     [arrayOfURLs enumerateObjectsUsingBlock:^(NSURL *logoImageURL, NSUInteger idx, BOOL * _Nonnull stop) {
+        __weak __typeof(self) wself = self;
         id <SDWebImageOperation> operation = [[SDWebImageManager sharedManager] loadImageWithURL:logoImageURL options:0 progress:nil completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
-            if (!wself) return;
+            __strong typeof(wself) sself = wself;
+            if (!sself) return;
             dispatch_main_async_safe(^{
-                __strong UIImageView *sself = wself;
                 [sself stopAnimating];
                 if (sself && image) {
                     NSMutableArray<UIImage *> *currentImages = [[sself animationImages] mutableCopy];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1209 

### Pull Request Description

It seems that this weak-strong usage is wrong. The weak reference is outside the block, so it may dealloc at any time if there are no strong reference to it. However, when you call `dispatch_main_async_safe`, there is a queue dispatch and will cause much more time. This weak instance may be alive when the `loadImageWithURL` completion block called, but when dispatch to the main queue it dealloced. This is not a designed behavior. So we should keep the strong reference before call `dispatch_main_async_safe`.

Any other similar code like this should also be fixed. If you also find some like this, fix it! :)