### PR TITLE
Refactor the implementation of SDWebImagePrefetcher

### DIFF
--- a/SDWebImage/SDWebImagePrefetcher.h
+++ b/SDWebImage/SDWebImagePrefetcher.h
@@ -11,12 +11,18 @@
 
 @class SDWebImagePrefetcher;
 
+@interface SDWebImagePrefetchToken : NSObject <SDWebImageOperation>
+
+@property (nonatomic, copy, readonly, nullable) NSArray<NSURL *> *urls;
+
+@end
+
 @protocol SDWebImagePrefetcherDelegate <NSObject>
 
 @optional
 
 /**
- * Called when an image was prefetched.
+ * Called when an image was prefetched. Which means it's called when one URL from any of prefetching finished.
  *
  * @param imagePrefetcher The current image prefetcher
  * @param imageURL        The image url that was prefetched
@@ -26,7 +32,7 @@
 - (void)imagePrefetcher:(nonnull SDWebImagePrefetcher *)imagePrefetcher didPrefetchURL:(nullable NSURL *)imageURL finishedCount:(NSUInteger)finishedCount totalCount:(NSUInteger)totalCount;
 
 /**
- * Called when all images are prefetched.
+ * Called when all images are prefetched. Which means it's called when all URLs from all of prefetching finished.
  * @param imagePrefetcher The current image prefetcher
  * @param totalCount      The total number of images that were prefetched (whether successful or not)
  * @param skippedCount    The total number of images that were skipped
@@ -54,15 +60,23 @@ typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger noOfFinishedUrls, 
 @property (nonatomic, assign) NSUInteger maxConcurrentDownloads;
 
 /**
- * SDWebImageOptions for prefetcher. Defaults to SDWebImageLowPriority.
+ * The options for prefetcher. Defaults to SDWebImageLowPriority.
  */
 @property (nonatomic, assign) SDWebImageOptions options;
 
 /**
- * Queue options for Prefetcher. Defaults to Main Queue.
+ * The context for prefetcher. Defaults to nil.
+ */
+@property (nonatomic, copy, nullable) SDWebImageContext *context;
+
+/**
+ * Queue options for prefetcher when call the progressBlock, completionBlock and delegate methods. Defaults to Main Queue.
  */
 @property (strong, nonatomic, nonnull) dispatch_queue_t prefetcherQueue;
 
+/**
+ * The delegate for the prefetcher.
+ */
 @property (weak, nonatomic, nullable) id <SDWebImagePrefetcherDelegate> delegate;
 
 /**
@@ -76,35 +90,35 @@ typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger noOfFinishedUrls, 
 - (nonnull instancetype)initWithImageManager:(nonnull SDWebImageManager *)manager NS_DESIGNATED_INITIALIZER;
 
 /**
- * Assign list of URLs to let SDWebImagePrefetcher to queue the prefetching,
- * currently one image is downloaded at a time,
- * and skips images for failed downloads and proceed to the next image in the list.
- * Any previously-running prefetch operations are canceled.
+ * Assign list of URLs to let SDWebImagePrefetcher to queue the prefetching. It based on the image manager so the image may from the cache and network according to the `options` property.
+ * Prefetching is seperate to each other, which means the progressBlock and completionBlock you provide is bind to the prefetching for the list of urls.
+ * Attention that call this will not cancel previous fetched urls. You should keep the token return by this to cancel or cancel all the prefetch.
  *
  * @param urls list of URLs to prefetch
+ * @return the token to cancel the current prefetching.
  */
-- (void)prefetchURLs:(nullable NSArray<NSURL *> *)urls;
+- (nullable SDWebImagePrefetchToken *)prefetchURLs:(nullable NSArray<NSURL *> *)urls;
 
 /**
- * Assign list of URLs to let SDWebImagePrefetcher to queue the prefetching,
- * currently one image is downloaded at a time,
- * and skips images for failed downloads and proceed to the next image in the list.
- * Any previously-running prefetch operations are canceled.
+ * Assign list of URLs to let SDWebImagePrefetcher to queue the prefetching. It based on the image manager so the image may from the cache and network according to the `options` property.
+ * Prefetching is seperate to each other, which means the progressBlock and completionBlock you provide is bind to the prefetching for the list of urls.
+ * Attention that call this will not cancel previous fetched urls. You should keep the token return by this to cancel or cancel all the prefetch.
  *
  * @param urls            list of URLs to prefetch
  * @param progressBlock   block to be called when progress updates; 
  *                        first parameter is the number of completed (successful or not) requests, 
  *                        second parameter is the total number of images originally requested to be prefetched
- * @param completionBlock block to be called when prefetching is completed
+ * @param completionBlock block to be called when the current prefetching is completed
  *                        first param is the number of completed (successful or not) requests,
  *                        second parameter is the number of skipped requests
+ * @return the token to cancel the current prefetching.
  */
-- (void)prefetchURLs:(nullable NSArray<NSURL *> *)urls
-            progress:(nullable SDWebImagePrefetcherProgressBlock)progressBlock
-           completed:(nullable SDWebImagePrefetcherCompletionBlock)completionBlock;
+- (nullable SDWebImagePrefetchToken *)prefetchURLs:(nullable NSArray<NSURL *> *)urls
+                                          progress:(nullable SDWebImagePrefetcherProgressBlock)progressBlock
+                                         completed:(nullable SDWebImagePrefetcherCompletionBlock)completionBlock;
 
 /**
- * Remove and cancel queued list
+ * Remove and cancel all the prefeching for the prefetcher.
  */
 - (void)cancelPrefetching;
 

--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -7,17 +7,27 @@
  */
 
 #import "SDWebImagePrefetcher.h"
+#import <libkern/OSAtomic.h>
+
+@interface SDWebImagePrefetchToken () {
+    @public
+    int64_t _skippedCount;
+    int64_t _finishedCount;
+}
+
+@property (nonatomic, copy, readwrite) NSArray<NSURL *> *urls;
+@property (nonatomic, assign) int64_t totalCount;
+@property (nonatomic, strong) NSMutableArray<id<SDWebImageOperation>> *operations;
+@property (nonatomic, weak) SDWebImagePrefetcher *prefetcher;
+@property (nonatomic, copy, nullable) SDWebImagePrefetcherCompletionBlock completionBlock;
+@property (nonatomic, copy, nullable) SDWebImagePrefetcherProgressBlock progressBlock;
+
+@end
 
 @interface SDWebImagePrefetcher ()
 
 @property (strong, nonatomic, nonnull) SDWebImageManager *manager;
-@property (strong, atomic, nullable) NSArray<NSURL *> *prefetchURLs; // may be accessed from different queue
-@property (assign, nonatomic) NSUInteger requestedCount;
-@property (assign, nonatomic) NSUInteger skippedCount;
-@property (assign, nonatomic) NSUInteger finishedCount;
-@property (assign, nonatomic) NSTimeInterval startedTime;
-@property (copy, nonatomic, nullable) SDWebImagePrefetcherCompletionBlock completionBlock;
-@property (copy, nonatomic, nullable) SDWebImagePrefetcherProgressBlock progressBlock;
+@property (strong, atomic, nonnull) NSMutableSet<SDWebImagePrefetchToken *> *runningTokens;
 
 @end
 
@@ -39,6 +49,7 @@
 - (nonnull instancetype)initWithImageManager:(SDWebImageManager *)manager {
     if ((self = [super init])) {
         _manager = manager;
+        _runningTokens = [NSMutableSet set];
         _options = SDWebImageLowPriority;
         _prefetcherQueue = dispatch_get_main_queue();
         self.maxConcurrentDownloads = 3;
@@ -54,91 +65,169 @@
     return self.manager.imageDownloader.maxConcurrentDownloads;
 }
 
-- (void)startPrefetchingAtIndex:(NSUInteger)index {
-    NSURL *currentURL;
-    @synchronized(self) {
-        if (index >= self.prefetchURLs.count) return;
-        currentURL = self.prefetchURLs[index];
-        self.requestedCount++;
-    }
-    [self.manager loadImageWithURL:currentURL options:self.options progress:nil completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
-        if (!finished) return;
-        self.finishedCount++;
-
-        if (self.progressBlock) {
-            self.progressBlock(self.finishedCount,(self.prefetchURLs).count);
-        }
-        if (!image) {
-            // Add last failed
-            self.skippedCount++;
-        }
-        if ([self.delegate respondsToSelector:@selector(imagePrefetcher:didPrefetchURL:finishedCount:totalCount:)]) {
-            [self.delegate imagePrefetcher:self
-                            didPrefetchURL:currentURL
-                             finishedCount:self.finishedCount
-                                totalCount:self.prefetchURLs.count
-             ];
-        }
-        if (self.prefetchURLs.count > self.requestedCount) {
-            dispatch_async(self.prefetcherQueue, ^{
-                // we need dispatch to avoid function recursion call. This can prevent stack overflow even for huge urls list
-                [self startPrefetchingAtIndex:self.requestedCount];
-            });
-        } else if (self.finishedCount == self.requestedCount) {
-            [self reportStatus];
-            if (self.completionBlock) {
-                self.completionBlock(self.finishedCount, self.skippedCount);
-                self.completionBlock = nil;
-            }
-            self.progressBlock = nil;
-        }
-    }];
+#pragma mark - Prefetch
+- (nullable SDWebImagePrefetchToken *)prefetchURLs:(nullable NSArray<NSURL *> *)urls {
+    return [self prefetchURLs:urls progress:nil completed:nil];
 }
 
-- (void)reportStatus {
-    NSUInteger total = (self.prefetchURLs).count;
-    if ([self.delegate respondsToSelector:@selector(imagePrefetcher:didFinishWithTotalCount:skippedCount:)]) {
-        [self.delegate imagePrefetcher:self
-               didFinishWithTotalCount:(total - self.skippedCount)
-                          skippedCount:self.skippedCount
-         ];
-    }
-}
-
-- (void)prefetchURLs:(nullable NSArray<NSURL *> *)urls {
-    [self prefetchURLs:urls progress:nil completed:nil];
-}
-
-- (void)prefetchURLs:(nullable NSArray<NSURL *> *)urls
-            progress:(nullable SDWebImagePrefetcherProgressBlock)progressBlock
-           completed:(nullable SDWebImagePrefetcherCompletionBlock)completionBlock {
-    [self cancelPrefetching]; // Prevent duplicate prefetch request
-    self.startedTime = CFAbsoluteTimeGetCurrent();
-    self.prefetchURLs = urls;
-    self.completionBlock = completionBlock;
-    self.progressBlock = progressBlock;
-
-    if (urls.count == 0) {
+- (nullable SDWebImagePrefetchToken *)prefetchURLs:(nullable NSArray<NSURL *> *)urls
+                                          progress:(nullable SDWebImagePrefetcherProgressBlock)progressBlock
+                                         completed:(nullable SDWebImagePrefetcherCompletionBlock)completionBlock {
+    if (!urls || urls.count == 0) {
         if (completionBlock) {
-            completionBlock(0,0);
+            completionBlock(0, 0);
         }
-    } else {
-        // Starts prefetching from the very first image on the list with the max allowed concurrency
-        NSUInteger listCount = self.prefetchURLs.count;
-        for (NSUInteger i = 0; i < self.maxConcurrentDownloads && self.requestedCount < listCount; i++) {
-            [self startPrefetchingAtIndex:i];
-        }
+        return nil;
+    }
+    SDWebImagePrefetchToken *token = [SDWebImagePrefetchToken new];
+    token.prefetcher = self;
+    token->_skippedCount = 0;
+    token->_finishedCount = 0;
+    token.urls = urls;
+    token.totalCount = urls.count;
+    token.operations = [NSMutableArray arrayWithCapacity:urls.count];
+    token.progressBlock = progressBlock;
+    token.completionBlock = completionBlock;
+    [self addRunningToken:token];
+    
+    for (NSURL *url in urls) {
+        __weak typeof(self) wself = self;
+        id<SDWebImageOperation> operation = [self.manager loadImageWithURL:url options:self.options progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+            __strong typeof(wself) sself = wself;
+            if (!sself) {
+                return;
+            }
+            if (!finished) {
+                return;
+            }
+            OSAtomicIncrement64(&(token->_finishedCount));
+            if (error) {
+                // Add last failed
+                OSAtomicIncrement64(&(token->_skippedCount));
+            }
+            
+            // Current operation finished
+            [sself callProgressBlockForToken:token imageURL:imageURL];
+            
+            if (token->_finishedCount + token->_skippedCount == token.totalCount) {
+                // All finished
+                [sself callCompletionBlockForToken:token];
+                [sself removeRunningToken:token];
+            }
+        } context:self.context];
+        [token.operations addObject:operation];
+    }
+    
+    return token;
+}
+
+#pragma mark - Cancel
+- (void)cancelPrefetching {
+    @synchronized(self.runningTokens) {
+        NSSet<SDWebImagePrefetchToken *> *copiedTokens = [self.runningTokens copy];
+        [copiedTokens makeObjectsPerformSelector:@selector(cancel)];
+        [self.runningTokens removeAllObjects];
     }
 }
 
-- (void)cancelPrefetching {
-    @synchronized(self) {
-        self.prefetchURLs = nil;
-        self.skippedCount = 0;
-        self.requestedCount = 0;
-        self.finishedCount = 0;
+- (void)callProgressBlockForToken:(SDWebImagePrefetchToken *)token imageURL:(NSURL *)url {
+    if (!token) {
+        return;
     }
-    [self.manager cancelAll];
+    BOOL shouldCallDelegate = [self.delegate respondsToSelector:@selector(imagePrefetcher:didPrefetchURL:finishedCount:totalCount:)];
+    dispatch_queue_async_safe(self.prefetcherQueue, ^{
+        if (shouldCallDelegate) {
+            [self.delegate imagePrefetcher:self didPrefetchURL:url finishedCount:[self tokenFinishedCount] totalCount:[self tokenTotalCount]];
+        }
+        if (token.progressBlock) {
+            token.progressBlock((NSUInteger)token->_finishedCount, (NSUInteger)token.totalCount);
+        }
+    });
+}
+
+- (void)callCompletionBlockForToken:(SDWebImagePrefetchToken *)token {
+    if (!token) {
+        return;
+    }
+    BOOL shoulCallDelegate = [self.delegate respondsToSelector:@selector(imagePrefetcher:didFinishWithTotalCount:skippedCount:)] && ([self countOfRunningTokens] == 1); // last one
+    dispatch_queue_async_safe(self.prefetcherQueue, ^{
+        if (shoulCallDelegate) {
+            [self.delegate imagePrefetcher:self didFinishWithTotalCount:[self tokenTotalCount] skippedCount:[self tokenSkippedCount]];
+        }
+        if (token.completionBlock) {
+            token.completionBlock((NSUInteger)token->_finishedCount, (NSUInteger)token->_skippedCount);
+        }
+    });
+}
+
+#pragma mark - Helper
+- (NSUInteger)tokenTotalCount {
+    NSUInteger tokenTotalCount = 0;
+    @synchronized (self.runningTokens) {
+        for (SDWebImagePrefetchToken *token in self.runningTokens) {
+            tokenTotalCount += token.totalCount;
+        }
+    }
+    return tokenTotalCount;
+}
+
+- (NSUInteger)tokenSkippedCount {
+    NSUInteger tokenSkippedCount = 0;
+    @synchronized (self.runningTokens) {
+        for (SDWebImagePrefetchToken *token in self.runningTokens) {
+            tokenSkippedCount += token->_skippedCount;
+        }
+    }
+    return tokenSkippedCount;
+}
+
+- (NSUInteger)tokenFinishedCount {
+    NSUInteger tokenFinishedCount = 0;
+    @synchronized (self.runningTokens) {
+        for (SDWebImagePrefetchToken *token in self.runningTokens) {
+            tokenFinishedCount += token->_finishedCount;
+        }
+    }
+    return tokenFinishedCount;
+}
+
+- (void)addRunningToken:(SDWebImagePrefetchToken *)token {
+    if (!token) {
+        return;
+    }
+    @synchronized (self.runningTokens) {
+        [self.runningTokens addObject:token];
+    }
+}
+
+- (void)removeRunningToken:(SDWebImagePrefetchToken *)token {
+    if (!token) {
+        return;
+    }
+    @synchronized (self.runningTokens) {
+        [self.runningTokens removeObject:token];
+    }
+}
+
+- (NSUInteger)countOfRunningTokens {
+    NSUInteger count = 0;
+    @synchronized (self.runningTokens) {
+        count = self.runningTokens.count;
+    }
+    return count;
+}
+
+@end
+
+@implementation SDWebImagePrefetchToken
+
+- (void)cancel {
+    @synchronized (self) {
+        for (id<SDWebImageOperation> operation in self.operations) {
+            [operation cancel];
+        }
+    }
+    [self.prefetcher removeRunningToken:self];
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass - **Passed**. And add two more tests for prefetcher
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1679 

### Pull Request Description

### Reason

Our `SDWebImagePrefetcher` seems design to use like a normal object but not to used as a `sharedPrefetcher`. Currently its implementation will cancel all the current request when you call `prefetchURLs`. So if you use the shared prefetcher somewhere to prefetch one url list, and another background queue start to prefetch another url list, all of your first request will be canceled and even the completion block will never called(This seems a bug). This is too misunderstanding and this cause some issue in my real application. Many programmers does not aware of this behavior when using.

And always, the #1679 show that some user want to cancel the specify urls because they do not want to affect the current requested urls. However, this can not be solved in current implementation from the design. Because the prefetcher works based on **only one** urls lists and **only one** progressBlock and completionBlock. If you remove one, the finished count or skipped will mess up.

And more interesting, our `SDWebImageManger` make a assert when you provide a nil completionBlock.

> If you mean to prefetch the image, use -[SDWebImagePrefetcher prefetchURLs] instead

It recommends you to use the prefetcher. However, user may get in trouble because these two works in really different ways. Maybe we should redesign the prefetcher to make it more conforming to intuition.

### Design and Implementation

So this refactor, reimplementation the prefetcher from the scratch design. Now, prefetcher do not cancel previous request and it separate different prefetching process. Which means it take your `urls, progressBlock, completionBlock` to bind with a context `SDWebImagePrefetchToken`. So when you call `prefetchURLs` twice, you get another different prefetching progress. You can cancel the token returned by `prefetchURLs` and this will not affect other running requests, only the `urls` associated to the token will be cancelled. This's is acceptable because this based on the manager, so you can hit the cache to return immediatelly. And if the cache miss, our downloader will reuse the download operation so you do not waste extra bandwidth to download same url twice.

This make that our `sharedPrefetcher` works more famillar like a shared instance. For normal use case like prefetching from a background queue, you do not need to worry about about someone cancel your prefeching from anywhere like a **scout** and have no choice to create a new prefetcher instance instead. You can simply call `prefetchURLs` on the shared instance with your own urls and your own completionBlock. And the self-alloc instance is still useful when you want to custom the options, context and delegate callback queue.(Now we introduce a `context` to pass some options which can not be represented by a enum)

For the delegate, we keep this because it's useful for some use cases like metrics and logger. But now, since we make the that prefetching associate to a context, we should also update the comment to point this out. The `-[SDWebImagePrefetcherDelegate imagePrefetcher:didFinishWithTotalCount:skippedCount:]` now called only all the urls from each prefeching context finished. And the `-[SDWebImagePrefetcherDelegate imagePrefetcher:didPrefetchURL:finishedCount:totalCount:]` now called any of urls from any prefetching context finished. This can make it more clear to use.

### API Change

And finally, about API changes. This refactoring actually does not change any of public API at all :) Because the change is more on the concept and implementation. Through, for normal usage, people will not find any difference between this two and even all the current tests for prefetcher passed without any modification. But since it's a big change for usage in some cases, We should mark this as 5.x

Note for Swift user, since Swift treat a unused value as a compile error, and the current API will  now return a `SDWebImagePrefetchToken` instance instead of void, so this is API-breaking for Swift user.