### PR TITLE
Fix that iOS 8 NSURLSessionTaskPriorityHigh symbol not defined in Foundation framework and cause crash

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -11,7 +11,14 @@
 #import "SDWebImageOperation.h"
 
 typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
+    /**
+     * Put the download in the low queue priority and task priority.
+     */
     SDWebImageDownloaderLowPriority = 1 << 0,
+    
+    /**
+     * This flag enables progressive download, the image is displayed progressively during download as a browser would do.
+     */
     SDWebImageDownloaderProgressiveDownload = 1 << 1,
 
     /**
@@ -45,7 +52,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     SDWebImageDownloaderAllowInvalidSSLCertificates = 1 << 6,
 
     /**
-     * Put the image in the high priority queue.
+     * Put the download in the high queue priority and task priority.
      */
     SDWebImageDownloaderHighPriority = 1 << 7,
     

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -14,6 +14,13 @@
 #define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
 #define UNLOCK(lock) dispatch_semaphore_signal(lock);
 
+// iOS 8 Foundation.framework extern these symbol but the define is in CFNetwork.framework. We just fix this without import CFNetwork.framework
+#if (__IPHONE_OS_VERSION_MIN_REQUIRED && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_9_0)
+const float NSURLSessionTaskPriorityHigh = 0.75;
+const float NSURLSessionTaskPriorityDefault = 0.5;
+const float NSURLSessionTaskPriorityLow = 0.25;
+#endif
+
 NSString *const SDWebImageDownloadStartNotification = @"SDWebImageDownloadStartNotification";
 NSString *const SDWebImageDownloadReceiveResponseNotification = @"SDWebImageDownloadReceiveResponseNotification";
 NSString *const SDWebImageDownloadStopNotification = @"SDWebImageDownloadStopNotification";
@@ -176,7 +183,6 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
     }
 
     if (self.dataTask) {
-        [self.dataTask resume];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
         if ([self.dataTask respondsToSelector:@selector(setPriority:)]) {
@@ -187,6 +193,7 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
             }
         }
 #pragma clang diagnostic pop
+        [self.dataTask resume];
         for (SDWebImageDownloaderProgressBlock progressBlock in [self callbacksForKey:kProgressCallbackKey]) {
             progressBlock(0, NSURLResponseUnknownLength, self.request.URL);
         }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2230 

### Pull Request Description

The `NSURLSessionTaskPriorityHigh` in Apple docs show that it's defined in Foundation. However, in iOS 8, it defined in CFNetwork.framework. If youo do not import CFNetwork manually, you will face a crash. (Sorry that our application import this framework so I didn't realize this issue in advance).

This is a bug caused by Apple. See [Radar](https://openradar.appspot.com/23956486) and [stackoverflow](https://stackoverflow.com/questions/24043532/dyld-symbol-not-found-nsurlauthenticationmethodclientcertificate-when-trying)

