### PR TITLE
Fix that SDImageCacheQueryDataWhenInMemory should response cacheType to memory cache when the in-memory cache hit

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -394,8 +394,13 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         
         @autoreleasepool {
             NSData *diskData = [self diskImageDataBySearchingAllPathsForKey:key];
-            UIImage *diskImage = image;
-            if (!diskImage && diskData) {
+            UIImage *diskImage;
+            SDImageCacheType cacheType = SDImageCacheTypeDisk;
+            if (image) {
+                // the image is from in-memory cache
+                diskImage = image;
+                cacheType = SDImageCacheTypeMemory;
+            } else if (diskData) {
                 // decode image data only if in-memory cache missed
                 diskImage = [self diskImageForKey:key data:diskData];
                 if (diskImage && self.config.shouldCacheImagesInMemory) {
@@ -406,10 +411,10 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             
             if (doneBlock) {
                 if (options & SDImageCacheQueryDiskSync) {
-                    doneBlock(diskImage, diskData, SDImageCacheTypeDisk);
+                    doneBlock(diskImage, diskData, cacheType);
                 } else {
                     dispatch_async(dispatch_get_main_queue(), ^{
-                        doneBlock(diskImage, diskData, SDImageCacheTypeDisk);
+                        doneBlock(diskImage, diskData, cacheType);
                     });
                 }
             }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2216 

### Pull Request Description

Maybe this is a issue during #2162. For the image which the actual `UIImage` from memory cache but contains a valid `NSData`,we should treat this as a memory cache type. However, current implementation treat this as a disk cache type. So this should be fixed.

