### PR TITLE
Use a lock to ensure headers mutable dictionary thread-safe

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -40,6 +40,7 @@
 @property (strong, nonatomic, nonnull) NSMutableDictionary<NSURL *, SDWebImageDownloaderOperation *> *URLOperations;
 @property (strong, nonatomic, nullable) SDHTTPHeadersMutableDictionary *HTTPHeaders;
 @property (strong, nonatomic, nonnull) dispatch_semaphore_t operationsLock; // a lock to keep the access to `URLOperations` thread-safe
+@property (strong, nonatomic, nonnull) dispatch_semaphore_t headersLock; // a lock to keep the access to `HTTPHeaders` thread-safe
 
 // The session in which data tasks will run
 @property (strong, nonatomic) NSURLSession *session;
@@ -99,6 +100,7 @@
         _HTTPHeaders = [@{@"Accept": @"image/*;q=0.8"} mutableCopy];
 #endif
         _operationsLock = dispatch_semaphore_create(1);
+        _headersLock = dispatch_semaphore_create(1);
         _downloadTimeout = 15.0;
 
         [self createNewSessionWithConfiguration:sessionConfiguration];
@@ -144,15 +146,27 @@
 }
 
 - (void)setValue:(nullable NSString *)value forHTTPHeaderField:(nullable NSString *)field {
+    LOCK(self.headersLock);
     if (value) {
         self.HTTPHeaders[field] = value;
     } else {
         [self.HTTPHeaders removeObjectForKey:field];
     }
+    UNLOCK(self.headersLock);
 }
 
 - (nullable NSString *)valueForHTTPHeaderField:(nullable NSString *)field {
-    return self.HTTPHeaders[field];
+    if (!field) {
+        return nil;
+    }
+    return [[self allHTTPHeaderFields] objectForKey:field];
+}
+
+- (nonnull SDHTTPHeadersDictionary *)allHTTPHeaderFields {
+    LOCK(self.headersLock);
+    SDHTTPHeadersDictionary *allHTTPHeaderFields = [self.HTTPHeaders copy];
+    UNLOCK(self.headersLock);
+    return allHTTPHeaderFields;
 }
 
 - (void)setMaxConcurrentDownloads:(NSInteger)maxConcurrentDownloads {
@@ -201,10 +215,10 @@
         request.HTTPShouldHandleCookies = (options & SDWebImageDownloaderHandleCookies);
         request.HTTPShouldUsePipelining = YES;
         if (sself.headersFilter) {
-            request.allHTTPHeaderFields = sself.headersFilter(url, [sself.HTTPHeaders copy]);
+            request.allHTTPHeaderFields = sself.headersFilter(url, [sself allHTTPHeaderFields]);
         }
         else {
-            request.allHTTPHeaderFields = sself.HTTPHeaders;
+            request.allHTTPHeaderFields = [sself allHTTPHeaderFields];
         }
         SDWebImageDownloaderOperation *operation = [[sself.operationClass alloc] initWithRequest:request inSession:sself.session options:options];
         operation.shouldDecompressImages = sself.shouldDecompressImages;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #961

### Pull Request Description

Well. Thread-safe problem again. It seems that our library's code does not think of multi-thread environment during the development.

For `Mutable Object`, you should always use a lock because mark it as `atomic` does not solve any problem. The instance itself can be mutated from their methods. So what you can do is just to mark all the methods which may mutate the instance with lock(Dispatch queue is another way to keep thread-safe. But the queue dispatch may be slower than a lock and may also consume the GCD thread-pool resource. For simple one instance like `NSMutableDictionary`, it's not recommend to do so)

For `Immutable Object`, you should also ask yourself : "Coult the getter and setter come from different queue ?". If the answer is YES, just mark the property to `atomic`. This is the simplest and the best situation for immutable object because when you mark `nonatomic`, the getter and setter in Objective-C is not a `atomic operation` so it's not thread-safe when getter and setter called from different queue. (If you are interested in Objective-C property atomic implementation, see Apple's [source code](https://opensource.apple.com/source/objc4/objc4-723/runtime/objc-accessors.mm.auto.html). It use a spin lock which may be the best performance than you write your own lock for getter and setter)

