### PR TITLE
Decode the image in the operation level's queue instead of URLSession delegate queue

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -63,7 +63,7 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 @property (nonatomic, assign) BOOL shouldUseCredentialStorage __deprecated_msg("Property deprecated. Does nothing. Kept only for backwards compatibility");
 
 /**
- * The credential used for authentication challenges in `-connection:didReceiveAuthenticationChallenge:`.
+ * The credential used for authentication challenges in `-URLSession:task:didReceiveChallenge:completionHandler:`.
  *
  * This will be overridden by any shared credentials that exist for the username or password of the request URL, if present.
  */
@@ -80,7 +80,7 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 @property (assign, nonatomic) NSInteger expectedSize;
 
 /**
- * The response returned by the operation's connection.
+ * The response returned by the operation's task.
  */
 @property (strong, nonatomic, nullable) NSURLResponse *response;
 


### PR DESCRIPTION
Because URLSession delegate queue is a barrier queue and shared between different operation

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

The decoding process for image may be a time consuming process. Current design, the `SDWebImageDownloader` pass the URLSession delegate to the `SDWebImageDownloadOperation`. So each operation created by the downloader share the same delegate queue. This queue is a serial queue obviously. So the process to decode the image will be queued between different urls. This result that your download timing is become `longer` than excepted. (Frame rate is not effected)

And it's especially time-consuming for big WebP images(200ms per WebP, if we have 5 WebP images, the last one need to be queued for 1000ms). This is not necessary because our build-in decoder is thread-safe from different queue and we already emphasized that in the `SDWebImageCoder` protocol.

>  @note Pay attention that these methods are not called from main queue.

So actually, we can use a `operation` level's queue to process the image decoding process. We have one `barrierQueue` in `SDWebImageDownloadOperation`. Through it's used for keep the aceess for `callbackBlocks` thread-safe. Because it's a concurrent queue so it's suitable for this stuff. So we can dispatch the decoding process to the `barrierQueue` to avoid one operation to wait for another operation finish decoding.