### PR TITLE
Refactor cache - Support custom memory cache and disk cache

### DIFF
--- a/Examples/SDWebImage Demo/AppDelegate.m
+++ b/Examples/SDWebImage Demo/AppDelegate.m
@@ -21,7 +21,10 @@
 {
     //Add a custom read-only cache path
     NSString *bundledPath = [[NSBundle mainBundle].resourcePath stringByAppendingPathComponent:@"CustomPathImages"];
-    [[SDImageCache sharedImageCache] addReadOnlyCachePath:bundledPath];
+    [SDImageCache sharedImageCache].additionalCachePathBlock = ^NSString * _Nullable(NSString * _Nonnull key) {
+        NSString *fileName = [[SDImageCache sharedImageCache] cachePathForKey:key].lastPathComponent;
+        return [bundledPath stringByAppendingPathComponent:fileName.stringByDeletingPathExtension];
+    };
 
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     // Override point for customization after application launch.

--- a/Examples/SDWebImage Demo/MasterViewController.m
+++ b/Examples/SDWebImage Demo/MasterViewController.m
@@ -85,8 +85,7 @@
 
 - (void)flushCache
 {
-    [SDWebImageManager.sharedManager.imageCache clearMemory];
-    [SDWebImageManager.sharedManager.imageCache clearDiskOnCompletion:nil];
+    [SDWebImageManager.sharedManager.imageCache clearWithCacheType:SDImageCacheTypeBoth completion:nil];
 }
 							
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -484,12 +484,12 @@
 		32CF1C101FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
 		32CF1C111FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
 		32CF1C121FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
-		32D6FE28207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
-		32D6FE29207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
-		32D6FE2A207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
-		32D6FE2B207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
-		32D6FE2C207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
-		32D6FE2D207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
+		32D6FE28207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D6FE29207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D6FE2A207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D6FE2B207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D6FE2C207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D6FE2D207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D6FE2E207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */; };
 		32D6FE2F207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */; };
 		32D6FE30207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */; };

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -400,6 +400,18 @@
 		325312D1200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
 		325312D2200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
 		325312D3200F09910046BF1E /* SDWebImageTransition.m in Sources */ = {isa = PBXBuildFile; fileRef = 325312C7200F09910046BF1E /* SDWebImageTransition.m */; };
+		325DBEA4207119DA008C6700 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 325DBEA2207119DA008C6700 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		325DBEA5207119DA008C6700 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 325DBEA2207119DA008C6700 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		325DBEA6207119DA008C6700 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 325DBEA2207119DA008C6700 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		325DBEA7207119DA008C6700 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 325DBEA2207119DA008C6700 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		325DBEA8207119DA008C6700 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 325DBEA2207119DA008C6700 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		325DBEA9207119DA008C6700 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 325DBEA2207119DA008C6700 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		325DBEAA207119DA008C6700 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 325DBEA3207119DA008C6700 /* SDWebImageCache.m */; };
+		325DBEAB207119DA008C6700 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 325DBEA3207119DA008C6700 /* SDWebImageCache.m */; };
+		325DBEAC207119DA008C6700 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 325DBEA3207119DA008C6700 /* SDWebImageCache.m */; };
+		325DBEAD207119DA008C6700 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 325DBEA3207119DA008C6700 /* SDWebImageCache.m */; };
+		325DBEAE207119DA008C6700 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 325DBEA3207119DA008C6700 /* SDWebImageCache.m */; };
+		325DBEAF207119DA008C6700 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 325DBEA3207119DA008C6700 /* SDWebImageCache.m */; };
 		327054D4206CD8B3006EA328 /* SDWebImageAPNGCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 327054D2206CD8B3006EA328 /* SDWebImageAPNGCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327054D5206CD8B3006EA328 /* SDWebImageAPNGCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 327054D2206CD8B3006EA328 /* SDWebImageAPNGCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		327054D6206CD8B3006EA328 /* SDWebImageAPNGCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 327054D2206CD8B3006EA328 /* SDWebImageAPNGCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -472,6 +484,18 @@
 		32CF1C101FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
 		32CF1C111FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
 		32CF1C121FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
+		32D6FE28207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
+		32D6FE29207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
+		32D6FE2A207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
+		32D6FE2B207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
+		32D6FE2C207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
+		32D6FE2D207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */; };
+		32D6FE2E207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */; };
+		32D6FE2F207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */; };
+		32D6FE30207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */; };
+		32D6FE31207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */; };
+		32D6FE32207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */; };
+		32D6FE33207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */; };
 		32EB6D8E206D132E005CAEF6 /* SDAnimatedImageRep.m in Sources */ = {isa = PBXBuildFile; fileRef = 320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */; };
 		32EB6D8F206D132E005CAEF6 /* SDAnimatedImageRep.m in Sources */ = {isa = PBXBuildFile; fileRef = 320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */; };
 		32EB6D90206D132E005CAEF6 /* SDAnimatedImageRep.m in Sources */ = {isa = PBXBuildFile; fileRef = 320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */; };
@@ -1518,6 +1542,8 @@
 		324DF4B3200A14DC008A84CC /* SDWebImageDefine.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDefine.m; sourceTree = "<group>"; };
 		325312C6200F09910046BF1E /* SDWebImageTransition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageTransition.h; sourceTree = "<group>"; };
 		325312C7200F09910046BF1E /* SDWebImageTransition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageTransition.m; sourceTree = "<group>"; };
+		325DBEA2207119DA008C6700 /* SDWebImageCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageCache.h; sourceTree = "<group>"; };
+		325DBEA3207119DA008C6700 /* SDWebImageCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageCache.m; sourceTree = "<group>"; };
 		327054D2206CD8B3006EA328 /* SDWebImageAPNGCoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDWebImageAPNGCoder.h; sourceTree = "<group>"; };
 		327054D3206CD8B3006EA328 /* SDWebImageAPNGCoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageAPNGCoder.m; sourceTree = "<group>"; };
 		3290FA021FA478AF0047D20C /* SDWebImageFrame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageFrame.h; sourceTree = "<group>"; };
@@ -1532,6 +1558,8 @@
 		32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageCoderHelper.m; sourceTree = "<group>"; };
 		32F21B4F20788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageDownloaderRequestModifier.h; sourceTree = "<group>"; };
 		32F21B5020788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDownloaderRequestModifier.m; sourceTree = "<group>"; };
+		32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageCachesManager.h; sourceTree = "<group>"; };
+		32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageCachesManager.m; sourceTree = "<group>"; };
 		32F7C06D2030114C00873181 /* SDWebImageTransformer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageTransformer.h; sourceTree = "<group>"; };
 		32F7C06E2030114C00873181 /* SDWebImageTransformer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageTransformer.m; sourceTree = "<group>"; };
 		32F7C07C2030719600873181 /* UIImage+Transform.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Transform.m"; sourceTree = "<group>"; };
@@ -2017,6 +2045,10 @@
 				3216093E2018A176008CBBC2 /* SDMemoryCache.m */,
 				3216094B2018A181008CBBC2 /* SDDiskCache.h */,
 				3216094C2018A181008CBBC2 /* SDDiskCache.m */,
+				325DBEA2207119DA008C6700 /* SDWebImageCache.h */,
+				325DBEA3207119DA008C6700 /* SDWebImageCache.m */,
+				32D6FE26207183E20033DBC5 /* SDWebImageCachesManager.h */,
+				32D6FE27207183E20033DBC5 /* SDWebImageCachesManager.m */,
 			);
 			name = Cache;
 			sourceTree = "<group>";
@@ -2239,6 +2271,7 @@
 				4317395A1CDFC8B70008FEB9 /* mux_types.h in Headers */,
 				431739561CDFC8B70008FEB9 /* demux.h in Headers */,
 				32B9B53A206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */,
+				325DBEA7207119DA008C6700 /* SDWebImageCache.h in Headers */,
 				80377C4A1F2F666300F89830 /* bit_writer_utils.h in Headers */,
 				4397D2F81D0DF44200BB2784 /* MKAnnotationView+WebCache.h in Headers */,
 				323F8BE71F38EF770092B609 /* vp8li_enc.h in Headers */,
@@ -2305,6 +2338,7 @@
 				3248476C201775F600AF9E5A /* SDAnimatedImageView.h in Headers */,
 				80377C5F1F2F666300F89830 /* utils.h in Headers */,
 				80377C5B1F2F666300F89830 /* rescaler_utils.h in Headers */,
+				32D6FE2B207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */,
 				323F8BF91F38EF770092B609 /* animi.h in Headers */,
 				32F7C0872030719600873181 /* UIImage+Transform.h in Headers */,
 				80377C4F1F2F666300F89830 /* filters_utils.h in Headers */,
@@ -2331,6 +2365,7 @@
 				3290FA051FA478AF0047D20C /* SDWebImageFrame.h in Headers */,
 				80377C1D1F2F666300F89830 /* huffman_encode_utils.h in Headers */,
 				321E60B11F38E90100405457 /* SDWebImageWebPCoder.h in Headers */,
+				325DBEA5207119DA008C6700 /* SDWebImageCache.h in Headers */,
 				80377E9A1F2F66D400F89830 /* common_dec.h in Headers */,
 				327054D5206CD8B3006EA328 /* SDWebImageAPNGCoder.h in Headers */,
 				32B9B538206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */,
@@ -2370,6 +2405,7 @@
 				80377C271F2F666300F89830 /* rescaler_utils.h in Headers */,
 				323F8B511F38EF770092B609 /* backward_references_enc.h in Headers */,
 				325312C9200F09910046BF1E /* SDWebImageTransition.h in Headers */,
+				32D6FE29207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */,
 				43A918651D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
 				4314D1741D0E0E3B004B36C9 /* types.h in Headers */,
 				4314D1761D0E0E3B004B36C9 /* decode.h in Headers */,
@@ -2449,6 +2485,7 @@
 				321E60A61F38E8F600405457 /* SDWebImageGIFCoder.h in Headers */,
 				431BB6E71D06D2C1006A3455 /* SDWebImageCompat.h in Headers */,
 				80377E211F2F66A800F89830 /* neon.h in Headers */,
+				32D6FE2C207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */,
 				80377C711F2F666400F89830 /* quant_levels_utils.h in Headers */,
 				323F8B541F38EF770092B609 /* backward_references_enc.h in Headers */,
 				32F7C0882030719600873181 /* UIImage+Transform.h in Headers */,
@@ -2491,6 +2528,7 @@
 				32F7C0732030114C00873181 /* SDWebImageTransformer.h in Headers */,
 				431BB6FA1D06D2C1006A3455 /* SDWebImageDownloader.h in Headers */,
 				3248476D201775F600AF9E5A /* SDAnimatedImageView.h in Headers */,
+				325DBEA8207119DA008C6700 /* SDWebImageCache.h in Headers */,
 				80377DF51F2F66A800F89830 /* common_sse2.h in Headers */,
 				323F8BDC1F38EF770092B609 /* vp8i_enc.h in Headers */,
 				80377ED21F2F66D500F89830 /* vp8i_dec.h in Headers */,
@@ -2511,6 +2549,7 @@
 				32F7C0892030719600873181 /* UIImage+Transform.h in Headers */,
 				80377EDA1F2F66D500F89830 /* common_dec.h in Headers */,
 				321609442018A176008CBBC2 /* SDMemoryCache.h in Headers */,
+				325DBEA9207119DA008C6700 /* SDWebImageCache.h in Headers */,
 				80377EE61F2F66D500F89830 /* webpi_dec.h in Headers */,
 				32B9B53C206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */,
 				4397D2BA1D0DDD8C00BB2784 /* demux.h in Headers */,
@@ -2578,6 +2617,7 @@
 				321E608B1F38E8C800405457 /* SDWebImageCoder.h in Headers */,
 				323F8B731F38EF770092B609 /* delta_palettization_enc.h in Headers */,
 				321E60C31F38E91700405457 /* UIImage+ForceDecode.h in Headers */,
+				32D6FE2D207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */,
 				32484768201775F600AF9E5A /* SDAnimatedImageView+WebCache.h in Headers */,
 				80377E561F2F66A800F89830 /* lossless_common.h in Headers */,
 				4397D2E91D0DDD8C00BB2784 /* UIImage+WebP.h in Headers */,
@@ -2606,6 +2646,7 @@
 				4317394F1CDFC8B70008FEB9 /* demux.h in Headers */,
 				43CE757D1CFE9427006C64D0 /* FLAnimatedImageView.h in Headers */,
 				32B9B539206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */,
+				325DBEA6207119DA008C6700 /* SDWebImageCache.h in Headers */,
 				80377C301F2F666300F89830 /* bit_writer_utils.h in Headers */,
 				431739541CDFC8B70008FEB9 /* types.h in Headers */,
 				323F8BE61F38EF770092B609 /* vp8li_enc.h in Headers */,
@@ -2672,6 +2713,7 @@
 				3248476B201775F600AF9E5A /* SDAnimatedImageView.h in Headers */,
 				4A2CAE311AB4BB7500B6BC39 /* UIImage+WebP.h in Headers */,
 				323F8BF81F38EF770092B609 /* animi.h in Headers */,
+				32D6FE2A207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */,
 				80377C351F2F666300F89830 /* filters_utils.h in Headers */,
 				32F7C0862030719600873181 /* UIImage+Transform.h in Headers */,
 				80377C321F2F666300F89830 /* color_cache_utils.h in Headers */,
@@ -2724,6 +2766,7 @@
 				80377D0B1F2F66A100F89830 /* mips_macro.h in Headers */,
 				329A18591FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */,
 				5376131A155AD0D5005750A4 /* SDWebImageDownloader.h in Headers */,
+				32D6FE28207183E20033DBC5 /* SDWebImageCachesManager.h in Headers */,
 				4369C2771D9807EC007E863A /* UIView+WebCache.h in Headers */,
 				80377CEF1F2F66A100F89830 /* dsp.h in Headers */,
 				32F21B5120788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.h in Headers */,
@@ -2768,6 +2811,7 @@
 				323F8B6E1F38EF770092B609 /* delta_palettization_enc.h in Headers */,
 				438096721CDFC08200DC626B /* MKAnnotationView+WebCache.h in Headers */,
 				43CE757C1CFE9427006C64D0 /* FLAnimatedImageView.h in Headers */,
+				325DBEA4207119DA008C6700 /* SDWebImageCache.h in Headers */,
 				80377E8A1F2F66D000F89830 /* common_dec.h in Headers */,
 				AB615303192DA24600A2D8E9 /* UIView+WebCacheOperation.h in Headers */,
 				323F8B501F38EF770092B609 /* backward_references_enc.h in Headers */,
@@ -3081,6 +3125,7 @@
 				80377DCA1F2F66A700F89830 /* filters_sse2.c in Sources */,
 				80377EBE1F2F66D500F89830 /* quant_dec.c in Sources */,
 				80377DB61F2F66A700F89830 /* dec_clip_tables.c in Sources */,
+				32D6FE31207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */,
 				80377C5E1F2F666300F89830 /* utils.c in Sources */,
 				32B9B540206ED4230026769D /* SDWebImageDownloaderConfig.m in Sources */,
 				323F8C0B1F38EF770092B609 /* muxedit.c in Sources */,
@@ -3124,6 +3169,7 @@
 				80377DD61F2F66A700F89830 /* lossless_neon.c in Sources */,
 				00733A5C1BC4880000A5A117 /* UIButton+WebCache.m in Sources */,
 				80377EC01F2F66D500F89830 /* vp8_dec.c in Sources */,
+				325DBEAD207119DA008C6700 /* SDWebImageCache.m in Sources */,
 				80377C521F2F666300F89830 /* huffman_utils.c in Sources */,
 				80377DD81F2F66A700F89830 /* lossless.c in Sources */,
 				80377DE11F2F66A700F89830 /* rescaler_sse2.c in Sources */,
@@ -3206,6 +3252,7 @@
 				4314D1341D0E0E3B004B36C9 /* UIImage+WebP.m in Sources */,
 				80377D3D1F2F66A700F89830 /* filters_mips_dsp_r2.c in Sources */,
 				323F8B751F38EF770092B609 /* filter_enc.c in Sources */,
+				325DBEAB207119DA008C6700 /* SDWebImageCache.m in Sources */,
 				80377D401F2F66A700F89830 /* filters_sse2.c in Sources */,
 				80377D1E1F2F66A700F89830 /* alpha_processing_mips_dsp_r2.c in Sources */,
 				80377D291F2F66A700F89830 /* cost_sse2.c in Sources */,
@@ -3247,6 +3294,7 @@
 				80377D2F1F2F66A700F89830 /* dec_msa.c in Sources */,
 				323F8C151F38EF770092B609 /* muxinternal.c in Sources */,
 				80377D571F2F66A700F89830 /* rescaler_sse2.c in Sources */,
+				32D6FE2F207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */,
 				43C892A11D9D6DDC0022038D /* demux.c in Sources */,
 				80377C131F2F666300F89830 /* bit_reader_utils.c in Sources */,
 				80377E9C1F2F66D400F89830 /* idec_dec.c in Sources */,
@@ -3365,6 +3413,7 @@
 				323F8BE21F38EF770092B609 /* vp8l_enc.c in Sources */,
 				431BB6A31D06D2C1006A3455 /* UIImageView+WebCache.m in Sources */,
 				80377E0C1F2F66A800F89830 /* filters_mips_dsp_r2.c in Sources */,
+				325DBEAE207119DA008C6700 /* SDWebImageCache.m in Sources */,
 				323F8B781F38EF770092B609 /* filter_enc.c in Sources */,
 				4369C2821D9807EC007E863A /* UIView+WebCache.m in Sources */,
 				80377E0F1F2F66A800F89830 /* filters_sse2.c in Sources */,
@@ -3406,6 +3455,7 @@
 				323F8BBE1F38EF770092B609 /* predictor_enc.c in Sources */,
 				80377E261F2F66A800F89830 /* rescaler_sse2.c in Sources */,
 				323F8C181F38EF770092B609 /* muxinternal.c in Sources */,
+				32D6FE32207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */,
 				80377C741F2F666400F89830 /* rescaler_utils.c in Sources */,
 				431BB6B11D06D2C1006A3455 /* UIView+WebCacheOperation.m in Sources */,
 				80377DF01F2F66A800F89830 /* alpha_processing_sse41.c in Sources */,
@@ -3540,6 +3590,7 @@
 				80377E551F2F66A800F89830 /* filters.c in Sources */,
 				80377E731F2F66A800F89830 /* yuv_mips32.c in Sources */,
 				4397D2911D0DDD8C00BB2784 /* MKAnnotationView+WebCache.m in Sources */,
+				32D6FE33207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */,
 				4397D2921D0DDD8C00BB2784 /* SDWebImagePrefetcher.m in Sources */,
 				323F8BBF1F38EF770092B609 /* predictor_enc.c in Sources */,
 				807A12331F89636300EC2A9B /* SDWebImageCodersManager.m in Sources */,
@@ -3553,6 +3604,7 @@
 				32F21B5C20788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.m in Sources */,
 				80377E3B1F2F66A800F89830 /* cost_mips_dsp_r2.c in Sources */,
 				4397D29B1D0DDD8C00BB2784 /* SDWebImageDownloader.m in Sources */,
+				325DBEAF207119DA008C6700 /* SDWebImageCache.m in Sources */,
 				80377E711F2F66A800F89830 /* upsampling.c in Sources */,
 				4397D29C1D0DDD8C00BB2784 /* NSData+ImageContentType.m in Sources */,
 				323F8BB31F38EF770092B609 /* picture_rescale_enc.c in Sources */,
@@ -3723,6 +3775,7 @@
 				80377D8D1F2F66A700F89830 /* lossless_enc_sse41.c in Sources */,
 				80377EAE1F2F66D400F89830 /* quant_dec.c in Sources */,
 				80377D6E1F2F66A700F89830 /* cost_sse2.c in Sources */,
+				32D6FE30207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */,
 				80377D991F2F66A700F89830 /* rescaler_mips32.c in Sources */,
 				32B9B53F206ED4230026769D /* SDWebImageDownloaderConfig.m in Sources */,
 				323F8C0A1F38EF770092B609 /* muxedit.c in Sources */,
@@ -3766,6 +3819,7 @@
 				80377EB51F2F66D400F89830 /* webp_dec.c in Sources */,
 				80377D701F2F66A700F89830 /* cpu.c in Sources */,
 				80377D911F2F66A700F89830 /* lossless_neon.c in Sources */,
+				325DBEAC207119DA008C6700 /* SDWebImageCache.m in Sources */,
 				80377EB01F2F66D400F89830 /* vp8_dec.c in Sources */,
 				80377C381F2F666300F89830 /* huffman_utils.c in Sources */,
 				80377C3A1F2F666300F89830 /* quant_levels_dec_utils.c in Sources */,
@@ -3886,6 +3940,7 @@
 				80377E8E1F2F66D000F89830 /* quant_dec.c in Sources */,
 				80377CE41F2F66A100F89830 /* cost_sse2.c in Sources */,
 				80377D0F1F2F66A100F89830 /* rescaler_mips32.c in Sources */,
+				32D6FE2E207183E20033DBC5 /* SDWebImageCachesManager.m in Sources */,
 				323F8C081F38EF770092B609 /* muxedit.c in Sources */,
 				32B9B53D206ED4230026769D /* SDWebImageDownloaderConfig.m in Sources */,
 				80377CFB1F2F66A100F89830 /* filters_sse2.c in Sources */,
@@ -3929,6 +3984,7 @@
 				80377CE61F2F66A100F89830 /* cpu.c in Sources */,
 				80377D071F2F66A100F89830 /* lossless_neon.c in Sources */,
 				80377E901F2F66D000F89830 /* vp8_dec.c in Sources */,
+				325DBEAA207119DA008C6700 /* SDWebImageCache.m in Sources */,
 				80377C041F2F665300F89830 /* huffman_utils.c in Sources */,
 				80377C061F2F665300F89830 /* quant_levels_dec_utils.c in Sources */,
 				80377D091F2F66A100F89830 /* lossless.c in Sources */,

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -39,6 +39,30 @@
 		00733A731BC4880E00A5A117 /* SDWebImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A2CAE031AB4BB5400B6BC39 /* SDWebImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		320224BB203979BA00E9F285 /* SDAnimatedImageRep.h in Headers */ = {isa = PBXBuildFile; fileRef = 320224B9203979BA00E9F285 /* SDAnimatedImageRep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		320224BC203979BA00E9F285 /* SDAnimatedImageRep.m in Sources */ = {isa = PBXBuildFile; fileRef = 320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */; };
+		3216093F2018A176008CBBC2 /* SDMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216093D2018A176008CBBC2 /* SDMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321609402018A176008CBBC2 /* SDMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216093D2018A176008CBBC2 /* SDMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321609412018A176008CBBC2 /* SDMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216093D2018A176008CBBC2 /* SDMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321609422018A176008CBBC2 /* SDMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216093D2018A176008CBBC2 /* SDMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321609432018A176008CBBC2 /* SDMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216093D2018A176008CBBC2 /* SDMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321609442018A176008CBBC2 /* SDMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216093D2018A176008CBBC2 /* SDMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321609452018A176008CBBC2 /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216093E2018A176008CBBC2 /* SDMemoryCache.m */; };
+		321609462018A176008CBBC2 /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216093E2018A176008CBBC2 /* SDMemoryCache.m */; };
+		321609472018A176008CBBC2 /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216093E2018A176008CBBC2 /* SDMemoryCache.m */; };
+		321609482018A176008CBBC2 /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216093E2018A176008CBBC2 /* SDMemoryCache.m */; };
+		321609492018A176008CBBC2 /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216093E2018A176008CBBC2 /* SDMemoryCache.m */; };
+		3216094A2018A176008CBBC2 /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216093E2018A176008CBBC2 /* SDMemoryCache.m */; };
+		3216094D2018A181008CBBC2 /* SDDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216094B2018A181008CBBC2 /* SDDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3216094E2018A181008CBBC2 /* SDDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216094B2018A181008CBBC2 /* SDDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3216094F2018A181008CBBC2 /* SDDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216094B2018A181008CBBC2 /* SDDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321609502018A181008CBBC2 /* SDDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216094B2018A181008CBBC2 /* SDDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321609512018A181008CBBC2 /* SDDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216094B2018A181008CBBC2 /* SDDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321609522018A181008CBBC2 /* SDDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 3216094B2018A181008CBBC2 /* SDDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		321609532018A181008CBBC2 /* SDDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216094C2018A181008CBBC2 /* SDDiskCache.m */; };
+		321609542018A181008CBBC2 /* SDDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216094C2018A181008CBBC2 /* SDDiskCache.m */; };
+		321609552018A181008CBBC2 /* SDDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216094C2018A181008CBBC2 /* SDDiskCache.m */; };
+		321609562018A181008CBBC2 /* SDDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216094C2018A181008CBBC2 /* SDDiskCache.m */; };
+		321609572018A181008CBBC2 /* SDDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216094C2018A181008CBBC2 /* SDDiskCache.m */; };
+		321609582018A181008CBBC2 /* SDDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 3216094C2018A181008CBBC2 /* SDDiskCache.m */; };
 		321DB3612011D4D70015D2CB /* NSButton+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 321DB35F2011D4D60015D2CB /* NSButton+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		321DB3622011D4D70015D2CB /* NSButton+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 321DB3602011D4D60015D2CB /* NSButton+WebCache.m */; };
 		321E60861F38E8C800405457 /* SDWebImageCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60841F38E8C800405457 /* SDWebImageCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1433,6 +1457,10 @@
 		00733A4C1BC487C000A5A117 /* SDWebImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		320224B9203979BA00E9F285 /* SDAnimatedImageRep.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDAnimatedImageRep.h; sourceTree = "<group>"; };
 		320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDAnimatedImageRep.m; sourceTree = "<group>"; };
+		3216093D2018A176008CBBC2 /* SDMemoryCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDMemoryCache.h; sourceTree = "<group>"; };
+		3216093E2018A176008CBBC2 /* SDMemoryCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDMemoryCache.m; sourceTree = "<group>"; };
+		3216094B2018A181008CBBC2 /* SDDiskCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDDiskCache.h; sourceTree = "<group>"; };
+		3216094C2018A181008CBBC2 /* SDDiskCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDDiskCache.m; sourceTree = "<group>"; };
 		321DB35F2011D4D60015D2CB /* NSButton+WebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSButton+WebCache.h"; path = "SDWebImage/NSButton+WebCache.h"; sourceTree = "<group>"; };
 		321DB3602011D4D60015D2CB /* NSButton+WebCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSButton+WebCache.m"; path = "SDWebImage/NSButton+WebCache.m"; sourceTree = "<group>"; };
 		321E60841F38E8C800405457 /* SDWebImageCoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDWebImageCoder.h; sourceTree = "<group>"; };
@@ -1985,6 +2013,10 @@
 				53922D86148C56230056699D /* SDImageCache.m */,
 				43A918621D8308FE00B3925F /* SDImageCacheConfig.h */,
 				43A918631D8308FE00B3925F /* SDImageCacheConfig.m */,
+				3216093D2018A176008CBBC2 /* SDMemoryCache.h */,
+				3216093E2018A176008CBBC2 /* SDMemoryCache.m */,
+				3216094B2018A181008CBBC2 /* SDDiskCache.h */,
+				3216094C2018A181008CBBC2 /* SDDiskCache.m */,
 			);
 			name = Cache;
 			sourceTree = "<group>";
@@ -2240,6 +2272,7 @@
 				323F8B651F38EF770092B609 /* cost_enc.h in Headers */,
 				00733A701BC4880E00A5A117 /* UIImageView+HighlightedWebCache.h in Headers */,
 				323F8BDB1F38EF770092B609 /* vp8i_enc.h in Headers */,
+				321609502018A181008CBBC2 /* SDDiskCache.h in Headers */,
 				80377C461F2F666300F89830 /* bit_reader_inl_utils.h in Headers */,
 				00733A671BC4880E00A5A117 /* SDImageCache.h in Headers */,
 				00733A711BC4880E00A5A117 /* UIImageView+WebCache.h in Headers */,
@@ -2258,6 +2291,7 @@
 				00733A6A1BC4880E00A5A117 /* SDWebImagePrefetcher.h in Headers */,
 				00733A641BC4880E00A5A117 /* SDWebImageOperation.h in Headers */,
 				32484766201775F600AF9E5A /* SDAnimatedImageView+WebCache.h in Headers */,
+				321609422018A176008CBBC2 /* SDMemoryCache.h in Headers */,
 				321E60A51F38E8F600405457 /* SDWebImageGIFCoder.h in Headers */,
 				32CF1C0A1FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */,
 				80377C4D1F2F666300F89830 /* endian_inl_utils.h in Headers */,
@@ -2292,6 +2326,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				80377D521F2F66A700F89830 /* neon.h in Headers */,
+				3216094E2018A181008CBBC2 /* SDDiskCache.h in Headers */,
 				80377D261F2F66A700F89830 /* common_sse2.h in Headers */,
 				3290FA051FA478AF0047D20C /* SDWebImageFrame.h in Headers */,
 				80377C1D1F2F666300F89830 /* huffman_encode_utils.h in Headers */,
@@ -2359,6 +2394,7 @@
 				80377C1F1F2F666300F89830 /* huffman_utils.h in Headers */,
 				4314D17F1D0E0E3B004B36C9 /* UIButton+WebCache.h in Headers */,
 				32484764201775F600AF9E5A /* SDAnimatedImageView+WebCache.h in Headers */,
+				321609402018A176008CBBC2 /* SDMemoryCache.h in Headers */,
 				4314D1811D0E0E3B004B36C9 /* UIImageView+WebCache.h in Headers */,
 				4314D1841D0E0E3B004B36C9 /* SDWebImageOperation.h in Headers */,
 				4314D1851D0E0E3B004B36C9 /* SDWebImageDownloaderOperation.h in Headers */,
@@ -2388,6 +2424,7 @@
 				43A62A1B1D0E0A800089D7DD /* decode.h in Headers */,
 				321E608A1F38E8C800405457 /* SDWebImageCoder.h in Headers */,
 				32484767201775F600AF9E5A /* SDAnimatedImageView+WebCache.h in Headers */,
+				321609432018A176008CBBC2 /* SDMemoryCache.h in Headers */,
 				80377C601F2F666400F89830 /* bit_reader_inl_utils.h in Headers */,
 				329A185D1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */,
 				431BB6DC1D06D2C1006A3455 /* UIButton+WebCache.h in Headers */,
@@ -2397,6 +2434,7 @@
 				80377C771F2F666400F89830 /* thread_utils.h in Headers */,
 				80377E1F1F2F66A800F89830 /* mips_macro.h in Headers */,
 				323F8B661F38EF770092B609 /* cost_enc.h in Headers */,
+				321609512018A181008CBBC2 /* SDDiskCache.h in Headers */,
 				80377C621F2F666400F89830 /* bit_reader_utils.h in Headers */,
 				431BB6E21D06D2C1006A3455 /* UIImageView+HighlightedWebCache.h in Headers */,
 				43A62A1C1D0E0A800089D7DD /* demux.h in Headers */,
@@ -2472,6 +2510,7 @@
 				324DF4B9200A14DC008A84CC /* SDWebImageDefine.h in Headers */,
 				32F7C0892030719600873181 /* UIImage+Transform.h in Headers */,
 				80377EDA1F2F66D500F89830 /* common_dec.h in Headers */,
+				321609442018A176008CBBC2 /* SDMemoryCache.h in Headers */,
 				80377EE61F2F66D500F89830 /* webpi_dec.h in Headers */,
 				32B9B53C206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */,
 				4397D2BA1D0DDD8C00BB2784 /* demux.h in Headers */,
@@ -2532,6 +2571,7 @@
 				4397D2F61D0DE2DF00BB2784 /* NSImage+Additions.h in Headers */,
 				4397D2E11D0DDD8C00BB2784 /* SDWebImageDownloader.h in Headers */,
 				323F8BFB1F38EF770092B609 /* animi.h in Headers */,
+				321609522018A181008CBBC2 /* SDDiskCache.h in Headers */,
 				4397D2E31D0DDD8C00BB2784 /* MKAnnotationView+WebCache.h in Headers */,
 				4397D2E61D0DDD8C00BB2784 /* encode.h in Headers */,
 				80377C7C1F2F666400F89830 /* bit_reader_utils.h in Headers */,
@@ -2599,6 +2639,7 @@
 				323F8B641F38EF770092B609 /* cost_enc.h in Headers */,
 				4A2CAE1D1AB4BB6800B6BC39 /* SDWebImageDownloaderOperation.h in Headers */,
 				323F8BDA1F38EF770092B609 /* vp8i_enc.h in Headers */,
+				3216094F2018A181008CBBC2 /* SDDiskCache.h in Headers */,
 				4317394E1CDFC8B70008FEB9 /* decode.h in Headers */,
 				80377C2C1F2F666300F89830 /* bit_reader_inl_utils.h in Headers */,
 				43CE75771CFE9427006C64D0 /* FLAnimatedImage.h in Headers */,
@@ -2617,6 +2658,7 @@
 				4A2CAE1A1AB4BB6400B6BC39 /* SDWebImageOperation.h in Headers */,
 				80377C331F2F666300F89830 /* endian_inl_utils.h in Headers */,
 				32484765201775F600AF9E5A /* SDAnimatedImageView+WebCache.h in Headers */,
+				321609412018A176008CBBC2 /* SDMemoryCache.h in Headers */,
 				321E60A41F38E8F600405457 /* SDWebImageGIFCoder.h in Headers */,
 				32CF1C091FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */,
 				4A2CAE1B1AB4BB6800B6BC39 /* SDWebImageDownloader.h in Headers */,
@@ -2686,6 +2728,7 @@
 				80377CEF1F2F66A100F89830 /* dsp.h in Headers */,
 				32F21B5120788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.h in Headers */,
 				80377C011F2F665300F89830 /* filters_utils.h in Headers */,
+				3216093F2018A176008CBBC2 /* SDMemoryCache.h in Headers */,
 				5376131C155AD0D5005750A4 /* SDWebImageManager.h in Headers */,
 				438096741CDFC09C00DC626B /* UIImage+WebP.h in Headers */,
 				80377BFF1F2F665300F89830 /* endian_inl_utils.h in Headers */,
@@ -2693,6 +2736,7 @@
 				321E60BE1F38E91700405457 /* UIImage+ForceDecode.h in Headers */,
 				5376131E155AD0D5005750A4 /* SDWebImagePrefetcher.h in Headers */,
 				32F7C06F2030114C00873181 /* SDWebImageTransformer.h in Headers */,
+				3216094D2018A181008CBBC2 /* SDDiskCache.h in Headers */,
 				324DF4B4200A14DC008A84CC /* SDWebImageDefine.h in Headers */,
 				80377CE11F2F66A100F89830 /* common_sse2.h in Headers */,
 				80377C0B1F2F665300F89830 /* random_utils.h in Headers */,
@@ -3090,6 +3134,7 @@
 				80377C4B1F2F666300F89830 /* color_cache_utils.c in Sources */,
 				80377DB81F2F66A700F89830 /* dec_mips32.c in Sources */,
 				323F8BED1F38EF770092B609 /* webp_enc.c in Sources */,
+				321609482018A176008CBBC2 /* SDMemoryCache.m in Sources */,
 				80377DC41F2F66A700F89830 /* enc_sse2.c in Sources */,
 				00733A5D1BC4880000A5A117 /* UIImage+GIF.m in Sources */,
 				323F8C171F38EF770092B609 /* muxinternal.c in Sources */,
@@ -3107,6 +3152,7 @@
 				80377DAD1F2F66A700F89830 /* argb_mips_dsp_r2.c in Sources */,
 				00733A601BC4880000A5A117 /* UIImageView+HighlightedWebCache.m in Sources */,
 				323F8BAB1F38EF770092B609 /* picture_psnr_enc.c in Sources */,
+				321609562018A181008CBBC2 /* SDDiskCache.m in Sources */,
 				323F8BA51F38EF770092B609 /* picture_enc.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3165,6 +3211,7 @@
 				80377D291F2F66A700F89830 /* cost_sse2.c in Sources */,
 				80377D601F2F66A700F89830 /* yuv_sse2.c in Sources */,
 				80377C281F2F666300F89830 /* thread_utils.c in Sources */,
+				321609542018A181008CBBC2 /* SDDiskCache.m in Sources */,
 				3290FA0B1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
 				80377C2A1F2F666300F89830 /* utils.c in Sources */,
 				323F8B4B1F38EF770092B609 /* backward_references_enc.c in Sources */,
@@ -3211,6 +3258,7 @@
 				32484770201775F600AF9E5A /* SDAnimatedImage.m in Sources */,
 				323F8BA91F38EF770092B609 /* picture_psnr_enc.c in Sources */,
 				3248477C201775F600AF9E5A /* SDAnimatedImageView+WebCache.m in Sources */,
+				321609462018A176008CBBC2 /* SDMemoryCache.m in Sources */,
 				323F8C091F38EF770092B609 /* muxedit.c in Sources */,
 				80377D1F1F2F66A700F89830 /* alpha_processing_neon.c in Sources */,
 				32C0FDE82013426C001B8F2D /* SDWebImageIndicator.m in Sources */,
@@ -3322,6 +3370,7 @@
 				80377E0F1F2F66A800F89830 /* filters_sse2.c in Sources */,
 				80377DED1F2F66A800F89830 /* alpha_processing_mips_dsp_r2.c in Sources */,
 				80377DF81F2F66A800F89830 /* cost_sse2.c in Sources */,
+				321609572018A181008CBBC2 /* SDDiskCache.m in Sources */,
 				3290FA0E1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
 				80377E2F1F2F66A800F89830 /* yuv_sse2.c in Sources */,
 				431BB6AA1D06D2C1006A3455 /* SDWebImageManager.m in Sources */,
@@ -3368,6 +3417,7 @@
 				32484773201775F600AF9E5A /* SDAnimatedImage.m in Sources */,
 				80377C611F2F666400F89830 /* bit_reader_utils.c in Sources */,
 				3248477F201775F600AF9E5A /* SDAnimatedImageView+WebCache.m in Sources */,
+				321609492018A176008CBBC2 /* SDMemoryCache.m in Sources */,
 				323F8BAC1F38EF770092B609 /* picture_psnr_enc.c in Sources */,
 				323F8C0C1F38EF770092B609 /* muxedit.c in Sources */,
 				32C0FDEB2013426C001B8F2D /* SDWebImageIndicator.m in Sources */,
@@ -3571,10 +3621,12 @@
 				80377E3D1F2F66A800F89830 /* cost_sse2.c in Sources */,
 				32F7C0832030719600873181 /* UIImage+Transform.m in Sources */,
 				321E60BB1F38E90100405457 /* SDWebImageWebPCoder.m in Sources */,
+				321609582018A181008CBBC2 /* SDDiskCache.m in Sources */,
 				80377E3C1F2F66A800F89830 /* cost_mips32.c in Sources */,
 				80377E421F2F66A800F89830 /* dec_mips32.c in Sources */,
 				32484774201775F600AF9E5A /* SDAnimatedImage.m in Sources */,
 				4397D2AE1D0DDD8C00BB2784 /* UIImageView+HighlightedWebCache.m in Sources */,
+				3216094A2018A176008CBBC2 /* SDMemoryCache.m in Sources */,
 				323F8B851F38EF770092B609 /* histogram_enc.c in Sources */,
 				80377EE51F2F66D500F89830 /* webp_dec.c in Sources */,
 				4397D2B01D0DDD8C00BB2784 /* SDImageCache.m in Sources */,
@@ -3724,6 +3776,7 @@
 				80377D9B1F2F66A700F89830 /* rescaler_neon.c in Sources */,
 				4A2CAE381AB4BB7500B6BC39 /* UIView+WebCacheOperation.m in Sources */,
 				80377C311F2F666300F89830 /* color_cache_utils.c in Sources */,
+				321609472018A176008CBBC2 /* SDMemoryCache.m in Sources */,
 				323F8BEC1F38EF770092B609 /* webp_enc.c in Sources */,
 				80377D731F2F66A700F89830 /* dec_mips32.c in Sources */,
 				80377D7F1F2F66A700F89830 /* enc_sse2.c in Sources */,
@@ -3741,6 +3794,7 @@
 				80377D9D1F2F66A700F89830 /* rescaler.c in Sources */,
 				80377D681F2F66A700F89830 /* argb_mips_dsp_r2.c in Sources */,
 				323F8BAA1F38EF770092B609 /* picture_psnr_enc.c in Sources */,
+				321609552018A181008CBBC2 /* SDDiskCache.m in Sources */,
 				323F8BA41F38EF770092B609 /* picture_enc.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3885,6 +3939,7 @@
 				AB615306192DA24600A2D8E9 /* UIView+WebCacheOperation.m in Sources */,
 				80377BFD1F2F665300F89830 /* color_cache_utils.c in Sources */,
 				323F8BEA1F38EF770092B609 /* webp_enc.c in Sources */,
+				321609452018A176008CBBC2 /* SDMemoryCache.m in Sources */,
 				80377CE91F2F66A100F89830 /* dec_mips32.c in Sources */,
 				80377CF51F2F66A100F89830 /* enc_sse2.c in Sources */,
 				323F8C141F38EF770092B609 /* muxinternal.c in Sources */,
@@ -3902,6 +3957,7 @@
 				80377D131F2F66A100F89830 /* rescaler.c in Sources */,
 				80377CDE1F2F66A100F89830 /* argb_mips_dsp_r2.c in Sources */,
 				323F8BA81F38EF770092B609 /* picture_psnr_enc.c in Sources */,
+				321609532018A181008CBBC2 /* SDDiskCache.m in Sources */,
 				323F8BA21F38EF770092B609 /* picture_enc.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SDWebImage/SDDiskCache.h
+++ b/SDWebImage/SDDiskCache.h
@@ -8,25 +8,22 @@
 
 #import "SDWebImageCompat.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
+@class SDImageCacheConfig;
 // A protocol to allow custom disk cache used in SDImageCache.
 @protocol SDDiskCache <NSObject>
 
 // All of these method are called from the same global queue to avoid blocking on main queue and thread-safe problem. But it's also recommend to ensure thread-safe yourself using lock or other ways.
 @required
 /**
- Create a new cache based on the specified path.
+ Create a new disk cache based on the specified path.
  
  @param cachePath Full path of a directory in which the cache will write data.
  Once initialized you should not read and write to this directory.
+ @param config The cache config to be used to create the cache.
  
  @return A new cache object, or nil if an error occurs.
- 
- @warning If the cache instance for the specified path already exists in memory,
- this method will return it directly, instead of creating a new instance.
  */
-- (nullable instancetype)initWithCachePath:(NSString *)cachePath;
+- (nullable instancetype)initWithCachePath:(nonnull NSString *)cachePath config:(nonnull SDImageCacheConfig *)config;
 
 /**
  Returns a boolean value that indicates whether a given key is in cache.
@@ -35,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param key A string identifying the data. If nil, just return NO.
  @return Whether the key is in cache.
  */
-- (BOOL)containsDataForKey:(NSString *)key;
+- (BOOL)containsDataForKey:(nonnull NSString *)key;
 
 /**
  Returns the data associated with a given key.
@@ -44,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param key A string identifying the data. If nil, just return nil.
  @return The value associated with key, or nil if no value is associated with key.
  */
-- (nullable NSData *)dataForKey:(NSString *)key;
+- (nullable NSData *)dataForKey:(nonnull NSString *)key;
 
 /**
  Sets the value of the specified key in the cache.
@@ -53,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param data The data to be stored in the cache.
  @param key    The key with which to associate the value. If nil, this method has no effect.
  */
-- (void)setData:(nullable NSData *)data forKey:(NSString *)key;
+- (void)setData:(nullable NSData *)data forKey:(nonnull NSString *)key;
 
 /**
  Removes the value of the specified key in the cache.
@@ -61,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param key The key identifying the value to be removed. If nil, this method has no effect.
  */
-- (void)removeDataForKey:(NSString *)key;
+- (void)removeDataForKey:(nonnull NSString *)key;
 
 /**
  Empties the cache.
@@ -80,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param key A string identifying the value
  @return The cache path for key. Or nil if the key can not associate to a path
  */
-- (nullable NSString *)cachePathForKey:(NSString *)key;
+- (nullable NSString *)cachePathForKey:(nonnull NSString *)key;
 
 /**
  Returns the number of data in this cache.
@@ -98,68 +95,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSInteger)totalSize;
 
-/**
- The maximum expiry time of data in cache.
- 
- @discussion The default value is DBL_MAX, which means no limit.
- This is not a strict limit — if data goes over the limit, the data could
- be evicted later in background queue.
- */
-- (NSTimeInterval)ageLimit;
-- (void)setAgeLimit:(NSTimeInterval)ageLimit;
-
-/**
- The maximum number of data the cache should hold.
- 
- @discussion The default value is NSUIntegerMax, which means no limit.
- This is not a strict limit—if the cache goes over the limit, some data in the
- cache could be evicted later in backgound thread.
- */
-- (NSUInteger)countLimit;
-- (void)setCountLimit:(NSUInteger)countLimit;
-
-/**
- The maximum total size that the cache can hold before it starts evicting data.
- 
- @discussion The default value is NSUIntegerMax, which means no limit.
- This is not a strict limit — if the cache goes over the limit, some data in the
- cache could be evicted later in background queue.
- */
-- (NSUInteger)sizeLimit;
-- (void)setSizeLimit:(NSUInteger)sizeLimit;
-
-@optional
-// Some configurations are optional because they are tied to implementation detail and does not impact the basic fucntion.
-
-/**
- Custom file manager. if your disk cache does not based on NSFileManager's API, Ignore it.
-
- @param fileManager fileManager
- */
-- (void)setFileManager:(NSFileManager *)fileManager;
-
-/**
- Custom data reading options. If your disk cache does not based on NSData's API, Ignore it.
-
- @param readingOptions data reading options
- */
-- (void)setReadingOptions:(NSDataReadingOptions)readingOptions;
-
-/**
- Custom data writing options. If your disk cache does not based on NSData's API, Ignore it.
-
- @param writingOptions data writing options
- */
-- (void)setWritingOptions:(NSDataWritingOptions)writingOptions;
-
 @end
 
-
+// The built-in disk cache
 @interface SDDiskCache : NSObject <SDDiskCache>
 
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
+@property (nonatomic, strong, readonly, nonnull) SDImageCacheConfig *config;
+
+- (nonnull instancetype)init NS_UNAVAILABLE;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/SDWebImage/SDDiskCache.h
+++ b/SDWebImage/SDDiskCache.h
@@ -1,0 +1,165 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDWebImageCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+// A protocol to allow custom disk cache used in SDImageCache.
+@protocol SDDiskCache <NSObject>
+
+// All of these method are called from the same global queue to avoid blocking on main queue and thread-safe problem. But it's also recommend to ensure thread-safe yourself using lock or other ways.
+@required
+/**
+ Create a new cache based on the specified path.
+ 
+ @param cachePath Full path of a directory in which the cache will write data.
+ Once initialized you should not read and write to this directory.
+ 
+ @return A new cache object, or nil if an error occurs.
+ 
+ @warning If the cache instance for the specified path already exists in memory,
+ this method will return it directly, instead of creating a new instance.
+ */
+- (nullable instancetype)initWithCachePath:(NSString *)cachePath;
+
+/**
+ Returns a boolean value that indicates whether a given key is in cache.
+ This method may blocks the calling thread until file read finished.
+ 
+ @param key A string identifying the data. If nil, just return NO.
+ @return Whether the key is in cache.
+ */
+- (BOOL)containsDataForKey:(NSString *)key;
+
+/**
+ Returns the data associated with a given key.
+ This method may blocks the calling thread until file read finished.
+ 
+ @param key A string identifying the data. If nil, just return nil.
+ @return The value associated with key, or nil if no value is associated with key.
+ */
+- (nullable NSData *)dataForKey:(NSString *)key;
+
+/**
+ Sets the value of the specified key in the cache.
+ This method may blocks the calling thread until file write finished.
+ 
+ @param data The data to be stored in the cache.
+ @param key    The key with which to associate the value. If nil, this method has no effect.
+ */
+- (void)setData:(nullable NSData *)data forKey:(NSString *)key;
+
+/**
+ Removes the value of the specified key in the cache.
+ This method may blocks the calling thread until file delete finished.
+ 
+ @param key The key identifying the value to be removed. If nil, this method has no effect.
+ */
+- (void)removeDataForKey:(NSString *)key;
+
+/**
+ Empties the cache.
+ This method may blocks the calling thread until file delete finished.
+ */
+- (void)removeAllData;
+
+/**
+ Removes the expired data from the cache. You can choose the data to remove base on `ageLimit`, `countLimit` and `sizeLimit` options.
+ */
+- (void)removeExpiredData;
+
+/**
+ The cache path for key
+
+ @param key A string identifying the value
+ @return The cache path for key. Or nil if the key can not associate to a path
+ */
+- (nullable NSString *)cachePathForKey:(NSString *)key;
+
+/**
+ Returns the number of data in this cache.
+ This method may blocks the calling thread until file read finished.
+ 
+ @return The total data count.
+ */
+- (NSInteger)totalCount;
+
+/**
+ Returns the total size (in bytes) of data in this cache.
+ This method may blocks the calling thread until file read finished.
+ 
+ @return The total data size in bytes.
+ */
+- (NSInteger)totalSize;
+
+/**
+ The maximum expiry time of data in cache.
+ 
+ @discussion The default value is DBL_MAX, which means no limit.
+ This is not a strict limit — if data goes over the limit, the data could
+ be evicted later in background queue.
+ */
+- (NSTimeInterval)ageLimit;
+- (void)setAgeLimit:(NSTimeInterval)ageLimit;
+
+/**
+ The maximum number of data the cache should hold.
+ 
+ @discussion The default value is NSUIntegerMax, which means no limit.
+ This is not a strict limit—if the cache goes over the limit, some data in the
+ cache could be evicted later in backgound thread.
+ */
+- (NSUInteger)countLimit;
+- (void)setCountLimit:(NSUInteger)countLimit;
+
+/**
+ The maximum total size that the cache can hold before it starts evicting data.
+ 
+ @discussion The default value is NSUIntegerMax, which means no limit.
+ This is not a strict limit — if the cache goes over the limit, some data in the
+ cache could be evicted later in background queue.
+ */
+- (NSUInteger)sizeLimit;
+- (void)setSizeLimit:(NSUInteger)sizeLimit;
+
+@optional
+// Some configurations are optional because they are tied to implementation detail and does not impact the basic fucntion.
+
+/**
+ Custom file manager. if your disk cache does not based on NSFileManager's API, Ignore it.
+
+ @param fileManager fileManager
+ */
+- (void)setFileManager:(NSFileManager *)fileManager;
+
+/**
+ Custom data reading options. If your disk cache does not based on NSData's API, Ignore it.
+
+ @param readingOptions data reading options
+ */
+- (void)setReadingOptions:(NSDataReadingOptions)readingOptions;
+
+/**
+ Custom data writing options. If your disk cache does not based on NSData's API, Ignore it.
+
+ @param writingOptions data writing options
+ */
+- (void)setWritingOptions:(NSDataWritingOptions)writingOptions;
+
+@end
+
+
+@interface SDDiskCache : NSObject <SDDiskCache>
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SDWebImage/SDDiskCache.m
+++ b/SDWebImage/SDDiskCache.m
@@ -77,8 +77,8 @@
 - (void)setData:(NSData *)data forKey:(NSString *)key {
     NSParameterAssert(data);
     NSParameterAssert(key);
-    if (![self.fileManager fileExistsAtPath:_diskCachePath]) {
-        [self.fileManager createDirectoryAtPath:_diskCachePath withIntermediateDirectories:YES attributes:nil error:NULL];
+    if (![self.fileManager fileExistsAtPath:self.diskCachePath]) {
+        [self.fileManager createDirectoryAtPath:self.diskCachePath withIntermediateDirectories:YES attributes:nil error:NULL];
     }
     
     // get cache Path for image key
@@ -87,6 +87,12 @@
     NSURL *fileURL = [NSURL fileURLWithPath:cachePathForKey];
     
     [data writeToURL:fileURL options:self.config.diskCacheWritingOptions error:nil];
+    
+    // disable iCloud backup
+    if (self.config.shouldDisableiCloud) {
+        // ignore iCloud backup resource value error
+        [fileURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:nil];
+    }
 }
 
 - (void)removeDataForKey:(NSString *)key {

--- a/SDWebImage/SDDiskCache.m
+++ b/SDWebImage/SDDiskCache.m
@@ -1,0 +1,226 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDDiskCache.h"
+#import <CommonCrypto/CommonDigest.h>
+
+@interface SDDiskCache ()
+
+@property (nonatomic, copy) NSString *diskCachePath;
+@property (nonatomic, strong, nonnull) NSFileManager *fileManager;
+@property (nonatomic, assign) NSTimeInterval ageLimit;
+@property (nonatomic, assign) NSUInteger countLimit;
+@property (nonatomic, assign) NSUInteger sizeLimit;
+@property (nonatomic, assign) NSDataReadingOptions diskCacheReadingOptions;
+@property (nonatomic, assign) NSDataWritingOptions diskCacheWritingOptions;
+
+@end
+
+@implementation SDDiskCache
+
+- (NSFileManager *)fileManager {
+    if (!_fileManager) {
+        _fileManager = [NSFileManager new];
+    }
+    return _fileManager;
+}
+
+- (instancetype)init {
+    NSAssert(NO, @"Use `initWithCachePath:` with the disk cache path");
+    return nil;
+}
+
+#pragma mark - SDcachePathForKeyDiskCache Protocol
+- (instancetype)initWithCachePath:(NSString *)cachePath {
+    if (self = [super init]) {
+        _diskCachePath = cachePath;
+    }
+    return self;
+}
+
+- (BOOL)containsDataForKey:(NSString *)key {
+    NSParameterAssert(key);
+    NSString *filePath = [self cachePathForKey:key];
+    BOOL exists = [self.fileManager fileExistsAtPath:filePath];
+    
+    // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
+    // checking the key with and without the extension
+    if (!exists) {
+        exists = [self.fileManager fileExistsAtPath:filePath.stringByDeletingPathExtension];
+    }
+    
+    return exists;
+}
+
+- (NSData *)dataForKey:(NSString *)key {
+    NSParameterAssert(key);
+    NSString *filePath = [self cachePathForKey:key];
+    NSData *data = [NSData dataWithContentsOfFile:filePath options:self.diskCacheReadingOptions error:nil];
+    if (data) {
+        return data;
+    }
+    
+    // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
+    // checking the key with and without the extension
+    data = [NSData dataWithContentsOfFile:filePath.stringByDeletingPathExtension options:self.diskCacheReadingOptions error:nil];
+    if (data) {
+        return data;
+    }
+    
+    return nil;
+}
+
+- (void)setData:(NSData *)data forKey:(NSString *)key {
+    NSParameterAssert(data);
+    NSParameterAssert(key);
+    if (![self.fileManager fileExistsAtPath:_diskCachePath]) {
+        [self.fileManager createDirectoryAtPath:_diskCachePath withIntermediateDirectories:YES attributes:nil error:NULL];
+    }
+    
+    // get cache Path for image key
+    NSString *cachePathForKey = [self cachePathForKey:key];
+    // transform to NSUrl
+    NSURL *fileURL = [NSURL fileURLWithPath:cachePathForKey];
+    
+    [data writeToURL:fileURL options:self.diskCacheWritingOptions error:nil];
+}
+
+- (void)removeDataForKey:(NSString *)key {
+    NSParameterAssert(key);
+    NSString *filePath = [self cachePathForKey:key];
+    [self.fileManager removeItemAtPath:filePath error:nil];
+}
+
+- (void)removeAllData {
+    [self.fileManager removeItemAtPath:self.diskCachePath error:nil];
+    [self.fileManager createDirectoryAtPath:self.diskCachePath
+            withIntermediateDirectories:YES
+                             attributes:nil
+                                  error:NULL];
+}
+
+- (void)removeExpiredData {
+    NSURL *diskCacheURL = [NSURL fileURLWithPath:self.diskCachePath isDirectory:YES];
+    NSArray<NSString *> *resourceKeys = @[NSURLIsDirectoryKey, NSURLContentModificationDateKey, NSURLTotalFileAllocatedSizeKey];
+    
+    // This enumerator prefetches useful properties for our cache files.
+    NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtURL:diskCacheURL
+                                               includingPropertiesForKeys:resourceKeys
+                                                                  options:NSDirectoryEnumerationSkipsHiddenFiles
+                                                             errorHandler:NULL];
+    
+    NSDate *expirationDate = [NSDate dateWithTimeIntervalSinceNow:-self.ageLimit];
+    NSMutableDictionary<NSURL *, NSDictionary<NSString *, id> *> *cacheFiles = [NSMutableDictionary dictionary];
+    NSUInteger currentCacheSize = 0;
+    
+    // Enumerate all of the files in the cache directory.  This loop has two purposes:
+    //
+    //  1. Removing files that are older than the expiration date.
+    //  2. Storing file attributes for the size-based cleanup pass.
+    NSMutableArray<NSURL *> *urlsToDelete = [[NSMutableArray alloc] init];
+    for (NSURL *fileURL in fileEnumerator) {
+        NSError *error;
+        NSDictionary<NSString *, id> *resourceValues = [fileURL resourceValuesForKeys:resourceKeys error:&error];
+        
+        // Skip directories and errors.
+        if (error || !resourceValues || [resourceValues[NSURLIsDirectoryKey] boolValue]) {
+            continue;
+        }
+        
+        // Remove files that are older than the expiration date;
+        NSDate *modificationDate = resourceValues[NSURLContentModificationDateKey];
+        if ([[modificationDate laterDate:expirationDate] isEqualToDate:expirationDate]) {
+            [urlsToDelete addObject:fileURL];
+            continue;
+        }
+        
+        // Store a reference to this file and account for its total size.
+        NSNumber *totalAllocatedSize = resourceValues[NSURLTotalFileAllocatedSizeKey];
+        currentCacheSize += totalAllocatedSize.unsignedIntegerValue;
+        cacheFiles[fileURL] = resourceValues;
+    }
+    
+    for (NSURL *fileURL in urlsToDelete) {
+        [self.fileManager removeItemAtURL:fileURL error:nil];
+    }
+    
+    // If our remaining disk cache exceeds a configured maximum size, perform a second
+    // size-based cleanup pass.  We delete the oldest files first.
+    if (self.sizeLimit > 0 && currentCacheSize > self.sizeLimit) {
+        // Target half of our maximum cache size for this cleanup pass.
+        const NSUInteger desiredCacheSize = self.sizeLimit / 2;
+        
+        // Sort the remaining cache files by their last modification time (oldest first).
+        NSArray<NSURL *> *sortedFiles = [cacheFiles keysSortedByValueWithOptions:NSSortConcurrent
+                                                                 usingComparator:^NSComparisonResult(id obj1, id obj2) {
+                                                                     return [obj1[NSURLContentModificationDateKey] compare:obj2[NSURLContentModificationDateKey]];
+                                                                 }];
+        
+        // Delete files until we fall below our desired cache size.
+        for (NSURL *fileURL in sortedFiles) {
+            if ([self.fileManager removeItemAtURL:fileURL error:nil]) {
+                NSDictionary<NSString *, id> *resourceValues = cacheFiles[fileURL];
+                NSNumber *totalAllocatedSize = resourceValues[NSURLTotalFileAllocatedSizeKey];
+                currentCacheSize -= totalAllocatedSize.unsignedIntegerValue;
+                
+                if (currentCacheSize < desiredCacheSize) {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+- (nullable NSString *)cachePathForKey:(NSString *)key {
+    NSParameterAssert(key);
+    return [self cachePathForKey:key inPath:self.diskCachePath];
+}
+
+- (NSInteger)totalSize {
+    NSUInteger size = 0;
+    NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtPath:self.diskCachePath];
+    for (NSString *fileName in fileEnumerator) {
+        NSString *filePath = [self.diskCachePath stringByAppendingPathComponent:fileName];
+        NSDictionary<NSString *, id> *attrs = [self.fileManager attributesOfItemAtPath:filePath error:nil];
+        size += [attrs fileSize];
+    }
+    return size;
+}
+
+- (NSInteger)totalCount {
+    NSUInteger count = 0;
+    NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtPath:self.diskCachePath];
+    count = fileEnumerator.allObjects.count;
+    return count;
+}
+
+#pragma mark - Cache paths
+
+- (nullable NSString *)cachePathForKey:(nullable NSString *)key inPath:(nonnull NSString *)path {
+    NSString *filename = SDDiskCacheFileNameForKey(key);
+    return [path stringByAppendingPathComponent:filename];
+}
+
+#pragma mark - Hash
+
+static inline NSString * _Nullable SDDiskCacheFileNameForKey(NSString * _Nullable key) {
+    const char *str = key.UTF8String;
+    if (str == NULL) {
+        return nil;
+    }
+    unsigned char r[CC_MD5_DIGEST_LENGTH];
+    CC_MD5(str, (CC_LONG)strlen(str), r);
+    NSURL *keyURL = [NSURL URLWithString:key];
+    NSString *ext = keyURL ? keyURL.pathExtension : key.pathExtension;
+    NSString *filename = [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%@",
+                          r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10],
+                          r[11], r[12], r[13], r[14], r[15], ext.length == 0 ? @"" : [NSString stringWithFormat:@".%@", ext]];
+    return filename;
+}
+
+@end

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -87,13 +87,6 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
 #pragma mark - Singleton and initialization
 
 /**
- Set the default cache config used for shared instance or initialization which does not provide any cache config
-
- @param config The default cache config to use. You should not pass nil.
- */
-+ (void)setDefaultCacheConfig:(nonnull SDImageCacheConfig *)config;
-
-/**
  * Returns global shared cache instance
  */
 @property (nonatomic, class, readonly, nonnull) SDImageCache *sharedImageCache;

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -10,21 +10,7 @@
 #import "SDWebImageCompat.h"
 #import "SDWebImageDefine.h"
 #import "SDImageCacheConfig.h"
-
-typedef NS_ENUM(NSInteger, SDImageCacheType) {
-    /**
-     * The image wasn't available the SDWebImage caches, but was downloaded from the web.
-     */
-    SDImageCacheTypeNone,
-    /**
-     * The image was obtained from the disk cache.
-     */
-    SDImageCacheTypeDisk,
-    /**
-     * The image was obtained from the memory cache.
-     */
-    SDImageCacheTypeMemory
-};
+#import "SDWebImageCache.h"
 
 typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     /**
@@ -50,8 +36,6 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     SDImageCachePreloadAllFrames = 1 << 4
 };
 
-typedef void(^SDImageCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);
-
 typedef void(^SDWebImageCheckCacheCompletionBlock)(BOOL isInCache);
 
 typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger totalSize);
@@ -62,7 +46,7 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
  * SDImageCache maintains a memory cache and an optional disk cache. Disk cache write operations are performed
  * asynchronous so it doesn’t add unnecessary latency to the UI.
  */
-@interface SDImageCache : NSObject
+@interface SDImageCache : NSObject <SDWebImageCache>
 
 #pragma mark - Properties
 
@@ -286,7 +270,7 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
  */
 - (void)removeImageFromDiskForKey:(nullable NSString *)key;
 
-#pragma mark - Cache clean Ops
+#pragma mark - Cache clear Ops
 
 /**
  * Synchronously Clear all memory cached images

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -50,13 +50,13 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     SDImageCachePreloadAllFrames = 1 << 4
 };
 
-typedef void(^SDCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);
+typedef void(^SDImageCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);
 
 typedef void(^SDWebImageCheckCacheCompletionBlock)(BOOL isInCache);
 
 typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger totalSize);
 
-typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable error);
+typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * _Nonnull key);
 
 /**
  * SDImageCache maintains a memory cache and an optional disk cache. Disk cache write operations are performed
@@ -67,11 +67,31 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 #pragma mark - Properties
 
 /**
- *  Cache Config object - storing all kind of settings
+ *  Cache Config object - storing all kind of settings.
+ *  The property is copy so change of currrent config will not accidentally affect other cache's config.
  */
-@property (nonatomic, nonnull, readonly) SDImageCacheConfig *config;
+@property (nonatomic, copy, nonnull, readonly) SDImageCacheConfig *config;
+
+/**
+ *  The disk cache's root path
+ */
+@property (nonatomic, copy, nonnull, readonly) NSString *diskCachePath;
+
+/**
+ *  The additional disk cache path to check if the query from disk cache not exist;
+ *  The `key` param is the image cache key. The returned file path will be used to load the disk cache. If return nil, ignore it.
+ *  Useful if you want to bundle pre-loaded images with your app
+ */
+@property (nonatomic, copy, nullable) SDImageCacheAdditionalCachePathBlock additionalCachePathBlock;
 
 #pragma mark - Singleton and initialization
+
+/**
+ Set the default cache config used for shared instance or initialization which does not provide any cache config
+
+ @param config The default cache config to use. You should not pass nil.
+ */
++ (void)setDefaultCacheConfig:(nonnull SDImageCacheConfig *)config;
 
 /**
  * Returns global shared cache instance
@@ -99,23 +119,21 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  *
  * @param ns          The namespace to use for this cache store
  * @param directory   Directory to cache disk images in
- * @param fileManager The file manager for storing image, if nil then will be created new one
+ * @param config      The cache config to be used to create the cache. You can provide custom memory cache or disk cache class in the cache config
  */
 - (nonnull instancetype)initWithNamespace:(nonnull NSString *)ns
                        diskCacheDirectory:(nonnull NSString *)directory
-                              fileManager:(nullable NSFileManager *)fileManager NS_DESIGNATED_INITIALIZER;
+                                   config:(nullable SDImageCacheConfig *)config;
 
-#pragma mark - Cache paths
-
-- (nullable NSString *)makeDiskCachePath:(nonnull NSString*)fullNamespace;
+#pragma mark - Cache Paths
 
 /**
- * Add a read-only cache path to search for images pre-cached by SDImageCache
- * Useful if you want to bundle pre-loaded images with your app
- *
- * @param path The path to use for this read-only cache path
+ Get the cache path for a certain key
+ 
+ @param key The unique image cache key
+ @return The cache path. You can check `lastPathComponent` to grab the file name.
  */
-- (void)addReadOnlyCachePath:(nonnull NSString *)path;
+- (nullable NSString *)cachePathForKey:(nullable NSString *)key;
 
 #pragma mark - Store Ops
 
@@ -128,7 +146,7 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  */
 - (void)storeImage:(nullable UIImage *)image
             forKey:(nullable NSString *)key
-        completion:(nullable SDWebImageCompletionWithPossibleErrorBlock)completionBlock;
+        completion:(nullable SDWebImageNoParamsBlock)completionBlock;
 
 /**
  * Asynchronously store an image into memory and disk cache at the given key.
@@ -141,7 +159,7 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 - (void)storeImage:(nullable UIImage *)image
             forKey:(nullable NSString *)key
             toDisk:(BOOL)toDisk
-        completion:(nullable SDWebImageCompletionWithPossibleErrorBlock)completionBlock;
+        completion:(nullable SDWebImageNoParamsBlock)completionBlock;
 
 /**
  * Asynchronously store an image into memory and disk cache at the given key.
@@ -158,18 +176,16 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
          imageData:(nullable NSData *)imageData
             forKey:(nullable NSString *)key
             toDisk:(BOOL)toDisk
-        completion:(nullable SDWebImageCompletionWithPossibleErrorBlock)completionBlock;
+        completion:(nullable SDWebImageNoParamsBlock)completionBlock;
 
 /**
  * Synchronously store image NSData into disk cache at the given key.
  *
  * @param imageData  The image data to store
  * @param key        The unique image cache key, usually it's image absolute URL
- * @param error      NSError pointer, for possible file I/O errors, See FoundationErrors.h
  */
-- (BOOL)storeImageDataToDisk:(nullable NSData *)imageData
-                      forKey:(nullable NSString *)key
-                       error:(NSError * _Nullable * _Nullable)error;
+- (void)storeImageDataToDisk:(nullable NSData *)imageData
+                      forKey:(nullable NSString *)key;
 
 
 #pragma mark - Query and Retrieve Ops
@@ -198,7 +214,7 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  *
  * @return a NSOperation instance containing the cache op
  */
-- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key done:(nullable SDCacheQueryCompletedBlock)doneBlock;
+- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key done:(nullable SDImageCacheQueryCompletedBlock)doneBlock;
 
 /**
  * Asynchronously queries the cache with operation and call the completion when done.
@@ -209,7 +225,7 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  *
  * @return a NSOperation instance containing the cache op
  */
-- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDCacheQueryCompletedBlock)doneBlock;
+- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDImageCacheQueryCompletedBlock)doneBlock;
 
 /**
  * Asynchronously queries the cache with operation and call the completion when done.
@@ -221,7 +237,7 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  *
  * @return a NSOperation instance containing the cache op
  */
-- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context done:(nullable SDCacheQueryCompletedBlock)doneBlock;
+- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context done:(nullable SDImageCacheQueryCompletedBlock)doneBlock;
 
 /**
  * Synchronously query the memory cache.
@@ -263,6 +279,20 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  */
 - (void)removeImageForKey:(nullable NSString *)key fromDisk:(BOOL)fromDisk withCompletion:(nullable SDWebImageNoParamsBlock)completion;
 
+/**
+ Synchronously remove the image from memory cache.
+
+ @param key The unique image cache key
+ */
+- (void)removeImageFromMemoryForKey:(nullable NSString *)key;
+
+/**
+ Synchronously remove the image from disk cache.
+ 
+ @param key The unique image cache key
+ */
+- (void)removeImageFromDiskForKey:(nullable NSString *)key;
+
 #pragma mark - Cache clean Ops
 
 /**
@@ -298,26 +328,5 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  * Asynchronously calculate the disk cache's size.
  */
 - (void)calculateSizeWithCompletionBlock:(nullable SDWebImageCalculateSizeBlock)completionBlock;
-
-#pragma mark - Cache Paths
-
-/**
- *  Get the cache path for a certain key (needs the cache path root folder)
- *
- *  @param key  the key (can be obtained from url using cacheKeyForURL)
- *  @param path the cache path root folder
- *
- *  @return the cache path
- */
-- (nullable NSString *)cachePathForKey:(nullable NSString *)key inPath:(nonnull NSString *)path;
-
-/**
- *  Get the default cache path for a certain key
- *
- *  @param key the key (can be obtained from url using cacheKeyForURL)
- *
- *  @return the default cache path
- */
-- (nullable NSString *)defaultCachePathForKey:(nullable NSString *)key;
 
 @end

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -36,9 +36,9 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     SDImageCachePreloadAllFrames = 1 << 4
 };
 
-typedef void(^SDWebImageCheckCacheCompletionBlock)(BOOL isInCache);
+typedef void(^SDImageCacheCheckCompletionBlock)(BOOL isInCache);
 
-typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger totalSize);
+typedef void(^SDImageCacheCalculateSizeBlock)(NSUInteger fileCount, NSUInteger totalSize);
 
 typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * _Nonnull key);
 
@@ -174,7 +174,7 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
  *  @param completionBlock the block to be executed when the check is done.
  *  @note the completion block will be always executed on the main queue
  */
-- (void)diskImageExistsWithKey:(nullable NSString *)key completion:(nullable SDWebImageCheckCacheCompletionBlock)completionBlock;
+- (void)diskImageExistsWithKey:(nullable NSString *)key completion:(nullable SDImageCacheCheckCompletionBlock)completionBlock;
 
 /**
  *  Synchronously check if image data exists in disk cache already (does not load the image)
@@ -191,7 +191,7 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
  *
  * @return a NSOperation instance containing the cache op
  */
-- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key done:(nullable SDImageCacheQueryCompletedBlock)doneBlock;
+- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 
 /**
  * Asynchronously queries the cache with operation and call the completion when done.
@@ -202,7 +202,7 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
  *
  * @return a NSOperation instance containing the cache op
  */
-- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDImageCacheQueryCompletedBlock)doneBlock;
+- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 
 /**
  * Asynchronously queries the cache with operation and call the completion when done.
@@ -214,7 +214,7 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
  *
  * @return a NSOperation instance containing the cache op
  */
-- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context done:(nullable SDImageCacheQueryCompletedBlock)doneBlock;
+- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context done:(nullable SDImageCacheQueryCompletionBlock)doneBlock;
 
 /**
  * Synchronously query the memory cache.
@@ -304,6 +304,6 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
 /**
  * Asynchronously calculate the disk cache's size.
  */
-- (void)calculateSizeWithCompletionBlock:(nullable SDWebImageCalculateSizeBlock)completionBlock;
+- (void)calculateSizeWithCompletionBlock:(nullable SDImageCacheCalculateSizeBlock)completionBlock;
 
 @end

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -605,21 +605,15 @@
             break;
         case SDImageCacheTypeBoth: {
             BOOL isInMemoryCache = ([self imageFromMemoryCacheForKey:key] != nil);
-            [self diskImageExistsWithKey:key completion:^(BOOL isInDiskCache) {
-                SDImageCacheType containsCacheType;
-                if (isInMemoryCache || isInDiskCache) {
-                    if (isInMemoryCache && isInDiskCache) {
-                        containsCacheType = SDImageCacheTypeBoth;
-                    } else if (isInMemoryCache) {
-                        containsCacheType = SDImageCacheTypeMemory;
-                    } else {
-                        containsCacheType = SDImageCacheTypeDisk;
-                    }
-                } else {
-                    containsCacheType = SDImageCacheTypeNone;
-                }
+            if (isInMemoryCache) {
                 if (completionBlock) {
-                    completionBlock(containsCacheType);
+                    completionBlock(SDImageCacheTypeMemory);
+                }
+                return;
+            }
+            [self diskImageExistsWithKey:key completion:^(BOOL isInDiskCache) {
+                if (completionBlock) {
+                    completionBlock(isInDiskCache ? SDImageCacheTypeDisk : SDImageCacheTypeNone);
                 }
             }];
         }

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -7,7 +7,8 @@
  */
 
 #import "SDImageCache.h"
-#import <CommonCrypto/CommonDigest.h>
+#import "SDMemoryCache.h"
+#import "SDDiskCache.h"
 #import "NSImage+Additions.h"
 #import "UIImage+WebCache.h"
 #import "SDWebImageCodersManager.h"
@@ -19,6 +20,7 @@
 #define UNLOCK(lock) dispatch_semaphore_signal(lock);
 
 static void * SDImageCacheContext = &SDImageCacheContext;
+static SDImageCacheConfig * _defaultCacheConfig;
 
 FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 #if SD_MAC
@@ -127,11 +129,11 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 @interface SDImageCache ()
 
 #pragma mark - Properties
-@property (strong, nonatomic, nonnull) SDMemoryCache *memCache;
-@property (strong, nonatomic, nonnull) NSString *diskCachePath;
-@property (strong, nonatomic, nullable) NSMutableArray<NSString *> *customPaths;
-@property (strong, nonatomic, nullable) dispatch_queue_t ioQueue;
-@property (strong, nonatomic, nonnull) NSFileManager *fileManager;
+@property (nonatomic, strong, nonnull) id<SDMemoryCache> memCache;
+@property (nonatomic, strong, nonnull) id<SDDiskCache> diskCache;
+@property (nonatomic, copy, readwrite, nonnull) SDImageCacheConfig *config;
+@property (nonatomic, copy, readwrite, nonnull) NSString *diskCachePath;
+@property (nonatomic, strong, nullable) dispatch_queue_t ioQueue;
 
 @end
 
@@ -139,6 +141,18 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 @implementation SDImageCache
 
 #pragma mark - Singleton, init, dealloc
+
++ (void)initialize {
+    if (self == [SDImageCache class]) {
+        [self setDefaultCacheConfig:[SDImageCacheConfig new]];
+    }
+}
+
++ (void)setDefaultCacheConfig:(SDImageCacheConfig *)config {
+    if (config) {
+        _defaultCacheConfig = config;
+    }
+}
 
 + (nonnull instancetype)sharedImageCache {
     static dispatch_once_t once;
@@ -160,27 +174,31 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (nonnull instancetype)initWithNamespace:(nonnull NSString *)ns
                        diskCacheDirectory:(nonnull NSString *)directory {
-    return [self initWithNamespace:ns diskCacheDirectory:directory fileManager: nil];
+    return [self initWithNamespace:ns diskCacheDirectory:directory config:_defaultCacheConfig];
 }
 
 - (nonnull instancetype)initWithNamespace:(nonnull NSString *)ns
                        diskCacheDirectory:(nonnull NSString *)directory
-                              fileManager:(nullable NSFileManager *)fileManager {
+                                   config:(nullable SDImageCacheConfig *)config {
     if ((self = [super init])) {
         NSString *fullNamespace = [@"com.hackemist.SDWebImageCache." stringByAppendingString:ns];
         
         // Create IO serial queue
         _ioQueue = dispatch_queue_create("com.hackemist.SDWebImageCache", DISPATCH_QUEUE_SERIAL);
         
-        _config = [[SDImageCacheConfig alloc] init];
+        if (!config) {
+            config = _defaultCacheConfig;
+        }
+        _config = [config copy];
         // KVO config property which need to be passed
         [_config addObserver:self forKeyPath:NSStringFromSelector(@selector(maxMemoryCost)) options:0 context:SDImageCacheContext];
         [_config addObserver:self forKeyPath:NSStringFromSelector(@selector(maxMemoryCount)) options:0 context:SDImageCacheContext];
         
         // Init the memory cache
-        _memCache = [[SDMemoryCache alloc] init];
+        NSAssert([config.memoryCacheClass conformsToProtocol:@protocol(SDMemoryCache)], @"Custom memory cache class must conform to `SDMemoryCache` protocol");
+        _memCache = [[config.memoryCacheClass alloc] init];
         _memCache.name = fullNamespace;
-
+        
         // Init the disk cache
         if (directory != nil) {
             _diskCachePath = [directory stringByAppendingPathComponent:fullNamespace];
@@ -188,10 +206,13 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             NSString *path = [self makeDiskCachePath:ns];
             _diskCachePath = path;
         }
-
-        dispatch_sync(_ioQueue, ^{
-            self.fileManager = fileManager ? fileManager : [NSFileManager new];
-        });
+        
+        NSAssert([config.diskCacheClass conformsToProtocol:@protocol(SDDiskCache)], @"Custom disk cache class must conform to `SDDiskCache` protocol");
+        _diskCache = [[config.diskCacheClass alloc] initWithCachePath:_diskCachePath];
+        
+        if (config.fileManager && [_diskCache respondsToSelector:@selector(setFileManager:)]) {
+            [_diskCache setFileManager:config.fileManager];
+        }
 
 #if SD_UIKIT
         // Subscribe to app events
@@ -218,38 +239,11 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 #pragma mark - Cache paths
 
-- (void)addReadOnlyCachePath:(nonnull NSString *)path {
-    if (!self.customPaths) {
-        self.customPaths = [NSMutableArray new];
+- (NSString *)cachePathForKey:(NSString *)key {
+    if (!key) {
+        return nil;
     }
-
-    if (![self.customPaths containsObject:path]) {
-        [self.customPaths addObject:path];
-    }
-}
-
-- (nullable NSString *)cachePathForKey:(nullable NSString *)key inPath:(nonnull NSString *)path {
-    NSString *filename = [self cachedFileNameForKey:key];
-    return [path stringByAppendingPathComponent:filename];
-}
-
-- (nullable NSString *)defaultCachePathForKey:(nullable NSString *)key {
-    return [self cachePathForKey:key inPath:self.diskCachePath];
-}
-
-- (nullable NSString *)cachedFileNameForKey:(nullable NSString *)key {
-    const char *str = key.UTF8String;
-    if (str == NULL) {
-        str = "";
-    }
-    unsigned char r[CC_MD5_DIGEST_LENGTH];
-    CC_MD5(str, (CC_LONG)strlen(str), r);
-    NSURL *keyURL = [NSURL URLWithString:key];
-    NSString *ext = keyURL ? keyURL.pathExtension : key.pathExtension;
-    NSString *filename = [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%@",
-                          r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10],
-                          r[11], r[12], r[13], r[14], r[15], ext.length == 0 ? @"" : [NSString stringWithFormat:@".%@", ext]];
-    return filename;
+    return [self.diskCache cachePathForKey:key];
 }
 
 - (nullable NSString *)makeDiskCachePath:(nonnull NSString*)fullNamespace {
@@ -261,14 +255,14 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (void)storeImage:(nullable UIImage *)image
             forKey:(nullable NSString *)key
-        completion:(nullable SDWebImageCompletionWithPossibleErrorBlock)completionBlock {
+        completion:(nullable SDWebImageNoParamsBlock)completionBlock {
     [self storeImage:image imageData:nil forKey:key toDisk:YES completion:completionBlock];
 }
 
 - (void)storeImage:(nullable UIImage *)image
             forKey:(nullable NSString *)key
             toDisk:(BOOL)toDisk
-        completion:(nullable SDWebImageCompletionWithPossibleErrorBlock)completionBlock {
+        completion:(nullable SDWebImageNoParamsBlock)completionBlock {
     [self storeImage:image imageData:nil forKey:key toDisk:toDisk completion:completionBlock];
 }
 
@@ -276,10 +270,10 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
          imageData:(nullable NSData *)imageData
             forKey:(nullable NSString *)key
             toDisk:(BOOL)toDisk
-        completion:(nullable SDWebImageCompletionWithPossibleErrorBlock)completionBlock {
+        completion:(nullable SDWebImageNoParamsBlock)completionBlock {
     if (!image || !key) {
         if (completionBlock) {
-            completionBlock(nil);
+            completionBlock();
         }
         return;
     }
@@ -291,7 +285,6 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     
     if (toDisk) {
         dispatch_async(self.ioQueue, ^{
-            NSError * writeError = nil;
             @autoreleasepool {
                 NSData *data = imageData;
                 if (!data && image) {
@@ -304,71 +297,51 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
                     }
                     data = [[SDWebImageCodersManager sharedManager] encodedDataWithImage:image format:format options:nil];
                 }
-                [self _storeImageDataToDisk:data forKey:key error:&writeError];
+                [self _storeImageDataToDisk:data forKey:key];
             }
             
             if (completionBlock) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    completionBlock(writeError);
+                    completionBlock();
                 });
             }
         });
     } else {
         if (completionBlock) {
-            completionBlock(nil);
+            completionBlock();
         }
     }
 }
 
-- (BOOL)storeImageDataToDisk:(nullable NSData *)imageData
-                      forKey:(nullable NSString *)key
-                       error:(NSError * _Nullable __autoreleasing * _Nullable)error {
+- (void)storeImageDataToDisk:(nullable NSData *)imageData
+                      forKey:(nullable NSString *)key {
     if (!imageData || !key) {
-        return NO;
-    }
-    __autoreleasing NSError *fileError;
-    if (!error) {
-        error = &fileError;
+        return;
     }
     
-    __block BOOL success = YES;
-    void(^storeImageDataBlock)(void) =  ^{
-        success = [self _storeImageDataToDisk:imageData forKey:key error:error];
-    };
-    dispatch_sync(self.ioQueue, storeImageDataBlock);
-    
-    return success;
+    dispatch_sync(self.ioQueue, ^{
+        [self _storeImageDataToDisk:imageData forKey:key];
+    });
 }
 
 // Make sure to call form io queue by caller
-- (BOOL)_storeImageDataToDisk:(nullable NSData *)imageData forKey:(nullable NSString *)key error:(NSError * _Nullable __autoreleasing * _Nonnull)error {
+- (void)_storeImageDataToDisk:(nullable NSData *)imageData forKey:(nullable NSString *)key {
     if (!imageData || !key) {
-        return NO;
-    }
-    if (![self.fileManager fileExistsAtPath:_diskCachePath]) {
-        if (![self.fileManager createDirectoryAtPath:_diskCachePath withIntermediateDirectories:YES attributes:nil error:error]) {
-            return NO;
-        }
+        return;
     }
     
-    // get cache Path for image key
-    NSString *cachePathForKey = [self defaultCachePathForKey:key];
-    // transform to NSUrl
-    NSURL *fileURL = [NSURL fileURLWithPath:cachePathForKey];
+    [self.diskCache setData:imageData forKey:key];
     
-    // NSFileManager's `createFileAtPath:` is used just for old code compatibility and will not trigger any delegate methods, so it's useless for custom NSFileManager at all.
-    // And also, NSFileManager's `createFileAtPath:` can only grab underlying POSIX errno, but NSData can grab errors defined in NSCocoaErrorDomain, which is better for user to check.
-    if (![imageData writeToURL:fileURL options:self.config.diskCacheWritingOptions error:error]) {
-        return NO;
-    }
     
     // disable iCloud backup
     if (self.config.shouldDisableiCloud) {
-        // ignore iCloud backup resource value error
-        [fileURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:nil];
+        NSString *filePath = [self.diskCache cachePathForKey:key];
+        if (filePath) {
+            NSURL *fileURL = [NSURL fileURLWithPath:filePath];
+            // ignore iCloud backup resource value error
+            [fileURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:nil];
+        }
     }
-    
-    return YES;
 }
 
 #pragma mark - Query and Retrieve Ops
@@ -402,15 +375,8 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     if (!key) {
         return NO;
     }
-    BOOL exists = [self.fileManager fileExistsAtPath:[self defaultCachePathForKey:key]];
     
-    // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
-    // checking the key with and without the extension
-    if (!exists) {
-        exists = [self.fileManager fileExistsAtPath:[self defaultCachePathForKey:key].stringByDeletingPathExtension];
-    }
-    
-    return exists;
+    return [self.diskCache containsDataForKey:key];
 }
 
 - (nullable UIImage *)imageFromMemoryCacheForKey:(nullable NSString *)key {
@@ -440,36 +406,24 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 }
 
 - (nullable NSData *)diskImageDataBySearchingAllPathsForKey:(nullable NSString *)key {
-    NSString *defaultPath = [self defaultCachePathForKey:key];
-    NSData *data = [NSData dataWithContentsOfFile:defaultPath options:self.config.diskCacheReadingOptions error:nil];
-    if (data) {
-        return data;
+    if (!key) {
+        return nil;
     }
-
-    // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
-    // checking the key with and without the extension
-    data = [NSData dataWithContentsOfFile:defaultPath.stringByDeletingPathExtension options:self.config.diskCacheReadingOptions error:nil];
-    if (data) {
-        return data;
+    
+    NSData *imageData = [self.diskCache dataForKey:key];
+    if (imageData) {
+        return imageData;
     }
-
-    NSArray<NSString *> *customPaths = [self.customPaths copy];
-    for (NSString *path in customPaths) {
-        NSString *filePath = [self cachePathForKey:key inPath:path];
-        NSData *imageData = [NSData dataWithContentsOfFile:filePath options:self.config.diskCacheReadingOptions error:nil];
-        if (imageData) {
-            return imageData;
-        }
-
-        // fallback because of https://github.com/rs/SDWebImage/pull/976 that added the extension to the disk file name
-        // checking the key with and without the extension
-        imageData = [NSData dataWithContentsOfFile:filePath.stringByDeletingPathExtension options:self.config.diskCacheReadingOptions error:nil];
-        if (imageData) {
-            return imageData;
+    
+    // Addtional cache path for custom pre-load cache
+    if (self.additionalCachePathBlock) {
+        NSString *filePath = self.additionalCachePathBlock(key);
+        if (filePath) {
+            imageData = [NSData dataWithContentsOfFile:filePath options:self.config.diskCacheReadingOptions error:nil];
         }
     }
-
-    return nil;
+    
+    return imageData;
 }
 
 - (nullable UIImage *)diskImageForKey:(nullable NSString *)key {
@@ -521,15 +475,15 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     }
 }
 
-- (nullable NSOperation *)queryCacheOperationForKey:(NSString *)key done:(SDCacheQueryCompletedBlock)doneBlock {
+- (nullable NSOperation *)queryCacheOperationForKey:(NSString *)key done:(SDImageCacheQueryCompletedBlock)doneBlock {
     return [self queryCacheOperationForKey:key options:0 done:doneBlock];
 }
 
-- (nullable NSOperation *)queryCacheOperationForKey:(NSString *)key options:(SDImageCacheOptions)options done:(SDCacheQueryCompletedBlock)doneBlock {
+- (nullable NSOperation *)queryCacheOperationForKey:(NSString *)key options:(SDImageCacheOptions)options done:(SDImageCacheQueryCompletedBlock)doneBlock {
     return [self queryCacheOperationForKey:key options:options context:nil done:doneBlock];
 }
 
-- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context done:(nullable SDCacheQueryCompletedBlock)doneBlock {
+- (nullable NSOperation *)queryCacheOperationForKey:(nullable NSString *)key options:(SDImageCacheOptions)options context:(nullable SDWebImageContext *)context done:(nullable SDImageCacheQueryCompletedBlock)doneBlock {
     if (!key) {
         if (doneBlock) {
             doneBlock(nil, nil, SDImageCacheTypeNone);
@@ -616,7 +570,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
     if (fromDisk) {
         dispatch_async(self.ioQueue, ^{
-            [self.fileManager removeItemAtPath:[self defaultCachePathForKey:key] error:nil];
+            [self _removeImageFromDiskForKey:key];
             
             if (completion) {
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -627,7 +581,32 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     } else if (completion){
         completion();
     }
+}
+
+- (void)removeImageFromMemoryForKey:(NSString *)key {
+    if (!key) {
+        return;
+    }
     
+    [self.memCache removeObjectForKey:key];
+}
+
+- (void)removeImageFromDiskForKey:(NSString *)key {
+    if (!key) {
+        return;
+    }
+    dispatch_sync(self.ioQueue, ^{
+        [self _removeImageFromDiskForKey:key];
+    });
+}
+
+// Make sure to call form io queue by caller
+- (void)_removeImageFromDiskForKey:(NSString *)key {
+    if (!key) {
+        return;
+    }
+    
+    [self.diskCache removeDataForKey:key];
 }
 
 #pragma mark - KVO
@@ -635,7 +614,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
     if (context == SDImageCacheContext) {
         if ([keyPath isEqualToString:NSStringFromSelector(@selector(maxMemoryCost))]) {
-            self.memCache.totalCostLimit = self.config.maxMemoryCost;
+            self.memCache.costLimit = self.config.maxMemoryCost;
         } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(maxMemoryCount))]) {
             self.memCache.countLimit = self.config.maxMemoryCount;
         }
@@ -652,12 +631,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (void)clearDiskOnCompletion:(nullable SDWebImageNoParamsBlock)completion {
     dispatch_async(self.ioQueue, ^{
-        [self.fileManager removeItemAtPath:self.diskCachePath error:nil];
-        [self.fileManager createDirectoryAtPath:self.diskCachePath
-                withIntermediateDirectories:YES
-                                 attributes:nil
-                                      error:NULL];
-
+        [self.diskCache removeAllData];
         if (completion) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 completion();
@@ -672,75 +646,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (void)deleteOldFilesWithCompletionBlock:(nullable SDWebImageNoParamsBlock)completionBlock {
     dispatch_async(self.ioQueue, ^{
-        NSURL *diskCacheURL = [NSURL fileURLWithPath:self.diskCachePath isDirectory:YES];
-        NSArray<NSString *> *resourceKeys = @[NSURLIsDirectoryKey, NSURLContentModificationDateKey, NSURLTotalFileAllocatedSizeKey];
-
-        // This enumerator prefetches useful properties for our cache files.
-        NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtURL:diskCacheURL
-                                                   includingPropertiesForKeys:resourceKeys
-                                                                      options:NSDirectoryEnumerationSkipsHiddenFiles
-                                                                 errorHandler:NULL];
-
-        NSDate *expirationDate = [NSDate dateWithTimeIntervalSinceNow:-self.config.maxCacheAge];
-        NSMutableDictionary<NSURL *, NSDictionary<NSString *, id> *> *cacheFiles = [NSMutableDictionary dictionary];
-        NSUInteger currentCacheSize = 0;
-
-        // Enumerate all of the files in the cache directory.  This loop has two purposes:
-        //
-        //  1. Removing files that are older than the expiration date.
-        //  2. Storing file attributes for the size-based cleanup pass.
-        NSMutableArray<NSURL *> *urlsToDelete = [[NSMutableArray alloc] init];
-        for (NSURL *fileURL in fileEnumerator) {
-            NSError *error;
-            NSDictionary<NSString *, id> *resourceValues = [fileURL resourceValuesForKeys:resourceKeys error:&error];
-
-            // Skip directories and errors.
-            if (error || !resourceValues || [resourceValues[NSURLIsDirectoryKey] boolValue]) {
-                continue;
-            }
-
-            // Remove files that are older than the expiration date;
-            NSDate *modificationDate = resourceValues[NSURLContentModificationDateKey];
-            if ([[modificationDate laterDate:expirationDate] isEqualToDate:expirationDate]) {
-                [urlsToDelete addObject:fileURL];
-                continue;
-            }
-
-            // Store a reference to this file and account for its total size.
-            NSNumber *totalAllocatedSize = resourceValues[NSURLTotalFileAllocatedSizeKey];
-            currentCacheSize += totalAllocatedSize.unsignedIntegerValue;
-            cacheFiles[fileURL] = resourceValues;
-        }
-        
-        for (NSURL *fileURL in urlsToDelete) {
-            [self.fileManager removeItemAtURL:fileURL error:nil];
-        }
-
-        // If our remaining disk cache exceeds a configured maximum size, perform a second
-        // size-based cleanup pass.  We delete the oldest files first.
-        if (self.config.maxCacheSize > 0 && currentCacheSize > self.config.maxCacheSize) {
-            // Target half of our maximum cache size for this cleanup pass.
-            const NSUInteger desiredCacheSize = self.config.maxCacheSize / 2;
-
-            // Sort the remaining cache files by their last modification time (oldest first).
-            NSArray<NSURL *> *sortedFiles = [cacheFiles keysSortedByValueWithOptions:NSSortConcurrent
-                                                                     usingComparator:^NSComparisonResult(id obj1, id obj2) {
-                                                                         return [obj1[NSURLContentModificationDateKey] compare:obj2[NSURLContentModificationDateKey]];
-                                                                     }];
-
-            // Delete files until we fall below our desired cache size.
-            for (NSURL *fileURL in sortedFiles) {
-                if ([self.fileManager removeItemAtURL:fileURL error:nil]) {
-                    NSDictionary<NSString *, id> *resourceValues = cacheFiles[fileURL];
-                    NSNumber *totalAllocatedSize = resourceValues[NSURLTotalFileAllocatedSizeKey];
-                    currentCacheSize -= totalAllocatedSize.unsignedIntegerValue;
-
-                    if (currentCacheSize < desiredCacheSize) {
-                        break;
-                    }
-                }
-            }
-        }
+        [self.diskCache removeExpiredData];
         if (completionBlock) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 completionBlock();
@@ -776,12 +682,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 - (NSUInteger)getSize {
     __block NSUInteger size = 0;
     dispatch_sync(self.ioQueue, ^{
-        NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtPath:self.diskCachePath];
-        for (NSString *fileName in fileEnumerator) {
-            NSString *filePath = [self.diskCachePath stringByAppendingPathComponent:fileName];
-            NSDictionary<NSString *, id> *attrs = [self.fileManager attributesOfItemAtPath:filePath error:nil];
-            size += [attrs fileSize];
-        }
+        size = [self.diskCache totalSize];
     });
     return size;
 }
@@ -789,31 +690,15 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 - (NSUInteger)getDiskCount {
     __block NSUInteger count = 0;
     dispatch_sync(self.ioQueue, ^{
-        NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtPath:self.diskCachePath];
-        count = fileEnumerator.allObjects.count;
+        count = [self.diskCache totalCount];
     });
     return count;
 }
 
 - (void)calculateSizeWithCompletionBlock:(nullable SDWebImageCalculateSizeBlock)completionBlock {
-    NSURL *diskCacheURL = [NSURL fileURLWithPath:self.diskCachePath isDirectory:YES];
-
     dispatch_async(self.ioQueue, ^{
-        NSUInteger fileCount = 0;
-        NSUInteger totalSize = 0;
-
-        NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtURL:diskCacheURL
-                                                   includingPropertiesForKeys:@[NSFileSize]
-                                                                      options:NSDirectoryEnumerationSkipsHiddenFiles
-                                                                 errorHandler:NULL];
-
-        for (NSURL *fileURL in fileEnumerator) {
-            NSNumber *fileSize;
-            [fileURL getResourceValue:&fileSize forKey:NSURLFileSizeKey error:NULL];
-            totalSize += fileSize.unsignedIntegerValue;
-            fileCount += 1;
-        }
-
+        NSUInteger fileCount = [self.diskCache totalCount];
+        NSUInteger totalSize = [self.diskCache totalSize];
         if (completionBlock) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 completionBlock(fileCount, totalSize);

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -13,6 +13,12 @@
 @interface SDImageCacheConfig : NSObject <NSCopying>
 
 /**
+ Gets/Sets the default cache config used for shared instance or initialization when it does not provide any cache config. Such as `SDImageCache.sharedImageCache`.
+ @note You should not pass nil to this value.
+ */
+@property (nonatomic, class, nonnull) SDImageCacheConfig *defaultCacheConfig;
+
+/**
  * Decompressing images means pre-decoding the image that are downloaded and cached on background queue. This can avoid image view decode it on main queue when rendering. This can improve performance but can consume more memory.
  * Defaults to YES. Set this to NO if you are experiencing a crash due to excessive memory consumption.
  */
@@ -29,6 +35,12 @@
  * Defaults to YES.
  */
 @property (assign, nonatomic) BOOL shouldCacheImagesInMemory;
+
+/**
+ * Whether or not to remove the expired disk data when application entering the background. (Not works for macOS)
+ * Defatuls to YES.
+ */
+@property (assign, nonatomic) BOOL shouldRemoveExpiredDataWhenEnterBackground;
 
 /**
  * The reading options while reading cache from disk.

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -9,7 +9,8 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
 
-@interface SDImageCacheConfig : NSObject
+// This class conform to NSCopying, make sure to add the property in `copyWithZone:` as well.
+@interface SDImageCacheConfig : NSObject <NSCopying>
 
 /**
  * Decompressing images means pre-decoding the image that are downloaded and cached on background queue. This can avoid image view decode it on main queue when rendering. This can improve performance but can consume more memory.
@@ -64,5 +65,23 @@
  * Defaults to 0. Which means there is no memory count limit.
  */
 @property (assign, nonatomic) NSUInteger maxMemoryCount;
+
+/**
+ * The custom file manager for disk cache. Pass nil to let disk cache choose the proper file manager.
+ * Defaults to nil.
+ */
+@property (strong, nonatomic, nullable) NSFileManager *fileManager;
+
+/**
+ * The custom memory cache class. Provided class instance must conform to `SDMemoryCache` protocol to allow usage.
+ * Defaults to built-in `SDMemoryCache` class.
+ */
+@property (assign, nonatomic, nonnull) Class memoryCacheClass;
+
+/**
+ * The custom disk cache class. Provided class instance must conform to `SDDiskCache` protocol to allow usage.
+ * Defaults to built-in `SDDiskCache` class.
+ */
+@property (assign ,nonatomic, nonnull) Class diskCacheClass;
 
 @end

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -13,10 +13,10 @@
 @interface SDImageCacheConfig : NSObject <NSCopying>
 
 /**
- Gets/Sets the default cache config used for shared instance or initialization when it does not provide any cache config. Such as `SDImageCache.sharedImageCache`.
- @note You should not pass nil to this value.
+ Gets the default cache config used for shared instance or initialization when it does not provide any cache config. Such as `SDImageCache.sharedImageCache`.
+ @note You can modify the property on default cache config, which can be used for later created cache instance. The already created cache instance does not get affected.
  */
-@property (nonatomic, class, nonnull) SDImageCacheConfig *defaultCacheConfig;
+@property (nonatomic, class, nonnull, readonly) SDImageCacheConfig *defaultCacheConfig;
 
 /**
  * Decompressing images means pre-decoding the image that are downloaded and cached on background queue. This can avoid image view decode it on main queue when rendering. This can improve performance but can consume more memory.
@@ -81,18 +81,22 @@
 /**
  * The custom file manager for disk cache. Pass nil to let disk cache choose the proper file manager.
  * Defaults to nil.
+ * @note This value does not support dynamic changes. Which means further modification on this value after cache initlized has no effect.
+ * @note Since `NSFileManager` does not support `NSCopying`. We just pass this by reference during copying. So it's not recommend to set this value on `defaultCacheConfig`.
  */
 @property (strong, nonatomic, nullable) NSFileManager *fileManager;
 
 /**
  * The custom memory cache class. Provided class instance must conform to `SDMemoryCache` protocol to allow usage.
  * Defaults to built-in `SDMemoryCache` class.
+ * @note This value does not support dynamic changes. Which means further modification on this value after cache initlized has no effect.
  */
 @property (assign, nonatomic, nonnull) Class memoryCacheClass;
 
 /**
  * The custom disk cache class. Provided class instance must conform to `SDDiskCache` protocol to allow usage.
  * Defaults to built-in `SDDiskCache` class.
+ * @note This value does not support dynamic changes. Which means further modification on this value after cache initlized has no effect.
  */
 @property (assign ,nonatomic, nonnull) Class diskCacheClass;
 

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -13,10 +13,11 @@
 @interface SDImageCacheConfig : NSObject <NSCopying>
 
 /**
- Gets the default cache config used for shared instance or initialization when it does not provide any cache config. Such as `SDImageCache.sharedImageCache`.
+ Gets/Sets the default cache config used for shared instance or initialization when it does not provide any cache config. Such as `SDImageCache.sharedImageCache`.
  @note You can modify the property on default cache config, which can be used for later created cache instance. The already created cache instance does not get affected.
+ @note You should not pass nil to this value.
  */
-@property (nonatomic, class, nonnull, readonly) SDImageCacheConfig *defaultCacheConfig;
+@property (nonatomic, class, nonnull) SDImageCacheConfig *defaultCacheConfig;
 
 /**
  * Decompressing images means pre-decoding the image that are downloaded and cached on background queue. This can avoid image view decode it on main queue when rendering. This can improve performance but can consume more memory.

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -7,6 +7,8 @@
  */
 
 #import "SDImageCacheConfig.h"
+#import "SDMemoryCache.h"
+#import "SDDiskCache.h"
 
 static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
 
@@ -21,8 +23,28 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
         _diskCacheWritingOptions = NSDataWritingAtomic;
         _maxCacheAge = kDefaultCacheMaxCacheAge;
         _maxCacheSize = 0;
+        _memoryCacheClass = [SDMemoryCache class];
+        _diskCacheClass = [SDDiskCache class];
     }
     return self;
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    SDImageCacheConfig *config = [[[self class] allocWithZone:zone] init];
+    config.shouldDecompressImages = self.shouldDecompressImages;
+    config.shouldDisableiCloud = self.shouldDisableiCloud;
+    config.shouldCacheImagesInMemory = self.shouldCacheImagesInMemory;
+    config.diskCacheReadingOptions = self.diskCacheReadingOptions;
+    config.diskCacheWritingOptions = self.diskCacheWritingOptions;
+    config.maxCacheAge = self.maxCacheAge;
+    config.maxCacheSize = self.maxCacheSize;
+    config.maxMemoryCost = self.maxMemoryCost;
+    config.maxMemoryCount = self.maxMemoryCount;
+    config.fileManager = self.fileManager; // NSFileManager does not conform to NSCopying, just pass the reference
+    config.memoryCacheClass = self.memoryCacheClass;
+    config.diskCacheClass = self.diskCacheClass;
+    
+    return config;
 }
 
 @end

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -10,17 +10,23 @@
 #import "SDMemoryCache.h"
 #import "SDDiskCache.h"
 
+static SDImageCacheConfig *_defaultCacheConfig;
 static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
 
 @implementation SDImageCacheConfig
 
 + (SDImageCacheConfig *)defaultCacheConfig {
     static dispatch_once_t onceToken;
-    static SDImageCacheConfig *defaultCacheConfig;
     dispatch_once(&onceToken, ^{
-        defaultCacheConfig = [SDImageCacheConfig new];
+        _defaultCacheConfig = [SDImageCacheConfig new];
     });
-    return defaultCacheConfig;
+    return _defaultCacheConfig;
+}
+
++ (void)setDefaultCacheConfig:(SDImageCacheConfig *)defaultCacheConfig {
+    if (defaultCacheConfig) {
+        _defaultCacheConfig = defaultCacheConfig;
+    }
 }
 
 - (instancetype)init {

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -10,23 +10,17 @@
 #import "SDMemoryCache.h"
 #import "SDDiskCache.h"
 
-static SDImageCacheConfig * _defaultCacheConfig;
 static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
 
 @implementation SDImageCacheConfig
 
 + (SDImageCacheConfig *)defaultCacheConfig {
-    if (!_defaultCacheConfig) {
-        _defaultCacheConfig = [SDImageCacheConfig new];
-    }
-    return _defaultCacheConfig;
-}
-
-+ (void)setDefaultCacheConfig:(SDImageCacheConfig *)config {
-    if (!config) {
-        return;
-    }
-    _defaultCacheConfig = config;
+    static dispatch_once_t onceToken;
+    static SDImageCacheConfig *defaultCacheConfig;
+    dispatch_once(&onceToken, ^{
+        defaultCacheConfig = [SDImageCacheConfig new];
+    });
+    return defaultCacheConfig;
 }
 
 - (instancetype)init {

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -10,15 +10,31 @@
 #import "SDMemoryCache.h"
 #import "SDDiskCache.h"
 
+static SDImageCacheConfig * _defaultCacheConfig;
 static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
 
 @implementation SDImageCacheConfig
+
++ (SDImageCacheConfig *)defaultCacheConfig {
+    if (!_defaultCacheConfig) {
+        _defaultCacheConfig = [SDImageCacheConfig new];
+    }
+    return _defaultCacheConfig;
+}
+
++ (void)setDefaultCacheConfig:(SDImageCacheConfig *)config {
+    if (!config) {
+        return;
+    }
+    _defaultCacheConfig = config;
+}
 
 - (instancetype)init {
     if (self = [super init]) {
         _shouldDecompressImages = YES;
         _shouldDisableiCloud = YES;
         _shouldCacheImagesInMemory = YES;
+        _shouldRemoveExpiredDataWhenEnterBackground = YES;
         _diskCacheReadingOptions = 0;
         _diskCacheWritingOptions = NSDataWritingAtomic;
         _maxCacheAge = kDefaultCacheMaxCacheAge;
@@ -34,6 +50,7 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
     config.shouldDecompressImages = self.shouldDecompressImages;
     config.shouldDisableiCloud = self.shouldDisableiCloud;
     config.shouldCacheImagesInMemory = self.shouldCacheImagesInMemory;
+    config.shouldRemoveExpiredDataWhenEnterBackground = self.shouldRemoveExpiredDataWhenEnterBackground;
     config.diskCacheReadingOptions = self.diskCacheReadingOptions;
     config.diskCacheWritingOptions = self.diskCacheWritingOptions;
     config.maxCacheAge = self.maxCacheAge;

--- a/SDWebImage/SDMemoryCache.h
+++ b/SDWebImage/SDMemoryCache.h
@@ -8,19 +8,34 @@
 
 #import "SDWebImageCompat.h"
 
-NS_ASSUME_NONNULL_BEGIN
+/**
+ Return the memory cache cost for specify image
 
+ @param image The image to store in cache
+ @return The memory cost for the image
+ */
+FOUNDATION_EXPORT NSUInteger SDMemoryCacheCostForImage(UIImage * _Nullable image);
+
+@class SDImageCacheConfig;
 // A protocol to allow custom memory cache used in SDImageCache.
 @protocol SDMemoryCache <NSObject>
 
 @required
+/**
+ Create a new memory cache instance with the specify cache config. You can check `maxMemoryCost` and `maxMemoryCount` used for memory cache.
+
+ @param config The cache config to be used to create the cache.
+ @return The new memory cache instance.
+ */
+- (nonnull instancetype)initWithConfig:(nonnull SDImageCacheConfig *)config;
+
 /**
  Returns the value associated with a given key.
  
  @param key An object identifying the value. If nil, just return nil.
  @return The value associated with key, or nil if no value is associated with key.
  */
-- (nullable id)objectForKey:(id)key;
+- (nullable id)objectForKey:(nonnull id)key;
 
 /**
  Sets the value of the specified key in the cache (0 cost).
@@ -30,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Unlike an NSMutableDictionary object, a cache does not copy the key
  objects that are put into it.
  */
-- (void)setObject:(nullable id)object forKey:(id)key;
+- (void)setObject:(nullable id)object forKey:(nonnull id)key;
 
 /**
  Sets the value of the specified key in the cache, and associates the key-value
@@ -42,45 +57,25 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion Unlike an NSMutableDictionary object, a cache does not copy the key
  objects that are put into it.
  */
-- (void)setObject:(nullable id)object forKey:(id)key cost:(NSUInteger)cost;
+- (void)setObject:(nullable id)object forKey:(nonnull id)key cost:(NSUInteger)cost;
 
 /**
  Removes the value of the specified key in the cache.
  
  @param key The key identifying the value to be removed. If nil, this method has no effect.
  */
-- (void)removeObjectForKey:(id)key;
+- (void)removeObjectForKey:(nonnull id)key;
 
 /**
  Empties the cache immediately.
  */
 - (void)removeAllObjects;
 
-/**
- The maximum number of objects the cache should hold.
- 
- @discussion The default value is NSUIntegerMax, which means no limit.
- This is not a strict limit—if the cache goes over the limit, some objects in the
- cache could be evicted later in backgound thread.
- */
-- (NSUInteger)countLimit;
-- (void)setCountLimit:(NSUInteger)countLimit;
-
-/**
- The maximum total cost that the cache can hold before it starts evicting objects.
- 
- @discussion The default value is NSUIntegerMax, which means no limit.
- This is not a strict limit—if the cache goes over the limit, some objects in the
- cache could be evicted later in backgound thread.
- */
-- (NSUInteger)costLimit;
-- (void)setCostLimit:(NSUInteger)costLimit;
-
 @end
 
+// A memory cache which auto purge the cache on memory warning and support weak cache.
+@interface SDMemoryCache <KeyType, ObjectType> : NSCache <KeyType, ObjectType> <SDMemoryCache>
 
-@interface SDMemoryCache : NSCache <SDMemoryCache>
+@property (nonatomic, strong, nonnull, readonly) SDImageCacheConfig *config;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/SDWebImage/SDMemoryCache.h
+++ b/SDWebImage/SDMemoryCache.h
@@ -1,0 +1,86 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDWebImageCompat.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+// A protocol to allow custom memory cache used in SDImageCache.
+@protocol SDMemoryCache <NSObject>
+
+@required
+/**
+ Returns the value associated with a given key.
+ 
+ @param key An object identifying the value. If nil, just return nil.
+ @return The value associated with key, or nil if no value is associated with key.
+ */
+- (nullable id)objectForKey:(id)key;
+
+/**
+ Sets the value of the specified key in the cache (0 cost).
+ 
+ @param object The object to be stored in the cache. If nil, it calls `removeObjectForKey:`.
+ @param key    The key with which to associate the value. If nil, this method has no effect.
+ @discussion Unlike an NSMutableDictionary object, a cache does not copy the key
+ objects that are put into it.
+ */
+- (void)setObject:(nullable id)object forKey:(id)key;
+
+/**
+ Sets the value of the specified key in the cache, and associates the key-value
+ pair with the specified cost.
+ 
+ @param object The object to store in the cache. If nil, it calls `removeObjectForKey`.
+ @param key    The key with which to associate the value. If nil, this method has no effect.
+ @param cost   The cost with which to associate the key-value pair.
+ @discussion Unlike an NSMutableDictionary object, a cache does not copy the key
+ objects that are put into it.
+ */
+- (void)setObject:(nullable id)object forKey:(id)key cost:(NSUInteger)cost;
+
+/**
+ Removes the value of the specified key in the cache.
+ 
+ @param key The key identifying the value to be removed. If nil, this method has no effect.
+ */
+- (void)removeObjectForKey:(id)key;
+
+/**
+ Empties the cache immediately.
+ */
+- (void)removeAllObjects;
+
+/**
+ The maximum number of objects the cache should hold.
+ 
+ @discussion The default value is NSUIntegerMax, which means no limit.
+ This is not a strict limit—if the cache goes over the limit, some objects in the
+ cache could be evicted later in backgound thread.
+ */
+- (NSUInteger)countLimit;
+- (void)setCountLimit:(NSUInteger)countLimit;
+
+/**
+ The maximum total cost that the cache can hold before it starts evicting objects.
+ 
+ @discussion The default value is NSUIntegerMax, which means no limit.
+ This is not a strict limit—if the cache goes over the limit, some objects in the
+ cache could be evicted later in backgound thread.
+ */
+- (NSUInteger)costLimit;
+- (void)setCostLimit:(NSUInteger)costLimit;
+
+@end
+
+
+@interface SDMemoryCache : NSCache <SDMemoryCache>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SDWebImage/SDMemoryCache.m
+++ b/SDWebImage/SDMemoryCache.m
@@ -7,15 +7,144 @@
  */
 
 #import "SDMemoryCache.h"
+#import "SDImageCacheConfig.h"
+
+#define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
+#define UNLOCK(lock) dispatch_semaphore_signal(lock);
+
+NSUInteger SDMemoryCacheCostForImage(UIImage * _Nullable image) {
+#if SD_MAC
+    return image.size.height * image.size.width;
+#elif SD_UIKIT || SD_WATCH
+    return image.size.height * image.size.width * image.scale * image.scale;
+#endif
+}
+
+static void * SDMemoryCacheContext = &SDMemoryCacheContext;
+
+@interface SDMemoryCache <KeyType, ObjectType> ()
+
+@property (nonatomic, strong, nullable) SDImageCacheConfig *config;
+@property (nonatomic, strong, nonnull) NSMapTable<KeyType, ObjectType> *weakCache; // strong-weak cache
+@property (nonatomic, strong, nonnull) dispatch_semaphore_t weakCacheLock; // a lock to keep the access to `weakCache` thread-safe
+
+@end
 
 @implementation SDMemoryCache
 
-- (NSUInteger)costLimit {
-    return self.totalCostLimit;
+- (void)dealloc {
+    [_config removeObserver:self forKeyPath:NSStringFromSelector(@selector(maxMemoryCost)) context:SDMemoryCacheContext];
+    [_config removeObserver:self forKeyPath:NSStringFromSelector(@selector(maxMemoryCount)) context:SDMemoryCacheContext];
+#if SD_UIKIT
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+#endif
 }
 
-- (void)setCostLimit:(NSUInteger)costLimit {
-    self.totalCostLimit = costLimit;
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _config = [[SDImageCacheConfig alloc] init];
+        [self commonInit];
+    }
+    return self;
+}
+
+- (instancetype)initWithConfig:(SDImageCacheConfig *)config {
+    self = [super init];
+    if (self) {
+        _config = config;
+        [self commonInit];
+    }
+    return self;
+}
+
+- (void)commonInit {
+    self.weakCache = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsStrongMemory valueOptions:NSPointerFunctionsWeakMemory capacity:0];
+    self.weakCacheLock = dispatch_semaphore_create(1);
+    
+    SDImageCacheConfig *config = self.config;
+    self.totalCostLimit = config.maxMemoryCost;
+    self.countLimit = config.maxMemoryCount;
+    
+    [config addObserver:self forKeyPath:NSStringFromSelector(@selector(maxMemoryCost)) options:0 context:SDMemoryCacheContext];
+    [config addObserver:self forKeyPath:NSStringFromSelector(@selector(maxMemoryCount)) options:0 context:SDMemoryCacheContext];
+    
+#if SD_UIKIT
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(didReceiveMemoryWarning:)
+                                                 name:UIApplicationDidReceiveMemoryWarningNotification
+                                               object:nil];
+#endif
+}
+
+// Current this seems no use on macOS (macOS use virtual memory and do not clear cache when memory warning). So we only override on iOS/tvOS platform.
+#if SD_UIKIT
+- (void)didReceiveMemoryWarning:(NSNotification *)notification {
+    // Only remove cache, but keep weak cache
+    [super removeAllObjects];
+}
+
+// `setObject:forKey:` just call this with 0 cost. Override this is enough
+- (void)setObject:(id)obj forKey:(id)key cost:(NSUInteger)g {
+    [super setObject:obj forKey:key cost:g];
+    if (key && obj) {
+        // Store weak cache
+        LOCK(self.weakCacheLock);
+        [self.weakCache setObject:obj forKey:key];
+        UNLOCK(self.weakCacheLock);
+    }
+}
+
+- (id)objectForKey:(id)key {
+    id obj = [super objectForKey:key];
+    if (key && !obj) {
+        // Check weak cache
+        LOCK(self.weakCacheLock);
+        obj = [self.weakCache objectForKey:key];
+        UNLOCK(self.weakCacheLock);
+        if (obj) {
+            // Sync cache
+            NSUInteger cost = 0;
+            if ([obj isKindOfClass:[UIImage class]]) {
+                cost = SDMemoryCacheCostForImage(obj);
+            }
+            [super setObject:obj forKey:key cost:cost];
+        }
+    }
+    return obj;
+}
+
+- (void)removeObjectForKey:(id)key {
+    [super removeObjectForKey:key];
+    if (key) {
+        // Remove weak cache
+        LOCK(self.weakCacheLock);
+        [self.weakCache removeObjectForKey:key];
+        UNLOCK(self.weakCacheLock);
+    }
+}
+
+- (void)removeAllObjects {
+    [super removeAllObjects];
+    // Manually remove should also remove weak cache
+    LOCK(self.weakCacheLock);
+    [self.weakCache removeAllObjects];
+    UNLOCK(self.weakCacheLock);
+}
+#endif
+
+#pragma mark - KVO
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
+    if (context == SDMemoryCacheContext) {
+        if ([keyPath isEqualToString:NSStringFromSelector(@selector(maxMemoryCost))]) {
+            self.totalCostLimit = self.config.maxMemoryCost;
+        } else if ([keyPath isEqualToString:NSStringFromSelector(@selector(maxMemoryCount))]) {
+            self.countLimit = self.config.maxMemoryCount;
+        }
+    } else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
 }
 
 @end

--- a/SDWebImage/SDMemoryCache.m
+++ b/SDWebImage/SDMemoryCache.m
@@ -1,0 +1,21 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDMemoryCache.h"
+
+@implementation SDMemoryCache
+
+- (NSUInteger)costLimit {
+    return self.totalCostLimit;
+}
+
+- (void)setCostLimit:(NSUInteger)costLimit {
+    self.totalCostLimit = costLimit;
+}
+
+@end

--- a/SDWebImage/SDWebImageCache.h
+++ b/SDWebImage/SDWebImageCache.h
@@ -13,29 +13,30 @@
 
 typedef NS_ENUM(NSInteger, SDImageCacheType) {
     /**
-     * For query op, means the image wasn't available the SDWebImage caches, but was downloaded from the web.
-     * For store, remove and clear op, this have no effect.
+     * For query and contains op in response, means the image isn't available in the image cache
+     * For op in request, this have no effect.
      */
     SDImageCacheTypeNone,
     /**
-     * For query op, means the image was obtained from the disk cache.
-     * For store, remove and clear op, means only disk cache.
+     * For query and contains op in response, means the image was obtained from the disk cache.
+     * For op in request, means process only disk cache.
      */
     SDImageCacheTypeDisk,
     /**
-     * For query op, means the image was obtained from the memory cache.
-     * For store, remove and clear op, means only memory cache.
+     * For query and contains op in response, means the image was obtained from the memory cache.
+     * For op in request, means process only memory cache.
      */
     SDImageCacheTypeMemory,
     /**
-     * For query op, means the image was obtained from memory cache, but image data is from disk cache.
-     * For store, remove and clear op, means both memory cache and disk cache.
+     * For query op in response, means the image was obtained from memory cache, but image data is from disk cache.
+     * For contains op in response, means the image is available in both memory cache and disk cache.
+     * For op in request, means process both memory cache and disk cache.
      */
     SDImageCacheTypeBoth
 };
 
-typedef void(^SDImageCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);
-
+typedef void(^SDImageCacheQueryCompletionBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);
+typedef void(^SDImageCacheContainsCompletionBlock)(SDImageCacheType containsCacheType);
 
 /**
  This is the image cache protocol to provide custom image cache for `SDWebImageManager`.
@@ -44,6 +45,7 @@ typedef void(^SDImageCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData
  */
 @protocol SDWebImageCache <NSObject>
 
+@required
 /**
  Query the cached image from image cache for given key. The operation can be used to cancel the query.
  The completion is called synchronously or aynchronously depends on the options arg (See `SDWebImageQueryDiskSync`)
@@ -57,7 +59,7 @@ typedef void(^SDImageCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData
 - (nullable id<SDWebImageOperation>)queryImageForKey:(nullable NSString *)key
                                              options:(SDWebImageOptions)options
                                              context:(nullable SDWebImageContext *)context
-                                          completion:(nullable SDImageCacheQueryCompletedBlock)completionBlock;
+                                          completion:(nullable SDImageCacheQueryCompletionBlock)completionBlock;
 
 /**
  Store the image into image cache for the given key. If cache type is memory only, completion is called synchronously, else aynchronously.
@@ -85,6 +87,16 @@ typedef void(^SDImageCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData
                 cacheType:(SDImageCacheType)cacheType
                completion:(nullable SDWebImageNoParamsBlock)completionBlock;
 
+/**
+ Check if image cache contains the image for the given key (does not load the image). If cache type is memory only, completion is called synchronously, else aynchronously.
+
+ @param key The image cache key
+ @param cacheType The image contains op cache type
+ @param completionBlock A block executed after the operation is finished.
+ */
+- (void)containsImageForKey:(nullable NSString *)key
+                  cacheType:(SDImageCacheType)cacheType
+                 completion:(nullable SDImageCacheContainsCompletionBlock)completionBlock;
 
 /**
  Clear all the cached images for image cache. If cache type is memory only, completion is called synchronously, else aynchronously.

--- a/SDWebImage/SDWebImageCache.h
+++ b/SDWebImage/SDWebImageCache.h
@@ -38,9 +38,9 @@ typedef void(^SDImageCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData
 
 
 /**
- This is the image cache protocol to provide custom image cache for web cache manager.
+ This is the image cache protocol to provide custom image cache for `SDWebImageManager`.
  Though the best practice to custom image cache, is to write your own class which conform `SDMemoryCache` or `SDDiskCache` protocol for `SDImageCache` class (See more on `SDImageCacheConfig.memoryCacheClass & SDImageCacheConfig.diskCacheClass`).
- However, if your own cache implementation contains more advanced feature beyond this, you can consider to provide this instead. For example, you can even use a cache manager like `SDWebImageCachesManager` to register multiple caches.
+ However, if your own cache implementation contains more advanced feature beyond `SDImageCache` itself, you can consider to provide this instead. For example, you can even use a cache manager like `SDWebImageCachesManager` to register multiple caches.
  */
 @protocol SDWebImageCache <NSObject>
 
@@ -79,7 +79,7 @@ typedef void(^SDImageCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData
 
  @param key The image cache key
  @param cacheType The image remove op cache type
- @param completion A block executed after the operation is finished
+ @param completionBlock A block executed after the operation is finished
  */
 - (void)removeImageForKey:(nullable NSString *)key
                 cacheType:(SDImageCacheType)cacheType
@@ -90,7 +90,7 @@ typedef void(^SDImageCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData
  Clear all the cached images for image cache. If cache type is memory only, completion is called synchronously, else aynchronously.
 
  @param cacheType The image clear op cache type
- @param completion A block executed after the operation is finished
+ @param completionBlock A block executed after the operation is finished
  */
 - (void)clearWithCacheType:(SDImageCacheType)cacheType
                 completion:(nullable SDWebImageNoParamsBlock)completionBlock;

--- a/SDWebImage/SDWebImageCache.h
+++ b/SDWebImage/SDWebImageCache.h
@@ -1,0 +1,98 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import <Foundation/Foundation.h>
+#import "SDWebImageCompat.h"
+#import "SDWebImageOperation.h"
+#import "SDWebImageDefine.h"
+
+typedef NS_ENUM(NSInteger, SDImageCacheType) {
+    /**
+     * For query op, means the image wasn't available the SDWebImage caches, but was downloaded from the web.
+     * For store, remove and clear op, this have no effect.
+     */
+    SDImageCacheTypeNone,
+    /**
+     * For query op, means the image was obtained from the disk cache.
+     * For store, remove and clear op, means only disk cache.
+     */
+    SDImageCacheTypeDisk,
+    /**
+     * For query op, means the image was obtained from the memory cache.
+     * For store, remove and clear op, means only memory cache.
+     */
+    SDImageCacheTypeMemory,
+    /**
+     * For query op, means the image was obtained from memory cache, but image data is from disk cache.
+     * For store, remove and clear op, means both memory cache and disk cache.
+     */
+    SDImageCacheTypeBoth
+};
+
+typedef void(^SDImageCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);
+
+
+/**
+ This is the image cache protocol to provide custom image cache for web cache manager.
+ Though the best practice to custom image cache, is to write your own class which conform `SDMemoryCache` or `SDDiskCache` protocol for `SDImageCache` class (See more on `SDImageCacheConfig.memoryCacheClass & SDImageCacheConfig.diskCacheClass`).
+ However, if your own cache implementation contains more advanced feature beyond this, you can consider to provide this instead. For example, you can even use a cache manager like `SDWebImageCachesManager` to register multiple caches.
+ */
+@protocol SDWebImageCache <NSObject>
+
+/**
+ Query the cached image from image cache for given key. The operation can be used to cancel the query.
+ The completion is called synchronously or aynchronously depends on the options arg (See `SDWebImageQueryDiskSync`)
+
+ @param key The image cache key
+ @param options A mask to specify options to use for this query
+ @param context A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ @param completionBlock The completion block. Will not get called if the operation is cancelled
+ @return The operation for this query
+ */
+- (nullable id<SDWebImageOperation>)queryImageForKey:(nullable NSString *)key
+                                             options:(SDWebImageOptions)options
+                                             context:(nullable SDWebImageContext *)context
+                                          completion:(nullable SDImageCacheQueryCompletedBlock)completionBlock;
+
+/**
+ Store the image into image cache for the given key. If cache type is memory only, completion is called synchronously, else aynchronously.
+
+ @param image The image to store
+ @param imageData The image data to be used for disk storage
+ @param key The image cache key
+ @param cacheType The image store op cache type
+ @param completionBlock A block executed after the operation is finished
+ */
+- (void)storeImage:(nullable UIImage *)image
+         imageData:(nullable NSData *)imageData
+            forKey:(nullable NSString *)key
+         cacheType:(SDImageCacheType)cacheType
+        completion:(nullable SDWebImageNoParamsBlock)completionBlock;
+
+/**
+ Remove the image from image cache for the given key. If cache type is memory only, completion is called synchronously, else aynchronously.
+
+ @param key The image cache key
+ @param cacheType The image remove op cache type
+ @param completion A block executed after the operation is finished
+ */
+- (void)removeImageForKey:(nullable NSString *)key
+                cacheType:(SDImageCacheType)cacheType
+               completion:(nullable SDWebImageNoParamsBlock)completionBlock;
+
+
+/**
+ Clear all the cached images for image cache. If cache type is memory only, completion is called synchronously, else aynchronously.
+
+ @param cacheType The image clear op cache type
+ @param completion A block executed after the operation is finished
+ */
+- (void)clearWithCacheType:(SDImageCacheType)cacheType
+                completion:(nullable SDWebImageNoParamsBlock)completionBlock;
+
+@end

--- a/SDWebImage/SDWebImageCache.h
+++ b/SDWebImage/SDWebImageCache.h
@@ -14,7 +14,7 @@
 typedef NS_ENUM(NSInteger, SDImageCacheType) {
     /**
      * For query and contains op in response, means the image isn't available in the image cache
-     * For op in request, this have no effect.
+     * For op in request, this type is not available and take no effect.
      */
     SDImageCacheTypeNone,
     /**
@@ -28,8 +28,7 @@ typedef NS_ENUM(NSInteger, SDImageCacheType) {
      */
     SDImageCacheTypeMemory,
     /**
-     * For query op in response, means the image was obtained from memory cache, but image data is from disk cache.
-     * For contains op in response, means the image is available in both memory cache and disk cache.
+     * For query and contains op in response, this type is not available and take no effect.
      * For op in request, means process both memory cache and disk cache.
      */
     SDImageCacheTypeBoth
@@ -48,7 +47,7 @@ typedef void(^SDImageCacheContainsCompletionBlock)(SDImageCacheType containsCach
 @required
 /**
  Query the cached image from image cache for given key. The operation can be used to cancel the query.
- The completion is called synchronously or aynchronously depends on the options arg (See `SDWebImageQueryDiskSync`)
+ If image is cached in memory, completion is called synchronously, else aynchronously and depends on the options arg (See `SDWebImageQueryDiskSync`)
 
  @param key The image cache key
  @param options A mask to specify options to use for this query
@@ -88,7 +87,7 @@ typedef void(^SDImageCacheContainsCompletionBlock)(SDImageCacheType containsCach
                completion:(nullable SDWebImageNoParamsBlock)completionBlock;
 
 /**
- Check if image cache contains the image for the given key (does not load the image). If cache type is memory only, completion is called synchronously, else aynchronously.
+ Check if image cache contains the image for the given key (does not load the image). If image is cached in memory, completion is called synchronously, else aynchronously.
 
  @param key The image cache key
  @param cacheType The image contains op cache type

--- a/SDWebImage/SDWebImageCache.m
+++ b/SDWebImage/SDWebImageCache.m
@@ -1,0 +1,9 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDWebImageCache.h"

--- a/SDWebImage/SDWebImageCachesManager.h
+++ b/SDWebImage/SDWebImageCachesManager.h
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import <Foundation/Foundation.h>
+#import "SDWebImageCache.h"
+
+typedef NS_ENUM(NSUInteger, SDWebImageCachesManagerOperationPolicy) {
+    SDWebImageCachesManagerOperationPolicyAll, // process all caches
+    SDWebImageCachesManagerOperationPolicyHighest, // process the highest priority cache only
+    SDWebImageCachesManagerOperationPolicyLowest // process the lowest priority cache only
+};
+
+@interface SDWebImageCachesManager : NSObject <SDWebImageCache>
+
+/**
+ Returns the global shared caches manager instance.
+ */
+@property (nonatomic, class, readonly, nonnull) SDWebImageCachesManager *sharedManager;
+
+// These are op policy for cache manager.
+
+/**
+ Operation policy for query op. `All` means query all caches serially (one completion called then next begin) until one cache query success.
+ Defaults to `All`
+ */
+@property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy queryOperationPolicy;
+
+/**
+ Operation policy for store op. `All` means store all caches concurrently.
+ Defaults to `Highest`
+ */
+@property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy storeOperationPolicy;
+
+/**
+ Operation policy for remove op. `All` means remove all caches concurrently.
+ Defaults to `All`
+ */
+@property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy removeOperationPolicy;
+
+/**
+ Operation policy for clear op. `All` means clear all caches concurrently.
+ Defaults to `All`
+ */
+@property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy clearOperationPolicy;
+
+/**
+ All caches in caches manager. The caches array is a priority queue, which means the later added cache will have the highest priority
+ */
+@property (atomic, copy, readwrite, nullable) NSArray<id<SDWebImageCache>> *caches;
+
+/**
+ Add a new cache to the end of caches array. Which has the highest priority.
+ 
+ @param cache cache
+ */
+- (void)addCache:(nonnull id<SDWebImageCache>)cache;
+
+/**
+ Remove a cache in the caches array.
+ 
+ @param cache cache
+ */
+- (void)removeCache:(nonnull id<SDWebImageCache>)cache;
+
+@end

--- a/SDWebImage/SDWebImageCachesManager.h
+++ b/SDWebImage/SDWebImageCachesManager.h
@@ -10,9 +10,10 @@
 #import "SDWebImageCache.h"
 
 typedef NS_ENUM(NSUInteger, SDWebImageCachesManagerOperationPolicy) {
-    SDWebImageCachesManagerOperationPolicyAll, // process all caches
-    SDWebImageCachesManagerOperationPolicyHighest, // process the highest priority cache only
-    SDWebImageCachesManagerOperationPolicyLowest // process the lowest priority cache only
+    SDWebImageCachesManagerOperationPolicySerial, // process all caches serially (from the highest priority to the lowest priority cache by order)
+    SDWebImageCachesManagerOperationPolicyConcurrent, // process all caches concurrently
+    SDWebImageCachesManagerOperationPolicyHighestOnly, // process the highest priority cache only
+    SDWebImageCachesManagerOperationPolicyLowestOnly // process the lowest priority cache only
 };
 
 @interface SDWebImageCachesManager : NSObject <SDWebImageCache>
@@ -25,26 +26,26 @@ typedef NS_ENUM(NSUInteger, SDWebImageCachesManagerOperationPolicy) {
 // These are op policy for cache manager.
 
 /**
- Operation policy for query op. `All` means query all caches serially (one completion called then next begin) until one cache query success.
- Defaults to `All`
+ Operation policy for query op.
+ Defaults to `Serial`, means query all caches serially (one completion called then next begin) until one cache query success.
  */
 @property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy queryOperationPolicy;
 
 /**
- Operation policy for store op. `All` means store all caches concurrently.
- Defaults to `Highest`
+ Operation policy for store op.
+ Defaults to `HighestOnly`, means store to the highest priority cache only.
  */
 @property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy storeOperationPolicy;
 
 /**
- Operation policy for remove op. `All` means remove all caches concurrently.
- Defaults to `All`
+ Operation policy for remove op.
+ Defaults to `Concurrent`, means remove all caches concurrently.
  */
 @property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy removeOperationPolicy;
 
 /**
- Operation policy for clear op. `All` means clear all caches concurrently.
- Defaults to `All`
+ Operation policy for clear op.
+ Defaults to `Concurrent`, means clear all caches concurrently.
  */
 @property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy clearOperationPolicy;
 

--- a/SDWebImage/SDWebImageCachesManager.h
+++ b/SDWebImage/SDWebImageCachesManager.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSUInteger, SDWebImageCachesManagerOperationPolicy) {
 
 /**
  Operation policy for query op.
- Defaults to `Serial`, means query all caches serially (one completion called then next begin) until one cache query success.
+ Defaults to `Serial`, means query all caches serially (one completion called then next begin) until one cache query success (`image` != nil).
  */
 @property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy queryOperationPolicy;
 
@@ -42,6 +42,12 @@ typedef NS_ENUM(NSUInteger, SDWebImageCachesManagerOperationPolicy) {
  Defaults to `Concurrent`, means remove all caches concurrently.
  */
 @property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy removeOperationPolicy;
+
+/**
+ Operation policy for contains op.
+ Defaults to `Serial`, means check all caches serially (one completion called then next begin) until one cache check success (`containsCacheType` != None).
+ */
+@property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy containsOperationPolicy;
 
 /**
  Operation policy for clear op.

--- a/SDWebImage/SDWebImageCachesManager.m
+++ b/SDWebImage/SDWebImageCachesManager.m
@@ -1,0 +1,239 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDWebImageCachesManager.h"
+
+#define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
+#define UNLOCK(lock) dispatch_semaphore_signal(lock);
+
+@implementation SDWebImageCachesManager
+
++ (SDWebImageCachesManager *)sharedManager {
+    static dispatch_once_t onceToken;
+    static SDWebImageCachesManager *manager;
+    dispatch_once(&onceToken, ^{
+        manager = [[SDWebImageCachesManager alloc] init];
+    });
+    return manager;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.queryOperationPolicy = SDWebImageCachesManagerOperationPolicyAll;
+        self.storeOperationPolicy = SDWebImageCachesManagerOperationPolicyHighest;
+        self.removeOperationPolicy = SDWebImageCachesManagerOperationPolicyAll;
+        self.clearOperationPolicy = SDWebImageCachesManagerOperationPolicyAll;
+    }
+    return self;
+}
+
+#pragma mark - Cache IO operations
+
+- (void)addCache:(id<SDWebImageCache>)cache {
+    if (![cache conformsToProtocol:@protocol(SDWebImageCache)]) {
+        return;
+    }
+    NSMutableArray<id<SDWebImageCache>> *mutableCaches = [self.caches mutableCopy];
+    if (!mutableCaches) {
+        mutableCaches = [NSMutableArray array];
+    }
+    [mutableCaches addObject:cache];
+    self.caches = [mutableCaches copy];
+}
+
+- (void)removeCache:(id<SDWebImageCache>)cache {
+    if (![cache conformsToProtocol:@protocol(SDWebImageCache)]) {
+        return;
+    }
+    NSMutableArray<id<SDWebImageCache>> *mutableCaches = [self.caches mutableCopy];
+    [mutableCaches removeObject:cache];
+    self.caches = [mutableCaches copy];
+}
+
+#pragma mark - SDWebImageCache
+
+- (id<SDWebImageOperation>)queryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletedBlock)completionBlock {
+    if (!key) {
+        return nil;
+    }
+    NSArray<id<SDWebImageCache>> *caches = [self.caches copy];
+    NSUInteger count = caches.count;
+    if (count == 0) {
+        return nil;
+    } else if (count == 1) {
+        return [caches.firstObject queryImageForKey:key options:options context:context completion:completionBlock];
+    }
+    switch (self.queryOperationPolicy) {
+        case SDWebImageCachesManagerOperationPolicyHighest: {
+            id<SDWebImageCache> cache = caches.lastObject;
+            return [cache queryImageForKey:key options:options context:context completion:completionBlock];
+        }
+            break;
+        case SDWebImageCachesManagerOperationPolicyLowest: {
+            id<SDWebImageCache> cache = caches.firstObject;
+            return [cache queryImageForKey:key options:options context:context completion:completionBlock];
+        }
+            break;
+        case SDWebImageCachesManagerOperationPolicyAll: {
+            NSOperation *operation = [NSOperation new];
+            [self recursiveQueryImageForEnumerator:self.caches.reverseObjectEnumerator operation:operation key:key options:options context:context completion:completionBlock];
+            return operation;
+        }
+            break;
+        default:
+            return nil;
+            break;
+    }
+}
+
+- (void)storeImage:(UIImage *)image imageData:(NSData *)imageData forKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock {
+    if (!key) {
+        return;
+    }
+    NSArray<id<SDWebImageCache>> *caches = [self.caches copy];
+    NSUInteger count = caches.count;
+    if (count == 0) {
+        return;
+    } else if (count == 1) {
+        [caches.firstObject storeImage:image imageData:imageData forKey:key cacheType:cacheType completion:completionBlock];
+    }
+    switch (self.storeOperationPolicy) {
+        case SDWebImageCachesManagerOperationPolicyHighest: {
+            id<SDWebImageCache> cache = caches.lastObject;
+            [cache storeImage:image imageData:imageData forKey:key cacheType:cacheType completion:completionBlock];
+        }
+            break;
+        case SDWebImageCachesManagerOperationPolicyLowest: {
+            id<SDWebImageCache> cache = caches.firstObject;
+            [cache storeImage:image imageData:imageData forKey:key cacheType:cacheType completion:completionBlock];
+        }
+            break;
+        case SDWebImageCachesManagerOperationPolicyAll: {
+            dispatch_group_t group = dispatch_group_create();
+            for (id<SDWebImageCache> cache in caches.reverseObjectEnumerator) {
+                dispatch_group_enter(group);
+                [cache storeImage:image imageData:imageData forKey:key cacheType:cacheType completion:^{
+                    dispatch_group_leave(group);
+                }];
+            }
+            if (completionBlock) {
+                dispatch_group_notify(group, dispatch_get_main_queue(), completionBlock);
+            }
+        }
+            break;
+        default:
+            break;
+    }
+}
+
+- (void)removeImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock {
+    if (!key) {
+        return;
+    }
+    NSArray<id<SDWebImageCache>> *caches = [self.caches copy];
+    NSUInteger count = caches.count;
+    if (count == 0) {
+        return;
+    } else if (count == 1) {
+        [caches.firstObject removeImageForKey:key cacheType:cacheType completion:completionBlock];
+    }
+    switch (self.removeOperationPolicy) {
+        case SDWebImageCachesManagerOperationPolicyHighest: {
+            id<SDWebImageCache> cache = caches.lastObject;
+            [cache removeImageForKey:key cacheType:cacheType completion:completionBlock];
+        }
+            break;
+        case SDWebImageCachesManagerOperationPolicyLowest: {
+            id<SDWebImageCache> cache = caches.firstObject;
+            [cache removeImageForKey:key cacheType:cacheType completion:completionBlock];
+        }
+            break;
+        case SDWebImageCachesManagerOperationPolicyAll: {
+            dispatch_group_t group = dispatch_group_create();
+            for (id<SDWebImageCache> cache in caches.reverseObjectEnumerator) {
+                dispatch_group_enter(group);
+                [cache removeImageForKey:key cacheType:cacheType completion:^{
+                    dispatch_group_leave(group);
+                }];
+            }
+            if (completionBlock) {
+                dispatch_group_notify(group, dispatch_get_main_queue(), completionBlock);
+            }
+        }
+            break;
+        default:
+            break;
+    }
+}
+
+- (void)clearWithCacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock {
+    NSArray<id<SDWebImageCache>> *caches = [self.caches copy];
+    NSUInteger count = caches.count;
+    if (count == 0) {
+        return;
+    } else if (count == 1) {
+        [caches.firstObject clearWithCacheType:cacheType completion:completionBlock];
+    }
+    switch (self.clearOperationPolicy) {
+        case SDWebImageCachesManagerOperationPolicyHighest: {
+            id<SDWebImageCache> cache = caches.lastObject;
+            [cache clearWithCacheType:cacheType completion:completionBlock];
+        }
+            break;
+        case SDWebImageCachesManagerOperationPolicyLowest: {
+            id<SDWebImageCache> cache = caches.firstObject;
+            [cache clearWithCacheType:cacheType completion:completionBlock];
+        }
+            break;
+        case SDWebImageCachesManagerOperationPolicyAll: {
+            dispatch_group_t group = dispatch_group_create();
+            for (id<SDWebImageCache> cache in caches.reverseObjectEnumerator) {
+                dispatch_group_enter(group);
+                [cache clearWithCacheType:cacheType completion:^{
+                    dispatch_group_leave(group);
+                }];
+            }
+            if (completionBlock) {
+                dispatch_group_notify(group, dispatch_get_main_queue(), completionBlock);
+            }
+        }
+            break;
+        default:
+            break;
+    }
+}
+
+#pragma mark - Util
+- (void)recursiveQueryImageForEnumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(NSOperation *)operation key:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletedBlock)completionBlock {
+    if (operation.isCancelled) {
+        return;
+    }
+    id<SDWebImageCache> cache = enumerator.nextObject;
+    if (!cache) {
+        // Failed
+        if (completionBlock) {
+            completionBlock(nil, nil, SDImageCacheTypeNone);
+        }
+        return;
+    }
+    __weak typeof(self) wself = self;
+    [cache queryImageForKey:key options:options context:context completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
+        if (image) {
+            // Finished
+            if (completionBlock) {
+                completionBlock(image, data, cacheType);
+            }
+            return;
+        }
+        // Next
+        [wself recursiveQueryImageForEnumerator:enumerator operation:operation key:key options:options context:context completion:completionBlock];
+    }];
+}
+
+@end

--- a/SDWebImage/SDWebImageCachesManager.m
+++ b/SDWebImage/SDWebImageCachesManager.m
@@ -553,7 +553,7 @@
             // Success
             [operation done];
             if (completionBlock) {
-                completionBlock(cacheType);
+                completionBlock(containsCacheType);
             }
             return;
         }

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -101,7 +101,7 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 /**
  * The image cache used by manager to query image cache.
  */
-@property (strong, nonatomic, readonly, nonnull) SDImageCache *imageCache;
+@property (strong, nonatomic, readonly, nonnull) id<SDWebImageCache> imageCache;
 
 /**
  * The image downloader used by manager to download image.
@@ -168,7 +168,7 @@ SDWebImageManager.sharedManager.cacheKeyFilter = ^(NSURL * _Nullable url) {
  * Allows to specify instance of cache and image downloader used with image manager.
  * @return new instance of `SDWebImageManager` with specified cache and downloader.
  */
-- (nonnull instancetype)initWithCache:(nonnull SDImageCache *)cache downloader:(nonnull SDWebImageDownloader *)downloader NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithCache:(nonnull id<SDWebImageCache>)cache downloader:(nonnull SDWebImageDownloader *)downloader NS_DESIGNATED_INITIALIZER;
 
 /**
  * Downloads the image at the given URL if not present in cache or return the cached version otherwise.
@@ -219,42 +219,9 @@ SDWebImageManager.sharedManager.cacheKeyFilter = ^(NSURL * _Nullable url) {
                                                  completed:(nonnull SDInternalCompletionBlock)completedBlock;
 
 /**
- * Saves image to cache for given URL
- *
- * @param image The image to cache
- * @param url   The URL to the image
- *
- */
-
-- (void)saveImageToCache:(nullable UIImage *)image forURL:(nullable NSURL *)url;
-
-/**
  * Cancel all current operations
  */
 - (void)cancelAll;
-
-/**
- *  Async check if image has already been cached
- *
- *  @param url              image url
- *  @param completionBlock  the block to be executed when the check is finished
- *  
- *  @note the completion block is always executed on the main queue
- */
-- (void)cachedImageExistsForURL:(nullable NSURL *)url
-                     completion:(nullable SDWebImageCheckCacheCompletionBlock)completionBlock;
-
-/**
- *  Async check if image has already been cached on disk only
- *
- *  @param url              image url
- *  @param completionBlock  the block to be executed when the check is finished
- *
- *  @note the completion block is always executed on the main queue
- */
-- (void)diskImageExistsForURL:(nullable NSURL *)url
-                   completion:(nullable SDWebImageCheckCacheCompletionBlock)completionBlock;
-
 
 /**
  *Return the cache key for a given URL

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -8,8 +8,8 @@
 
 #import "SDWebImageCompat.h"
 #import "SDWebImageOperation.h"
+#import "SDWebImageCache.h"
 #import "SDWebImageDownloader.h"
-#import "SDImageCache.h"
 #import "SDWebImageTransformer.h"
 
 typedef void(^SDExternalCompletionBlock)(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL);
@@ -158,6 +158,16 @@ SDWebImageManager.sharedManager.cacheKeyFilter = ^(NSURL * _Nullable url) {
  * Check one or more operations running
  */
 @property (nonatomic, assign, readonly, getter=isRunning) BOOL running;
+
+/**
+ The default image cache when the manager which is created with no arguments. Such as shared manager.
+ */
+@property (nonatomic, class, nonnull) id<SDWebImageCache> defaultImageCache;
+
+/**
+ The default image downloader for manager which is created with no arguments. Such as shared manager.
+ */
+@property (nonatomic, class, nonnull) SDWebImageDownloader *defaultImageDownloader;
 
 /**
  * Returns global shared manager instance.

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -160,14 +160,16 @@ SDWebImageManager.sharedManager.cacheKeyFilter = ^(NSURL * _Nullable url) {
 @property (nonatomic, assign, readonly, getter=isRunning) BOOL running;
 
 /**
- The default image cache when the manager which is created with no arguments. Such as shared manager.
+ The default image cache when the manager which is created with no arguments. Such as shared manager or init.
+ Defaults to nil. Means using `SDImageCache.sharedImageCache`
  */
-@property (nonatomic, class, nonnull) id<SDWebImageCache> defaultImageCache;
+@property (nonatomic, class, nullable) id<SDWebImageCache> defaultImageCache;
 
 /**
- The default image downloader for manager which is created with no arguments. Such as shared manager.
+ The default image downloader for manager which is created with no arguments. Such as shared manager or init.
+ Defaults to nil. Means using `SDWebImageDownloader.sharedDownloader`
  */
-@property (nonatomic, class, nonnull) SDWebImageDownloader *defaultImageDownloader;
+@property (nonatomic, class, nullable) SDWebImageDownloader *defaultImageDownloader;
 
 /**
  * Returns global shared manager instance.

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -236,7 +236,7 @@ SDWebImageManager.sharedManager.cacheKeyFilter = ^(NSURL * _Nullable url) {
 - (void)cancelAll;
 
 /**
- *Return the cache key for a given URL
+ * Return the cache key for a given URL
  */
 - (nullable NSString *)cacheKeyForURL:(nullable NSURL *)url;
 

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -36,29 +36,23 @@ static SDWebImageDownloader *_defaultImageDownloader;
 
 @implementation SDWebImageManager
 
-+ (nonnull id<SDWebImageCache>)defaultImageCache {
-    if (!_defaultImageCache) {
-        _defaultImageCache = [SDImageCache sharedImageCache];
-    }
++ (id<SDWebImageCache>)defaultImageCache {
     return _defaultImageCache;
 }
 
 + (void)setDefaultImageCache:(id<SDWebImageCache>)defaultImageCache {
-    if (![defaultImageCache conformsToProtocol:@protocol(SDWebImageCache)]) {
+    if (defaultImageCache && ![defaultImageCache conformsToProtocol:@protocol(SDWebImageCache)]) {
         return;
     }
     _defaultImageCache = defaultImageCache;
 }
 
 + (SDWebImageDownloader *)defaultImageDownloader {
-    if (!_defaultImageDownloader) {
-        _defaultImageDownloader = [SDWebImageDownloader sharedDownloader];
-    }
     return _defaultImageDownloader;
 }
 
 + (void)setDefaultImageDownloader:(SDWebImageDownloader *)defaultImageDownloader {
-    if (!defaultImageDownloader) {
+    if (defaultImageDownloader && ![defaultImageDownloader isKindOfClass:[SDWebImageDownloader class]]) {
         return;
     }
     _defaultImageDownloader = defaultImageDownloader;
@@ -75,7 +69,13 @@ static SDWebImageDownloader *_defaultImageDownloader;
 
 - (nonnull instancetype)init {
     id<SDWebImageCache> cache = [[self class] defaultImageCache];
+    if (!cache) {
+        cache = [SDImageCache sharedImageCache];
+    }
     SDWebImageDownloader *downloader = [[self class] defaultImageDownloader];
+    if (!downloader) {
+        downloader = [SDWebImageDownloader sharedDownloader];
+    }
     return [self initWithCache:cache downloader:downloader];
 }
 

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -8,7 +8,6 @@
 
 #import "SDWebImageManager.h"
 #import "SDImageCache.h"
-#import "SDWebImageCachesManager.h"
 #import "NSImage+Additions.h"
 #import "UIImage+WebCache.h"
 #import "SDAnimatedImage.h"

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -72,42 +72,6 @@
     return SDScaledImageForKey(key, image);
 }
 
-- (void)cachedImageExistsForURL:(nullable NSURL *)url
-                     completion:(nullable SDWebImageCheckCacheCompletionBlock)completionBlock {
-    NSString *key = [self cacheKeyForURL:url];
-    
-    BOOL isInMemoryCache = ([self.imageCache imageFromMemoryCacheForKey:key] != nil);
-    
-    if (isInMemoryCache) {
-        // making sure we call the completion block on the main queue
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (completionBlock) {
-                completionBlock(YES);
-            }
-        });
-        return;
-    }
-    
-    [self.imageCache diskImageExistsWithKey:key completion:^(BOOL isInDiskCache) {
-        // the completion block of checkDiskCacheForImageWithKey:completion: is always called on the main queue, no need to further dispatch
-        if (completionBlock) {
-            completionBlock(isInDiskCache);
-        }
-    }];
-}
-
-- (void)diskImageExistsForURL:(nullable NSURL *)url
-                   completion:(nullable SDWebImageCheckCacheCompletionBlock)completionBlock {
-    NSString *key = [self cacheKeyForURL:url];
-    
-    [self.imageCache diskImageExistsWithKey:key completion:^(BOOL isInDiskCache) {
-        // the completion block of checkDiskCacheForImageWithKey:completion: is always called on the main queue, no need to further dispatch
-        if (completionBlock) {
-            completionBlock(isInDiskCache);
-        }
-    }];
-}
-
 - (SDWebImageCombinedOperation *)loadImageWithURL:(NSURL *)url options:(SDWebImageOptions)options progress:(SDWebImageDownloaderProgressBlock)progressBlock completed:(SDInternalCompletionBlock)completedBlock {
     return [self loadImageWithURL:url options:options context:nil progress:progressBlock completed:completedBlock];
 }
@@ -151,13 +115,6 @@
     }
     NSString *key = [self cacheKeyForURL:url];
     
-    SDImageCacheOptions cacheOptions = 0;
-    if (options & SDWebImageQueryDataWhenInMemory) cacheOptions |= SDImageCacheQueryDataWhenInMemory;
-    if (options & SDWebImageQueryDiskSync) cacheOptions |= SDImageCacheQueryDiskSync;
-    if (options & SDWebImageTransformAnimatedImage) cacheOptions |= SDImageCacheTransformAnimatedImage;
-    if (options & SDWebImageDecodeFirstFrameOnly) cacheOptions |= SDImageCacheDecodeFirstFrameOnly;
-    if (options & SDWebImagePreloadAllFrames) cacheOptions |= SDImageCachePreloadAllFrames;
-    
     // Image transformer
     id<SDWebImageTransformer> transformer;
     if ([context valueForKey:SDWebImageContextCustomTransformer]) {
@@ -176,7 +133,7 @@
     }
     
     __weak SDWebImageCombinedOperation *weakOperation = operation;
-    operation.cacheOperation = [self.imageCache queryCacheOperationForKey:key options:cacheOptions context:context done:^(UIImage *cachedImage, NSData *cachedData, SDImageCacheType cacheType) {
+    operation.cacheOperation = [self.imageCache queryImageForKey:key options:options context:context completion:^(UIImage * _Nullable cachedImage, NSData * _Nullable cachedData, SDImageCacheType cacheType) {
         __strong __typeof(weakOperation) strongOperation = weakOperation;
         if (!strongOperation || strongOperation.isCancelled) {
             [self safelyRemoveOperationFromRunning:strongOperation];
@@ -252,7 +209,10 @@
                         }
                     }
                     
-                    BOOL cacheOnDisk = !(options & SDWebImageCacheMemoryOnly);
+                    SDImageCacheType storeCacheType = SDImageCacheTypeBoth;
+                    if (options & SDWebImageCacheMemoryOnly) {
+                        storeCacheType = SDImageCacheTypeMemory;
+                    }
                     
                     // We've done the scale process in SDWebImageDownloader with the shared manager, this is used for custom manager and avoid extra scale.
                     if (self != [SDWebImageManager sharedManager] && self.cacheKeyFilter && downloadedImage && ![downloadedImage conformsToProtocol:@protocol(SDAnimatedImage)]) {
@@ -275,7 +235,7 @@
                                 } else {
                                     cacheData = (imageWasTransformed ? nil : downloadedData);
                                 }
-                                [self.imageCache storeImage:transformedImage imageData:cacheData forKey:cacheKey toDisk:cacheOnDisk completion:nil];
+                                [self.imageCache storeImage:transformedImage imageData:cacheData forKey:cacheKey cacheType:storeCacheType completion:nil];
                             }
                             
                             [self callCompletionBlockForOperation:strongSubOperation completion:completedBlock image:transformedImage data:downloadedData error:nil cacheType:SDImageCacheTypeNone finished:finished url:url];
@@ -285,10 +245,10 @@
                             if (self.cacheSerializer) {
                                 dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
                                     NSData *cacheData = self.cacheSerializer(downloadedImage, downloadedData, url);
-                                    [self.imageCache storeImage:downloadedImage imageData:cacheData forKey:key toDisk:cacheOnDisk completion:nil];
+                                    [self.imageCache storeImage:downloadedImage imageData:cacheData forKey:key cacheType:storeCacheType completion:nil];
                                 });
                             } else {
-                                [self.imageCache storeImage:downloadedImage imageData:downloadedData forKey:key toDisk:cacheOnDisk completion:nil];
+                                [self.imageCache storeImage:downloadedImage imageData:downloadedData forKey:key cacheType:storeCacheType completion:nil];
                             }
                         }
                         [self callCompletionBlockForOperation:strongSubOperation completion:completedBlock image:downloadedImage data:downloadedData error:nil cacheType:SDImageCacheTypeNone finished:finished url:url];
@@ -310,13 +270,6 @@
     }];
 
     return operation;
-}
-
-- (void)saveImageToCache:(nullable UIImage *)image forURL:(nullable NSURL *)url {
-    if (image && url) {
-        NSString *key = [self cacheKeyForURL:url];
-        [self.imageCache storeImage:image forKey:key toDisk:YES completion:nil];
-    }
 }
 
 - (void)cancelAll {

--- a/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
+++ b/Tests/SDWebImage Tests.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		321259EE1F39E4110096FE0E /* TestImageAnimated.webp in Resources */ = {isa = PBXBuildFile; fileRef = 321259ED1F39E4110096FE0E /* TestImageAnimated.webp */; };
 		3226ECBB20754F7700FAFACF /* SDWebImageTestDownloadOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 3226ECBA20754F7700FAFACF /* SDWebImageTestDownloadOperation.m */; };
 		3226ECBC20754F7700FAFACF /* SDWebImageTestDownloadOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 3226ECBA20754F7700FAFACF /* SDWebImageTestDownloadOperation.m */; };
+		323F3EF92073D8EE00640E1D /* SDWebImageTestCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 323F3EF82073D8EE00640E1D /* SDWebImageTestCache.m */; };
+		323F3EFA2073D8EE00640E1D /* SDWebImageTestCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 323F3EF82073D8EE00640E1D /* SDWebImageTestCache.m */; };
 		3254C32020641077008D1022 /* SDWebImageTransformerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3254C31F20641077008D1022 /* SDWebImageTransformerTests.m */; };
 		3254C32120641077008D1022 /* SDWebImageTransformerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3254C31F20641077008D1022 /* SDWebImageTransformerTests.m */; };
 		3264FF2F205D42CB00F6BD48 /* SDWebImageTestTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 3264FF2E205D42CB00F6BD48 /* SDWebImageTestTransformer.m */; };
@@ -67,6 +69,8 @@
 		321259ED1F39E4110096FE0E /* TestImageAnimated.webp */ = {isa = PBXFileReference; lastKnownFileType = file; path = TestImageAnimated.webp; sourceTree = "<group>"; };
 		3226ECB920754F7700FAFACF /* SDWebImageTestDownloadOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageTestDownloadOperation.h; sourceTree = "<group>"; };
 		3226ECBA20754F7700FAFACF /* SDWebImageTestDownloadOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageTestDownloadOperation.m; sourceTree = "<group>"; };
+		323F3EF72073D8EE00640E1D /* SDWebImageTestCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageTestCache.h; sourceTree = "<group>"; };
+		323F3EF82073D8EE00640E1D /* SDWebImageTestCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageTestCache.m; sourceTree = "<group>"; };
 		3254C31F20641077008D1022 /* SDWebImageTransformerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageTransformerTests.m; sourceTree = "<group>"; };
 		3264FF2D205D42CB00F6BD48 /* SDWebImageTestTransformer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageTestTransformer.h; sourceTree = "<group>"; };
 		3264FF2E205D42CB00F6BD48 /* SDWebImageTestTransformer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageTestTransformer.m; sourceTree = "<group>"; };
@@ -216,6 +220,8 @@
 				32E6F0311F3A1B4700A945E6 /* SDWebImageTestDecoder.m */,
 				3264FF2D205D42CB00F6BD48 /* SDWebImageTestTransformer.h */,
 				3264FF2E205D42CB00F6BD48 /* SDWebImageTestTransformer.m */,
+				323F3EF72073D8EE00640E1D /* SDWebImageTestCache.h */,
+				323F3EF82073D8EE00640E1D /* SDWebImageTestCache.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -467,6 +473,7 @@
 				3254C32120641077008D1022 /* SDWebImageTransformerTests.m in Sources */,
 				32B99E9C203B2EE40017FD66 /* SDCategoriesTests.m in Sources */,
 				32B99EAA203B365F0017FD66 /* SDImageCacheTests.m in Sources */,
+				323F3EFA2073D8EE00640E1D /* SDWebImageTestCache.m in Sources */,
 				32B99EAD203B36690017FD66 /* SDWebImagePrefetcherTests.m in Sources */,
 				32B99EAE203B366C0017FD66 /* SDWebCacheCategoriesTests.m in Sources */,
 				32B99E9D203B2F7D0017FD66 /* SDWebImageTestDecoder.m in Sources */,
@@ -486,6 +493,7 @@
 				32E6F0321F3A1B4700A945E6 /* SDWebImageTestDecoder.m in Sources */,
 				3226ECBB20754F7700FAFACF /* SDWebImageTestDownloadOperation.m in Sources */,
 				3254C32020641077008D1022 /* SDWebImageTransformerTests.m in Sources */,
+				323F3EF92073D8EE00640E1D /* SDWebImageTestCache.m in Sources */,
 				32A571562037DB2D002EDAAE /* SDAnimatedImageTest.m in Sources */,
 				1E3C51E919B46E370092B5E6 /* SDWebImageDownloaderTests.m in Sources */,
 				37D122881EC48B5E00D98CEB /* SDMockFileManager.m in Sources */,

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -8,6 +8,7 @@
  */
 
 #import "SDTestCase.h"
+#import <SDWebImage/SDImageCache.h>
 #import <SDWebImage/SDAnimatedImage.h>
 #import <SDWebImage/SDAnimatedImageView.h>
 #import <SDWebImage/SDWebImageGIFCoder.h>

--- a/Tests/Tests/SDMockFileManager.h
+++ b/Tests/Tests/SDMockFileManager.h
@@ -11,6 +11,8 @@
 // This is a mock class to provide custom error for methods
 @interface SDMockFileManager : NSFileManager
 
+@property (nonatomic, strong, readonly, nullable) NSError *lastError;
+
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, NSError *> *mockSelectors; // used to specify mocked selectors which will return NO with specify error instead of normal process. If you specify a NSNull, will use nil instead.
 
 @end

--- a/Tests/Tests/SDMockFileManager.m
+++ b/Tests/Tests/SDMockFileManager.m
@@ -10,11 +10,14 @@
 
 @interface SDMockFileManager ()
 
+@property (nonatomic, strong, nullable) NSError *lastError;
+
 @end
 
 @implementation SDMockFileManager
 
 - (BOOL)createDirectoryAtPath:(NSString *)path withIntermediateDirectories:(BOOL)createIntermediates attributes:(NSDictionary<NSFileAttributeKey,id> *)attributes error:(NSError * _Nullable __autoreleasing *)error {
+    self.lastError = nil;
     NSError *mockError = [self.mockSelectors objectForKey:NSStringFromSelector(_cmd)];
     if ([mockError isEqual:[NSNull null]]) {
         if (error) {
@@ -25,6 +28,7 @@
         if (error) {
             *error = mockError;
         }
+        self.lastError = mockError;
         return NO;
     } else {
         return [super createDirectoryAtPath:path withIntermediateDirectories:createIntermediates attributes:attributes error:error];

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -8,6 +8,7 @@
 
 #import "SDTestCase.h"
 #import <SDWebImage/SDWebImageManager.h>
+#import <SDWebImage/SDImageCache.h>
 #import "SDWebImageTestTransformer.h"
 
 @interface SDWebImageManagerTests : SDTestCase
@@ -59,32 +60,6 @@
         expectation = nil;
     }];
     
-    [self waitForExpectationsWithCommonTimeout];
-}
-
-- (void)test04CachedImageExistsForURL {
-    __block XCTestExpectation *expectation = [self expectationWithDescription:@"Image exists in cache"];
-    NSURL *imageURL = [NSURL URLWithString:kTestJpegURL];
-    [[SDWebImageManager sharedManager] cachedImageExistsForURL:imageURL completion:^(BOOL isInCache) {
-        if (isInCache) {
-            [expectation fulfill];
-        } else {
-            XCTFail(@"Image should be in cache");
-        }
-    }];
-    [self waitForExpectationsWithCommonTimeout];
-}
-
-- (void)test05DiskImageExistsForURL {
-    __block XCTestExpectation *expectation = [self expectationWithDescription:@"Image exists in disk cache"];
-    NSURL *imageURL = [NSURL URLWithString:kTestJpegURL];
-    [[SDWebImageManager sharedManager] diskImageExistsForURL:imageURL completion:^(BOOL isInCache) {
-        if (isInCache) {
-            [expectation fulfill];
-        } else {
-            XCTFail(@"Image should be in cache");
-        }
-    }];
     [self waitForExpectationsWithCommonTimeout];
 }
 

--- a/Tests/Tests/SDWebImagePrefetcherTests.m
+++ b/Tests/Tests/SDWebImagePrefetcherTests.m
@@ -9,6 +9,7 @@
 
 #import "SDTestCase.h"
 #import <SDWebImage/SDWebImagePrefetcher.h>
+#import <SDWebImage/SDImageCache.h>
 
 @interface SDWebImagePrefetcherTests : SDTestCase <SDWebImagePrefetcherDelegate>
 

--- a/Tests/Tests/SDWebImageTestCache.h
+++ b/Tests/Tests/SDWebImageTestCache.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ * (c) Matt Galloway
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import <SDWebImage/SDMemoryCache.h>
+#import <SDWebImage/SDDiskCache.h>
+
+// A really naive implementation of custom memory cache and disk cache
+
+@interface SDWebImageTestMemoryCache : NSObject <SDMemoryCache>
+
+@property (nonatomic, strong, nonnull) SDImageCacheConfig *config;
+@property (nonatomic, strong, nonnull) NSCache *cache;
+
+@end
+
+@interface SDWebImageTestDiskCache : NSObject <SDDiskCache>
+
+@property (nonatomic, strong, nonnull) SDImageCacheConfig *config;
+@property (nonatomic, copy, nonnull) NSString *cachePath;
+@property (nonatomic, strong, nonnull) NSFileManager *fileManager;
+
+@end

--- a/Tests/Tests/SDWebImageTestCache.m
+++ b/Tests/Tests/SDWebImageTestCache.m
@@ -1,0 +1,107 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ * (c) Matt Galloway
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDWebImageTestCache.h"
+#import <SDWebImage/SDImageCacheConfig.h>
+
+@implementation SDWebImageTestMemoryCache
+
+- (nonnull instancetype)initWithConfig:(nonnull SDImageCacheConfig *)config {
+    self = [super init];
+    if (self) {
+        self.config = config;
+        self.cache = [[NSCache alloc] init];
+    }
+    return self;
+}
+
+- (nullable id)objectForKey:(nonnull id)key {
+    return [self.cache objectForKey:key];
+}
+
+- (void)removeAllObjects {
+    [self.cache removeAllObjects];
+}
+
+- (void)removeObjectForKey:(nonnull id)key {
+    [self.cache removeObjectForKey:key];
+}
+
+- (void)setObject:(nullable id)object forKey:(nonnull id)key {
+    [self.cache setObject:object forKey:key];
+}
+
+- (void)setObject:(nullable id)object forKey:(nonnull id)key cost:(NSUInteger)cost {
+    [self.cache setObject:object forKey:key cost:cost];
+}
+
+@end
+
+@implementation SDWebImageTestDiskCache
+
+- (nullable NSString *)cachePathForKey:(nonnull NSString *)key {
+    return [self.cachePath stringByAppendingPathComponent:key];
+}
+
+- (BOOL)containsDataForKey:(nonnull NSString *)key {
+    return [self.fileManager fileExistsAtPath:[self cachePathForKey:key]];
+}
+
+- (nullable NSData *)dataForKey:(nonnull NSString *)key {
+    return [self.fileManager contentsAtPath:[self cachePathForKey:key]];
+}
+
+- (nullable instancetype)initWithCachePath:(nonnull NSString *)cachePath config:(nonnull SDImageCacheConfig *)config {
+    self = [super init];
+    if (self) {
+        self.cachePath = cachePath;
+        self.config = config;
+        self.fileManager = config.fileManager ? config.fileManager : [NSFileManager new];
+        [self.fileManager createDirectoryAtPath:self.cachePath withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+    return self;
+}
+
+- (void)removeAllData {
+    [self.fileManager removeItemAtPath:self.cachePath error:nil];
+}
+
+- (void)removeDataForKey:(nonnull NSString *)key {
+    [self.fileManager removeItemAtPath:[self cachePathForKey:key] error:nil];
+}
+
+- (void)removeExpiredData {
+    NSDate *expirationDate = [NSDate dateWithTimeIntervalSinceNow:-self.config.maxCacheAge];
+    for (NSString *fileName in [self.fileManager enumeratorAtPath:self.cachePath]) {
+        NSString *filePath = [self.cachePath stringByAppendingPathComponent:fileName];
+        NSDate *modificationDate = [[self.fileManager attributesOfItemAtPath:filePath error:nil] objectForKey:NSFileModificationDate];
+        if ([[modificationDate laterDate:expirationDate] isEqualToDate:expirationDate]) {
+            [self.fileManager removeItemAtPath:filePath error:nil];
+        }
+    }
+}
+
+- (void)setData:(nullable NSData *)data forKey:(nonnull NSString *)key {
+    [self.fileManager createFileAtPath:[self cachePathForKey:key] contents:data attributes:nil];
+}
+
+- (NSInteger)totalCount {
+    return [self.fileManager contentsOfDirectoryAtPath:self.cachePath error:nil].count;
+}
+
+- (NSInteger)totalSize {
+    NSUInteger size = 0;
+    for (NSString *fileName in [self.fileManager enumeratorAtPath:self.cachePath]) {
+        NSString *filePath = [self.cachePath stringByAppendingPathComponent:fileName];
+        size += [[[self.fileManager attributesOfItemAtPath:filePath error:nil] objectForKey:NSFileSize] unsignedIntegerValue];
+    }
+    return size;
+}
+
+@end

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -26,6 +26,8 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/SDImageCache.h>
 #import <SDWebImage/SDMemoryCache.h>
 #import <SDWebImage/SDDiskCache.h>
+#import <SDWebImage/SDWebImageCache.h>
+#import <SDWebImage/SDWebImageCachesManager.h>
 #import <SDWebImage/UIView+WebCache.h>
 #import <SDWebImage/UIImageView+WebCache.h>
 #import <SDWebImage/UIImageView+HighlightedWebCache.h>
@@ -64,7 +66,6 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/UIImage+ForceDecode.h>
 #import <SDWebImage/NSData+ImageContentType.h>
 #import <SDWebImage/SDWebImageDefine.h>
-#import <SDWebImage/SDWebImageCache.h>
 
 #if SD_MAC
     #import <SDWebImage/NSImage+Additions.h>

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -24,6 +24,8 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/SDWebImageManager.h>
 #import <SDWebImage/SDImageCacheConfig.h>
 #import <SDWebImage/SDImageCache.h>
+#import <SDWebImage/SDMemoryCache.h>
+#import <SDWebImage/SDDiskCache.h>
 #import <SDWebImage/UIView+WebCache.h>
 #import <SDWebImage/UIImageView+WebCache.h>
 #import <SDWebImage/UIImageView+HighlightedWebCache.h>

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -64,6 +64,7 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/UIImage+ForceDecode.h>
 #import <SDWebImage/NSData+ImageContentType.h>
 #import <SDWebImage/SDWebImageDefine.h>
+#import <SDWebImage/SDWebImageCache.h>
 
 #if SD_MAC
     #import <SDWebImage/NSImage+Additions.h>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding // Added 8 tests for memory cache, disk cache and webcache protocol
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1270 #1355 #1912

### Pull Request Description

### Reason

#### Custom memory and disk cache
Our `SDImageCache` works for most cases. But it's tied to `UIImage` and it's not customable at all. From some issues about cache, we can find that some people want to implement a LRU-cache algorithm for memory cache and disk cache for performance. Or have their own way to handle detailed information such as error. However, we can not easily do this unless we open the memory cache and disk cache impl to user. This need we to introduce the protobol and let user provide their desired cache such as YYCache by writing a category to conform the protocol. This can make our cache more scalable, let we seperate the `disk cache` part and `memory cache` part into different files with non-heavy logic related code.

### Design
#### Custom memory and disk cache
To support custom memory cache and disk cache, we should introduce two abstract protocol and separate the current implementation into two level. So that our `SDImageCache` can just like a manager to control the memory cache and disk cache operations. This can also make the code more clean to maintain.

```ascii
-------- Image Cache --------
               |
Memory Cache ----- Disk Cache
```

For the protocol define, we could just keep a abstract of basic operation, including: `check`, `query`, `store`, `remove`, `removeAll`, `trim`(For disk cache only, remove the out-dated files). This is enough for basic usage. All the current information in `SDImageCacheConfig` can also be passed to the implementation (Some really implement-detailed config are optional).

### Implementation
#### Custom memory and disk cache for `SDImageCache`

We introduce two protocol,  `SDMemoryCache` and `SDDiskCache`. And provide the built-in implementation class conform these two protocol. The actually implementation code is just copied from the original `SDImageCache` class :)

Memeory Cache:

```objective-c
// Cache object on memory
@protocol SDMemoryCache <NSObject>

- (nonnull instancetype)initWithConfig:(nonnull SDImageCacheConfig *)config;

- (nullable id)objectForKey:(nonnull id)key;

- (void)setObject:(nullable id)object forKey:(nonnull id)key;

- (void)setObject:(nullable id)object forKey:(nonnull id)key cost:(NSUInteger)cost;

- (void)removeObjectForKey:(nonnull id)key;

- (void)removeAllObjects;

@end
```

Disk Cache:

```objective-c
// Cache data to disk
@protocol SDDiskCache <NSObject>

- (nullable instancetype)initWithCachePath:(nonnull NSString *)cachePath config:(nonnull SDImageCacheConfig *)config;

// All these method called from single io queue, thread-safe

- (BOOL)containsDataForKey:(nonnull NSString *)key;

- (nullable NSData *)dataForKey:(nonnull NSString *)key;

- (void)setData:(nullable NSData *)data forKey:(nonnull NSString *)key;

- (void)removeDataForKey:(nonnull NSString *)key;

- (void)removeAllData;

- (void)removeExpiredData;

- (nullable NSString *)cachePathForKey:(nonnull NSString *)key;

- (NSInteger)totalCount;

- (NSInteger)totalSize;

@end
```

#### Extra change
One extra change is that I mentioned in #1898. Through the error information is useful for some people. But after I research acrossing many library including YYCache/YYImage/AFNetworking/Kingfisher, they do not have this design. Because cache is used for something may be evict and removed at any time. You should check using something like exist method instead of handler error. But it's can be done even if we revert that change. We keep the support for custom `NSFileManager`. Use the delegate method to get some file level error. For the error generated by `-[NSData writeToURL:]`, I think we can only use POSIX errno. Through it's hard to use, but since this use case is really rare, I think's the pain(API-break) is more than the gain.

And also, if you really need the error information for metric or logging. Consider use custom disk cache class instead. You can implement that inside the class (You can even subclass our `SDDiskCache` and override some function). So I think this PR can solve that problem as well.