### PR TITLE
Pass the context arg from the top level to the bottom level to allow specify logic in the future

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -205,6 +205,18 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 - (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDCacheQueryCompletedBlock)doneBlock;
 
 /**
+ * Asynchronously queries the cache with operation and call the completion when done.
+ *
+ * @param key       The unique key used to store the wanted image
+ * @param options   A mask to specify options to use for this cache query
+ * @param doneBlock The completion block. Will not get called if the operation is cancelled
+ * @param context   A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ *
+ * @return a NSOperation instance containing the cache op
+ */
+- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDCacheQueryCompletedBlock)doneBlock context:(nullable SDWebImageContext *)context;
+
+/**
  * Synchronously query the memory cache.
  *
  * @param key The unique key used to store the image

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -385,11 +385,15 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     return SDScaledImageForKey(key, image);
 }
 
-- (NSOperation *)queryCacheOperationForKey:(NSString *)key done:(SDCacheQueryCompletedBlock)doneBlock {
+- (nullable NSOperation *)queryCacheOperationForKey:(NSString *)key done:(SDCacheQueryCompletedBlock)doneBlock {
     return [self queryCacheOperationForKey:key options:0 done:doneBlock];
 }
 
-- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDCacheQueryCompletedBlock)doneBlock {
+- (nullable NSOperation *)queryCacheOperationForKey:(NSString *)key options:(SDImageCacheOptions)options done:(SDCacheQueryCompletedBlock)doneBlock {
+    return [self queryCacheOperationForKey:key options:options done:doneBlock context:nil];
+}
+
+- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDCacheQueryCompletedBlock)doneBlock context:(nullable SDWebImageContext *)context {
     if (!key) {
         if (doneBlock) {
             doneBlock(nil, nil, SDImageCacheTypeNone);

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -228,6 +228,28 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
                                                  completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock;
 
 /**
+ * Creates a SDWebImageDownloader async downloader instance with a given URL
+ *
+ * The delegate will be informed when the image is finish downloaded or an error has happen.
+ *
+ * @see SDWebImageDownloaderDelegate
+ *
+ * @param url            The URL to the image to download
+ * @param options        The options to be used for this download
+ * @param progressBlock  A block called repeatedly while the image is downloading
+ *                       @note the progress block is executed on a background queue
+ * @param completedBlock A block called once the download is completed.
+ * @param context        A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ *
+ * @return A token (SDWebImageDownloadToken) that can be passed to -cancel: to cancel this operation
+ */
+- (nullable SDWebImageDownloadToken *)downloadImageWithURL:(nullable NSURL *)url
+                                                   options:(SDWebImageDownloaderOptions)options
+                                                  progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                                                 completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock
+                                                   context:(nullable SDWebImageContext *)context;
+
+/**
  * Cancels a download that was previously queued using -downloadImageWithURL:options:progress:completed:
  *
  * @param token The token received from -downloadImageWithURL:options:progress:completed: that should be canceled.

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -174,10 +174,14 @@
     }
 }
 
+- (nullable SDWebImageDownloadToken *)downloadImageWithURL:(NSURL *)url options:(SDWebImageDownloaderOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDWebImageDownloaderCompletedBlock)completedBlock {
+    return [self downloadImageWithURL:url options:options progress:progressBlock completed:completedBlock context:nil];
+}
+
 - (nullable SDWebImageDownloadToken *)downloadImageWithURL:(nullable NSURL *)url
                                                    options:(SDWebImageDownloaderOptions)options
                                                   progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
-                                                 completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock {
+                                                 completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock context:(nullable SDWebImageContext *)context {
     __weak SDWebImageDownloader *wself = self;
 
     return [self addProgressCallback:progressBlock completedBlock:completedBlock forURL:url createCallback:^SDWebImageDownloaderOperation *{
@@ -203,6 +207,7 @@
         }
         SDWebImageDownloaderOperation *operation = [[sself.operationClass alloc] initWithRequest:request inSession:sself.session options:options];
         operation.shouldDecompressImages = sself.shouldDecompressImages;
+        operation.context = context;
         
         if (sself.urlCredential) {
             operation.credential = sself.urlCredential;

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -36,6 +36,9 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 - (nullable NSURLCredential *)credential;
 - (void)setCredential:(nullable NSURLCredential *)value;
 
+- (nullable SDWebImageContext *)context;
+- (void)setContext:(nullable SDWebImageContext *)context;
+
 - (BOOL)cancel:(nullable id)token;
 
 @end
@@ -67,19 +70,24 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 @property (nonatomic, strong, nullable) NSURLCredential *credential;
 
 /**
- * The SDWebImageDownloaderOptions for the receiver.
+ * The options for the receiver.
  */
 @property (assign, nonatomic, readonly) SDWebImageDownloaderOptions options;
 
 /**
+ * The context for the receiver.
+ */
+@property (copy, nonatomic, nullable) SDWebImageContext *context;
+
+/**
  * The expected size of data.
  */
-@property (assign, nonatomic) NSInteger expectedSize;
+@property (assign, nonatomic, readonly) NSInteger expectedSize;
 
 /**
  * The response returned by the operation's connection.
  */
-@property (strong, nonatomic, nullable) NSURLResponse *response;
+@property (strong, nonatomic, nullable, readonly) NSURLResponse *response;
 
 /**
  *  Initializes a `SDWebImageDownloaderOperation` object

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -29,6 +29,8 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 @property (assign, nonatomic, getter = isFinished) BOOL finished;
 @property (strong, nonatomic, nullable) NSMutableData *imageData;
 @property (copy, nonatomic, nullable) NSData *cachedData;
+@property (assign, nonatomic, readwrite) NSInteger expectedSize;
+@property (strong, nonatomic, nullable, readwrite) NSURLResponse *response;
 
 // This is weak because it is injected by whoever manages this session. If this gets nil-ed out, we won't be able to run
 // the task associated with this operation

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -242,6 +242,24 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
                                             completed:(nonnull SDInternalCompletionBlock)completedBlock;
 
 /**
+ * Downloads the image at the given URL if not present in cache or return the cached version otherwise.
+ *
+ * @param url            The URL to the image
+ * @param options        A mask to specify options to use for this request
+ * @param progressBlock  A block called while image is downloading
+ *                       @note the progress block is executed on a background queue
+ * @param completedBlock A block called when operation has been completed.
+ * @param context        A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ *
+ * @return Returns an NSObject conforming to SDWebImageOperation. Should be an instance of SDWebImageDownloaderOperation
+ */
+- (nullable id <SDWebImageOperation>)loadImageWithURL:(nullable NSURL *)url
+                                              options:(SDWebImageOptions)options
+                                             progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                                            completed:(nonnull SDInternalCompletionBlock)completedBlock
+                                              context:(nullable SDWebImageContext *)context;
+
+/**
  * Saves image to cache for given URL
  *
  * @param image The image to cache

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -107,10 +107,15 @@
     }];
 }
 
-- (id <SDWebImageOperation>)loadImageWithURL:(nullable NSURL *)url
-                                     options:(SDWebImageOptions)options
-                                    progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
-                                   completed:(nonnull SDInternalCompletionBlock)completedBlock {
+- (id<SDWebImageOperation>)loadImageWithURL:(NSURL *)url options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDInternalCompletionBlock)completedBlock {
+    return [self loadImageWithURL:url options:options progress:progressBlock completed:completedBlock context:nil];
+}
+
+- (id<SDWebImageOperation>)loadImageWithURL:(nullable NSURL *)url
+                                    options:(SDWebImageOptions)options
+                                   progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
+                                  completed:(nonnull SDInternalCompletionBlock)completedBlock
+                                    context:(nullable SDWebImageContext *)context {
     // Invoking this method without a completedBlock is pointless
     NSAssert(completedBlock != nil, @"If you mean to prefetch the image, use -[SDWebImagePrefetcher prefetchURLs] instead");
 
@@ -250,7 +255,7 @@
                 if (finished) {
                     [self safelyRemoveOperationFromRunning:strongSubOperation];
                 }
-            }];
+            } context:context];
         } else if (cachedImage) {
             [self callCompletionBlockForOperation:strongOperation completion:completedBlock image:cachedImage data:cachedData error:nil cacheType:cacheType finished:YES url:url];
             [self safelyRemoveOperationFromRunning:strongOperation];
@@ -259,7 +264,7 @@
             [self callCompletionBlockForOperation:strongOperation completion:completedBlock image:nil data:nil error:nil cacheType:SDImageCacheTypeNone finished:YES url:url];
             [self safelyRemoveOperationFromRunning:strongOperation];
         }
-    }];
+    } context:context];
 
     return operation;
 }

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -161,7 +161,7 @@ static char TAG_ACTIVITY_SHOW;
                     callCompletedBlockClojure();
                 });
             }
-        }];
+        } context:context];
         [self sd_setImageLoadOperation:operation forKey:validOperationKey];
     } else {
         dispatch_main_async_safe(^{


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2166

### Pull Request Description

t seems that there are always some trick logic specify for some rare use case :). We should make our lib more flexible for these changes.

I think, we should use a context which should be passed from the UIView category(top) to the manager, downloader(bottom) and connect all the process. Each important API should reserve this context and we can then add some specify logic. And the good thing is that we do not need to change API again and again.

See Kingfisher's [KingfisherOptionsInfo]( https://github.com/onevcat/Kingfisher/blob/master/Sources/KingfisherOptionsInfo.swift) design. It take advantage of Swift's powerful `enum`(Which you can bind a `object`, `block` and even `multiple value` but not a simple integer) and make their lib more flexible to develop. Sadly, we can not do this by our `SDWebImageOptions` in Objective-C, but we can use one `NSDictionary` context arg to pass any specify logic as well. It's looks betther than add more and more args without limit. The `context` arg in `UIView+WebCache.h` is added during SD 4.2 and it seems solve some issue, maybe we can make this further.

