### PR TITLE
Add a option SDWebImageFromCacheOnly to load the image from cache only and prevent network

### DIFF
--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -98,15 +98,20 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     
     /**
      * By default, we do not query disk data when the image is cached in memory. This mask can force to query disk data at the same time.
-     * This options is recommend to be used with `SDWebImageQueryDiskSync` to ensure the image is loaded in the same runloop.
+     * This flag is recommend to be used with `SDWebImageQueryDiskSync` to ensure the image is loaded in the same runloop.
      */
     SDWebImageQueryDataWhenInMemory = 1 << 13,
     
     /**
      * By default, we query the memory cache synchronously, disk cache asynchronously. This mask can force to query disk cache synchronously to ensure that image is loaded in the same runloop.
-     * This can avoid flashing during cell reuse if you disable memory cache or in some other cases.
+     * This flag can avoid flashing during cell reuse if you disable memory cache or in some other cases.
      */
-    SDWebImageQueryDiskSync = 1 << 14
+    SDWebImageQueryDiskSync = 1 << 14,
+    
+    /**
+     * By default, when the cache missed, the image is download from the network. This flag can prevent network to load from cache only.
+     */
+    SDWebImageFromCacheOnly = 1 << 15
 };
 
 typedef void(^SDExternalCompletionBlock)(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL);

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -157,8 +157,12 @@
             [self safelyRemoveOperationFromRunning:strongOperation];
             return;
         }
-
-        if ((!cachedImage || options & SDWebImageRefreshCached) && (![self.delegate respondsToSelector:@selector(imageManager:shouldDownloadImageForURL:)] || [self.delegate imageManager:self shouldDownloadImageForURL:url])) {
+        
+        // Check whether we should download image from network
+        BOOL shouldDownload = (!(options & SDWebImageFromCacheOnly))
+            && (!cachedImage || options & SDWebImageRefreshCached)
+            && (![self.delegate respondsToSelector:@selector(imageManager:shouldDownloadImageForURL:)] || [self.delegate imageManager:self shouldDownloadImageForURL:url]);
+        if (shouldDownload) {
             if (cachedImage && options & SDWebImageRefreshCached) {
                 // If image was found in the cache but SDWebImageRefreshCached is provided, notify about the cached image
                 // AND try to re-download it in order to let a chance to NSURLCache to refresh it from server.


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1818 

### Pull Request Description

Some user need to access cache only without any network. This new introduces `SDWebImageFromCacheOnly` may solve their use case.

Because this can be easily implemented without any extra effect, so we can add this in 4.3.0.