### PR TITLE
Add cacheKeyFilter to allow user provide modified version of data when storing the disk cache in SDWebImageManager

### DIFF
--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -122,7 +122,9 @@ typedef void(^SDExternalCompletionBlock)(UIImage * _Nullable image, NSError * _N
 
 typedef void(^SDInternalCompletionBlock)(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL);
 
-typedef NSString * _Nullable (^SDWebImageCacheKeyFilterBlock)(NSURL * _Nullable url);
+typedef NSString * _Nullable(^SDWebImageCacheKeyFilterBlock)(NSURL * _Nullable url);
+
+typedef NSData * _Nullable(^SDWebImageCacheSerializerBlock)(UIImage * _Nonnull image, NSData * _Nullable data, NSURL * _Nullable imageURL);
 
 
 @class SDWebImageManager;
@@ -193,14 +195,34 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
  *
  * @code
 
-[[SDWebImageManager sharedManager] setCacheKeyFilter:^(NSURL *url) {
+SDWebImageManager.sharedManager.cacheKeyFilter = ^(NSURL * _Nullable url) {
     url = [[NSURL alloc] initWithScheme:url.scheme host:url.host path:url.path];
     return [url absoluteString];
-}];
+};
 
  * @endcode
  */
 @property (nonatomic, copy, nullable) SDWebImageCacheKeyFilterBlock cacheKeyFilter;
+
+/**
+ * The cache serializer is a block used to convert the decoded image, the source downloaded data, to the actual data used for storing to the disk cache. If you return nil, means to generate the data from the image instance, see `SDImageCache`.
+ * For example, if you are using WebP images and facing the slow decoding time issue when later retriving from disk cache again. You can try to encode the decoded image to JPEG/PNG format to disk cache instead of source downloaded data.
+ * @note The `image` arg is nonnull, but when you also provide a image transformer and the image is transformed, the `data` arg may be nil, take attention to this case.
+ * @note This method is called from a global queue in order to not to block the main thread.
+ * @code
+ SDWebImageManager.sharedManager.cacheKeyFilter = ^NSData * _Nullable(UIImage * _Nonnull image, NSData * _Nullable data, NSURL * _Nullable imageURL) {
+    SDImageFormat format = [NSData sd_imageFormatForImageData:data];
+    switch (format) {
+        case SDImageFormatWebP:
+            return image.images ? data : nil;
+        default:
+            return data;
+    }
+ };
+ * @endcode
+ * The default value is nil. Means we just store the source downloaded data to disk cache.
+ */
+@property (nonatomic, copy, nullable) SDWebImageCacheSerializerBlock cacheSerializer;
 
 /**
  * Returns global SDWebImageManager instance.


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2127 #2236 #2227

### Pull Request Description

## Reason

Many user facing the performance of WebP decoding. Since Apple does not adopt WebP images in Apple's framework(UIKit, Image/IO), we use [libwebp](https://github.com/webmproject/libwebp) from Google to do WebP decoding. For the same image, WebP decoding spend 5x time slower than JPEG images. And it's even time-consuming when decoding Animated WebP.

## Design

So, some user argue to store the encoded image into disk cache instead of the original data from the server. Since we previously adopt the behavior to store the original data, this property is optional. Default to store the original data.

Since some user may decide to encode the image to another data, which is also time-consuming. The cache serializer block is dispatch on a global queue to avoid blocking main queue.

## Implementation
The block should look like this, to allow user get the right context(Throguh `imageURL` arg) and the source data and image.

```objective-c
typedef NSData * _Nullable(^SDWebImageCacheSerializerBlock)(UIImage * _Nonnull image, NSData * _Nullable data, NSURL * _Nullable imageURL);
```