### PR TITLE
Fix the issue that prefetcher will cause stack overflow is the input urls list is huge because of recursion function call

### DIFF
--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -80,7 +80,8 @@
              ];
         }
         if (self.prefetchURLs.count > self.requestedCount) {
-            dispatch_queue_async_safe(self.prefetcherQueue, ^{
+            dispatch_async(self.prefetcherQueue, ^{
+                // we need dispatch to avoid function recursion call. This can prevent stack overflow even for huge urls list
                 [self startPrefetchingAtIndex:self.requestedCount];
             });
         } else if (self.finishedCount == self.requestedCount) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2193 

### Pull Request Description

This change that wrong usage of `dispatch_queue_async_safe` in `SDWebImagePrefetcher`. Because that if we call the block immediately, this will use recursion and will reach stack overflow if the input url lists is huge. (Test that 2K+ will trigger this issue on real device. 20K+ will trigger on iPhone Simulator)
