### PR TITLE
Expose the read write to FLAnimatedImage associate to the UIImage to allow advanced feature like placeholder

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -25,8 +25,9 @@
 
 /**
  *  The FLAnimatedImage associated to the UIImage instance when an animated GIF image load.
+ *  For most cases this is read-only and you should avoid manually setting this value. Util some cases like using placeholder with a `FLAnimatedImage`.
  */
-@property (nonatomic, strong, readonly, nullable) FLAnimatedImage *sd_FLAnimatedImage;
+@property (nonatomic, strong, nullable) FLAnimatedImage *sd_FLAnimatedImage;
 
 @end
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2217

### Pull Request Description

In SD 4.3.0. We introduce a way to use associate object to bind `FLAnimatedImage` to `UIImage`. This allow user to "store" the FLAnimatedImage into our memory cache and fix some potential issue. At that time I mark this property `readonly` because I think user should avoid touching this in most cases.

However, some user also argue that they need to set placeholder of a `FLAnimatedImage` instance. Since `FLAnimatedImage` is not a `UIImage` subclass, they can not do this. So maybe we should just open this ability to allow write to that associate type. User now just set a `FLAnimatedImage` to `UIImage` placeholder and all things done.

This will not cause API-breaking because `readwrite` is superset of `readonly`. This is used for advanced feature and user should have the knowledge of what they are doing.
