### PR TITLE
Add sync version API diskImageDataExistsWithKey and keep thread-safe. Add diskCacheWritingOptions

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -172,6 +172,13 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 - (void)diskImageExistsWithKey:(nullable NSString *)key completion:(nullable SDWebImageCheckCacheCompletionBlock)completionBlock;
 
 /**
+ *  Sync check if image data exists in disk cache already (does not load the image)
+ *
+ *  @param key             the key describing the url
+ */
+- (BOOL)diskImageDataExistsWithKey:(nullable NSString *)key;
+
+/**
  * Operation that queries the cache asynchronously and call the completion when done.
  *
  * @param key       The unique key used to store the wanted image

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -106,14 +106,6 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)checkIfQueueIsIOQueue {
-    const char *currentQueueLabel = dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL);
-    const char *ioQueueLabel = dispatch_queue_get_label(self.ioQueue);
-    if (strcmp(currentQueueLabel, ioQueueLabel) != 0) {
-        NSLog(@"This method should be called from the ioQueue");
-    }
-}
-
 #pragma mark - Cache paths
 
 - (void)addReadOnlyCachePath:(nonnull NSString *)path {
@@ -201,7 +193,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
                     }
                     data = [[SDWebImageCodersManager sharedInstance] encodedDataWithImage:image format:format];
                 }
-                [self storeImageDataToDisk:data forKey:key];
+                [self _storeImageDataToDisk:data forKey:key];
             }
             
             if (completionBlock) {
@@ -221,8 +213,16 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     if (!imageData || !key) {
         return;
     }
-    
-    [self checkIfQueueIsIOQueue];
+    dispatch_sync(self.ioQueue, ^{
+        [self _storeImageDataToDisk:imageData forKey:key];
+    });
+}
+
+// Make sure to call form io queue by caller
+- (void)_storeImageDataToDisk:(nullable NSData *)imageData forKey:(nullable NSString *)key {
+    if (!imageData || !key) {
+        return;
+    }
     
     if (![_fileManager fileExistsAtPath:_diskCachePath]) {
         [_fileManager createDirectoryAtPath:_diskCachePath withIntermediateDirectories:YES attributes:nil error:NULL];
@@ -233,7 +233,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     // transform to NSUrl
     NSURL *fileURL = [NSURL fileURLWithPath:cachePathForKey];
     
-    [_fileManager createFileAtPath:cachePathForKey contents:imageData attributes:nil];
+    [imageData writeToURL:fileURL options:self.config.diskCacheWritingOptions error:nil];
     
     // disable iCloud backup
     if (self.config.shouldDisableiCloud) {
@@ -244,21 +244,42 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 #pragma mark - Query and Retrieve Ops
 
 - (void)diskImageExistsWithKey:(nullable NSString *)key completion:(nullable SDWebImageCheckCacheCompletionBlock)completionBlock {
-    dispatch_async(_ioQueue, ^{
-        BOOL exists = [_fileManager fileExistsAtPath:[self defaultCachePathForKey:key]];
-
-        // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
-        // checking the key with and without the extension
-        if (!exists) {
-            exists = [_fileManager fileExistsAtPath:[self defaultCachePathForKey:key].stringByDeletingPathExtension];
-        }
-
+    dispatch_async(self.ioQueue, ^{
+        BOOL exists = [self _diskImageDataExistsWithKey:key];
         if (completionBlock) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 completionBlock(exists);
             });
         }
     });
+}
+
+- (BOOL)diskImageDataExistsWithKey:(nullable NSString *)key {
+    if (!key) {
+        return NO;
+    }
+    __block BOOL exists = NO;
+    dispatch_sync(self.ioQueue, ^{
+        exists = [self _diskImageDataExistsWithKey:key];
+    });
+    
+    return exists;
+}
+
+// Make sure to call form io queue by caller
+- (BOOL)_diskImageDataExistsWithKey:(nullable NSString *)key {
+    if (!key) {
+        return NO;
+    }
+    BOOL exists = [_fileManager fileExistsAtPath:[self defaultCachePathForKey:key]];
+    
+    // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
+    // checking the key with and without the extension
+    if (!exists) {
+        exists = [_fileManager fileExistsAtPath:[self defaultCachePathForKey:key].stringByDeletingPathExtension];
+    }
+    
+    return exists;
 }
 
 - (nullable UIImage *)imageFromMemoryCacheForKey:(nullable NSString *)key {

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -29,9 +29,15 @@
 
 /**
  * The reading options while reading cache from disk.
- * Defaults to 0. You can set this to mapped file to improve performance.
+ * Defaults to 0. You can set this to `NSDataReadingMappedIfSafe` to improve performance.
  */
 @property (assign, nonatomic) NSDataReadingOptions diskCacheReadingOptions;
+
+/**
+ * The writing options while writing cache to disk.
+ * Defaults to `NSDataWritingAtomic`. You can set this to `NSDataWritingWithoutOverwriting` to prevent overwriting an existing file.
+ */
+@property (assign, nonatomic) NSDataWritingOptions diskCacheWritingOptions;
 
 /**
  * The maximum length of time to keep an image in the cache, in seconds.

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -18,6 +18,7 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
         _shouldDisableiCloud = YES;
         _shouldCacheImagesInMemory = YES;
         _diskCacheReadingOptions = 0;
+        _diskCacheWritingOptions = NSDataWritingAtomic;
         _maxCacheAge = kDefaultCacheMaxCacheAge;
         _maxCacheSize = 0;
     }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2151

### Pull Request Description

This PR contains some part of #2151. Why I create this again is that this `diskImageDataExistsWithKey` is actually important for some user who need extra logic(Such as use downloader for non-UI related stuff). These user understand that sync version API should call from backrgound queue to avoid blocking main queue. And our lib itself does not use this sync version API so there is no influence to the current behavior.

This is not a API-break change and the implementation change is really simple. I know the context that why we remove that sync version API to check image exist. But that is becasuse SD 3.x expose `self.ioQueue` to public. And if user call from `self.ioQueue` with `dispatch_sync`, the deadlock occur.

But now, we do not expose this queue to public, so the deadlock will not happend. For thread-safe issue, it's really simple, we can just put a `internal` API without queue check. Let our public API call the internal API to make sure the `NSFileManager` is always on the `self.ioQueue`.

I test this with the different queue access with no issue. The same method has already existed on my real application for long time (We write a category for `SDImageCache` :)). So maybe we should adopt this to 4.x.
