### PR TITLE
Refactor api style

### DIFF
--- a/Examples/SDWebImage OSX Demo/ViewController.m
+++ b/Examples/SDWebImage OSX Demo/ViewController.m
@@ -26,7 +26,7 @@
     [super viewDidLoad];
     
     //Add GIF coder for better animated image rendering
-    [[SDWebImageCodersManager sharedInstance] addCoder:[SDWebImageGIFCoder sharedCoder]];
+    [[SDWebImageCodersManager sharedManager] addCoder:[SDWebImageGIFCoder sharedCoder]];
     
     // NOTE: https links or authentication ones do not work (there is a crash)
     

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -62,10 +62,8 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 
 /**
  * Returns global shared cache instance
- *
- * @return SDImageCache global instance
  */
-+ (nonnull instancetype)sharedImageCache;
+@property (nonatomic, class, readonly, nonnull) SDImageCache *sharedImageCache;
 
 /**
  * Init a new cache store with a specific namespace

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -298,7 +298,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
                     } else {
                         format = SDImageFormatJPEG;
                     }
-                    data = [[SDWebImageCodersManager sharedInstance] encodedDataWithImage:image format:format];
+                    data = [[SDWebImageCodersManager sharedManager] encodedDataWithImage:image format:format];
                 }
                 [self _storeImageDataToDisk:data forKey:key error:&writeError];
             }
@@ -475,10 +475,10 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (nullable UIImage *)diskImageForKey:(nullable NSString *)key data:(nullable NSData *)data {
     if (data) {
-        UIImage *image = [[SDWebImageCodersManager sharedInstance] decodedImageWithData:data];
+        UIImage *image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:data];
         image = [self scaledImageForKey:key image:image];
         if (self.config.shouldDecompressImages) {
-            image = [[SDWebImageCodersManager sharedInstance] decompressedImageWithImage:image data:&data options:@{SDWebImageCoderScaleDownLargeImagesKey: @(NO)}];
+            image = [[SDWebImageCodersManager sharedManager] decompressedImageWithImage:image data:&data options:@{SDWebImageCoderScaleDownLargeImagesKey: @(NO)}];
         }
         return image;
     } else {

--- a/SDWebImage/SDWebImageCodersManager.h
+++ b/SDWebImage/SDWebImageCodersManager.h
@@ -32,9 +32,9 @@
 @interface SDWebImageCodersManager : NSObject<SDWebImageCoder>
 
 /**
- Shared reusable instance
+ Returns the global shared coders manager instance.
  */
-+ (nonnull instancetype)sharedInstance;
+@property (nonatomic, class, readonly, nonnull) SDWebImageCodersManager *sharedManager;
 
 /**
  All coders in coders manager. The coders array is a priority queue, which means the later added coder will have the highest priority

--- a/SDWebImage/SDWebImageCodersManager.m
+++ b/SDWebImage/SDWebImageCodersManager.m
@@ -22,7 +22,7 @@
 
 @implementation SDWebImageCodersManager
 
-+ (nonnull instancetype)sharedInstance {
++ (nonnull instancetype)sharedManager {
     static dispatch_once_t once;
     static id instance;
     dispatch_once(&once, ^{

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -139,18 +139,25 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
  */
 @property (readonly, nonatomic, nonnull) NSURLSessionConfiguration *sessionConfiguration;
 
+/**
+ * Gets/Sets a subclass of `SDWebImageDownloaderOperation` as the default
+ * `NSOperation` to be used each time SDWebImage constructs a request
+ * operation to download an image.
+ *
+ * @param operationClass The subclass of `SDWebImageDownloaderOperation` to set
+ *        as default. Passing `nil` will revert to `SDWebImageDownloaderOperation`.
+ */
+@property (assign, nonatomic, nullable) Class operationClass;
+
+/**
+ * Gets/Sets the download queue suspension state.
+ */
+@property (assign, nonatomic, getter=isSuspended) BOOL suspended;
 
 /**
  * Changes download operations execution order. Default value is `SDWebImageDownloaderFIFOExecutionOrder`.
  */
 @property (assign, nonatomic) SDWebImageDownloaderExecutionOrder executionOrder;
-
-/**
- *  Singleton method, returns the shared instance
- *
- *  @return global shared instance of downloader class
- */
-+ (nonnull instancetype)sharedDownloader;
 
 /**
  *  Set the default URL credential to be set for request operations.
@@ -176,6 +183,13 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
 @property (nonatomic, copy, nullable) SDWebImageDownloaderHeadersFilterBlock headersFilter;
 
 /**
+ *  Singleton method, returns the shared instance
+ *
+ *  @return global shared instance of downloader class
+ */
++ (nonnull instancetype)sharedDownloader;
+
+/**
  * Creates an instance of a downloader with specified session configuration.
  * @note `timeoutIntervalForRequest` is going to be overwritten.
  * @return new instance of downloader class
@@ -196,16 +210,6 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
  * @return The value associated with the header field field, or `nil` if there is no corresponding header field.
  */
 - (nullable NSString *)valueForHTTPHeaderField:(nullable NSString *)field;
-
-/**
- * Sets a subclass of `SDWebImageDownloaderOperation` as the default
- * `NSOperation` to be used each time SDWebImage constructs a request
- * operation to download an image.
- *
- * @param operationClass The subclass of `SDWebImageDownloaderOperation` to set 
- *        as default. Passing `nil` will revert to `SDWebImageDownloaderOperation`.
- */
-- (void)setOperationClass:(nullable Class)operationClass;
 
 /**
  * Creates a SDWebImageDownloader async downloader instance with a given URL
@@ -262,11 +266,6 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
  * @param token The token received from -downloadImageWithURL:options:progress:completed: that should be canceled.
  */
 - (void)cancel:(nullable SDWebImageDownloadToken *)token;
-
-/**
- * Sets the download queue suspension state
- */
-- (void)setSuspended:(BOOL)suspended;
 
 /**
  * Cancels all download operations in the queue

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -183,11 +183,9 @@ typedef SDHTTPHeadersDictionary * _Nullable (^SDWebImageDownloaderHeadersFilterB
 @property (nonatomic, copy, nullable) SDWebImageDownloaderHeadersFilterBlock headersFilter;
 
 /**
- *  Singleton method, returns the shared instance
- *
- *  @return global shared instance of downloader class
+ *  Returns the global shared downloader instance
  */
-+ (nonnull instancetype)sharedDownloader;
+@property (nonatomic, class, readonly, nonnull) SDWebImageDownloader *sharedDownloader;
 
 /**
  * Creates an instance of a downloader with specified session configuration.

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -36,7 +36,6 @@
 
 @property (strong, nonatomic, nonnull) NSOperationQueue *downloadQueue;
 @property (weak, nonatomic, nullable) NSOperation *lastAddedOperation;
-@property (assign, nonatomic, nullable) Class operationClass;
 @property (strong, nonatomic, nonnull) NSMutableDictionary<NSURL *, SDWebImageDownloaderOperation *> *URLOperations;
 @property (strong, nonatomic, nullable) SDHTTPHeadersMutableDictionary *HTTPHeaders;
 @property (strong, nonatomic, nonnull) dispatch_semaphore_t operationsLock; // a lock to keep the access to `URLOperations` thread-safe
@@ -307,6 +306,10 @@
     token.downloadOperationCancelToken = downloadOperationCancelToken;
 
     return token;
+}
+
+- (BOOL)isSuspended {
+    return self.downloadQueue.isSuspended;
 }
 
 - (void)setSuspended:(BOOL)suspended {

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -345,7 +345,7 @@ didReceiveResponse:(NSURLResponse *)response
         
         if (!self.progressiveCoder) {
             // We need to create a new instance for progressive decoding to avoid conflicts
-            for (id<SDWebImageCoder>coder in [SDWebImageCodersManager sharedInstance].coders) {
+            for (id<SDWebImageCoder>coder in [SDWebImageCodersManager sharedManager].coders) {
                 if ([coder conformsToProtocol:@protocol(SDWebImageProgressiveCoder)] &&
                     [((id<SDWebImageProgressiveCoder>)coder) canIncrementallyDecodeFromData:imageData]) {
                     self.progressiveCoder = [[[coder class] alloc] init];
@@ -361,7 +361,7 @@ didReceiveResponse:(NSURLResponse *)response
                 NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                 image = [self scaledImageForKey:key image:image];
                 if (self.shouldDecompressImages) {
-                    image = [[SDWebImageCodersManager sharedInstance] decompressedImageWithImage:image data:&imageData options:@{SDWebImageCoderScaleDownLargeImagesKey: @(NO)}];
+                    image = [[SDWebImageCodersManager sharedManager] decompressedImageWithImage:image data:&imageData options:@{SDWebImageCoderScaleDownLargeImagesKey: @(NO)}];
                 }
                 
                 // We do not keep the progressive decoding image even when `finished`=YES. Because they are for view rendering but not take full function from downloader options. And some coders implementation may not keep consistent between progressive decoding and normal decoding.
@@ -427,7 +427,7 @@ didReceiveResponse:(NSURLResponse *)response
                 } else {
                     // decode the image in coder queue
                     dispatch_async(self.coderQueue, ^{
-                        UIImage *image = [[SDWebImageCodersManager sharedInstance] decodedImageWithData:imageData];
+                        UIImage *image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:imageData];
                         NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
                         image = [self scaledImageForKey:key image:image];
                         
@@ -447,7 +447,7 @@ didReceiveResponse:(NSURLResponse *)response
                         if (shouldDecode) {
                             if (self.shouldDecompressImages) {
                                 BOOL shouldScaleDown = self.options & SDWebImageDownloaderScaleDownLargeImages;
-                                image = [[SDWebImageCodersManager sharedInstance] decompressedImageWithImage:image data:&imageData options:@{SDWebImageCoderScaleDownLargeImagesKey: @(shouldScaleDown)}];
+                                image = [[SDWebImageCodersManager sharedManager] decompressedImageWithImage:image data:&imageData options:@{SDWebImageCoderScaleDownLargeImagesKey: @(shouldScaleDown)}];
                             }
                         }
                         CGSize imageSize = image.size;

--- a/SDWebImage/SDWebImageGIFCoder.h
+++ b/SDWebImage/SDWebImageGIFCoder.h
@@ -18,6 +18,6 @@
  */
 @interface SDWebImageGIFCoder : NSObject <SDWebImageCoder>
 
-+ (nonnull instancetype)sharedCoder;
+@property (nonatomic, class, readonly, nonnull) SDWebImageGIFCoder *sharedCoder;
 
 @end

--- a/SDWebImage/SDWebImageImageIOCoder.h
+++ b/SDWebImage/SDWebImageImageIOCoder.h
@@ -25,6 +25,6 @@
  */
 @interface SDWebImageImageIOCoder : NSObject <SDWebImageProgressiveCoder>
 
-+ (nonnull instancetype)sharedCoder;
+@property (nonatomic, class, readonly, nonnull) SDWebImageImageIOCoder *sharedCoder;
 
 @end

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -213,11 +213,9 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 @property (nonatomic, copy, nullable) SDWebImageCacheKeyFilterBlock cacheKeyFilter;
 
 /**
- * Returns global SDWebImageManager instance.
- *
- * @return SDWebImageManager shared instance
+ * Returns global shared manager instance.
  */
-+ (nonnull instancetype)sharedManager;
+@property (nonatomic, class, readonly, nonnull) SDWebImageManager *sharedManager;
 
 /**
  * Allows to specify instance of cache and image downloader used with image manager.

--- a/SDWebImage/SDWebImagePrefetcher.h
+++ b/SDWebImage/SDWebImagePrefetcher.h
@@ -80,9 +80,9 @@ typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger noOfFinishedUrls, 
 @property (weak, nonatomic, nullable) id <SDWebImagePrefetcherDelegate> delegate;
 
 /**
- * Return the global image prefetcher instance.
+ * Returns the global shared image prefetcher instance.
  */
-+ (nonnull instancetype)sharedImagePrefetcher;
+@property (nonatomic, class, readonly, nonnull) SDWebImagePrefetcher *sharedImagePrefetcher;
 
 /**
  * Allows you to instantiate a prefetcher with any arbitrary image manager.

--- a/SDWebImage/SDWebImageWebPCoder.h
+++ b/SDWebImage/SDWebImageWebPCoder.h
@@ -16,7 +16,7 @@
  */
 @interface SDWebImageWebPCoder : NSObject <SDWebImageProgressiveCoder>
 
-+ (nonnull instancetype)sharedCoder;
+@property (nonatomic, class, readonly, nonnull) SDWebImageWebPCoder *sharedCoder;
 
 @end
 

--- a/SDWebImage/UIImage+ForceDecode.m
+++ b/SDWebImage/UIImage+ForceDecode.m
@@ -16,7 +16,7 @@
         return nil;
     }
     NSData *tempData;
-    return [[SDWebImageCodersManager sharedInstance] decompressedImageWithImage:image data:&tempData options:@{SDWebImageCoderScaleDownLargeImagesKey: @(NO)}];
+    return [[SDWebImageCodersManager sharedManager] decompressedImageWithImage:image data:&tempData options:@{SDWebImageCoderScaleDownLargeImagesKey: @(NO)}];
 }
 
 + (UIImage *)sd_decodedAndScaledDownImageWithImage:(UIImage *)image {
@@ -24,7 +24,7 @@
         return nil;
     }
     NSData *tempData;
-    return [[SDWebImageCodersManager sharedInstance] decompressedImageWithImage:image data:&tempData options:@{SDWebImageCoderScaleDownLargeImagesKey: @(YES)}];
+    return [[SDWebImageCodersManager sharedManager] decompressedImageWithImage:image data:&tempData options:@{SDWebImageCoderScaleDownLargeImagesKey: @(YES)}];
 }
 
 @end

--- a/SDWebImage/UIImage+MultiFormat.m
+++ b/SDWebImage/UIImage+MultiFormat.m
@@ -12,7 +12,7 @@
 @implementation UIImage (MultiFormat)
 
 + (nullable UIImage *)sd_imageWithData:(nullable NSData *)data {
-    return [[SDWebImageCodersManager sharedInstance] decodedImageWithData:data];
+    return [[SDWebImageCodersManager sharedManager] decodedImageWithData:data];
 }
 
 - (nullable NSData *)sd_imageData {
@@ -22,7 +22,7 @@
 - (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat {
     NSData *imageData = nil;
     if (self) {
-        imageData = [[SDWebImageCodersManager sharedInstance] encodedDataWithImage:self format:imageFormat];
+        imageData = [[SDWebImageCodersManager sharedManager] encodedDataWithImage:self format:imageFormat];
     }
     return imageData;
 }

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -264,7 +264,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     XCTestExpectation *expectation = [self expectationWithDescription:@"Custom decoder for SDImageCache not works"];
     SDImageCache *cache = [[SDImageCache alloc] initWithNamespace:@"TestDecode"];
     SDWebImageTestDecoder *testDecoder = [[SDWebImageTestDecoder alloc] init];
-    [[SDWebImageCodersManager sharedInstance] addCoder:testDecoder];
+    [[SDWebImageCodersManager sharedManager] addCoder:testDecoder];
     NSString * testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImage" ofType:@"png"];
     UIImage *image = [[UIImage alloc] initWithContentsOfFile:testImagePath];
     NSString *key = @"TestPNGImageEncodedToDataAndRetrieveToJPEG";
@@ -298,7 +298,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
             XCTFail(@"Custom decoder not work for SDImageCache, check -[SDWebImageTestDecoder decodedImageWithData:]");
         }
         
-        [[SDWebImageCodersManager sharedInstance] removeCoder:testDecoder];
+        [[SDWebImageCodersManager sharedManager] removeCoder:testDecoder];
         
         [[SDImageCache sharedImageCache] removeImageForKey:key withCompletion:^{
             [expectation fulfill];

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -17,7 +17,6 @@
  *  Category for SDWebImageDownloader so we can access the operationClass
  */
 @interface SDWebImageDownloader ()
-@property (assign, nonatomic, nullable) Class operationClass;
 @property (strong, nonatomic, nonnull) NSOperationQueue *downloadQueue;
 
 - (nullable SDWebImageDownloadToken *)addProgressCallback:(SDWebImageDownloaderProgressBlock)progressBlock

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -366,7 +366,7 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Custom decoder for SDWebImageDownloader not works"];
     SDWebImageDownloader *downloader = [[SDWebImageDownloader alloc] init];
     SDWebImageTestDecoder *testDecoder = [[SDWebImageTestDecoder alloc] init];
-    [[SDWebImageCodersManager sharedInstance] addCoder:testDecoder];
+    [[SDWebImageCodersManager sharedManager] addCoder:testDecoder];
     NSURL * testImageURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"TestImage" withExtension:@"png"];
     
     // Decoded result is JPEG
@@ -384,7 +384,7 @@
         if (![str1 isEqualToString:str2]) {
             XCTFail(@"The image data is not modified by the custom decoder, check -[SDWebImageTestDecoder decompressedImageWithImage:data:options:]");
         }
-        [[SDWebImageCodersManager sharedInstance] removeCoder:testDecoder];
+        [[SDWebImageCodersManager sharedManager] removeCoder:testDecoder];
         [expectation fulfill];
     }];
     


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

In 5.x, we adopt many modern Objective-C feature and make the API more easy to for Swift user. By introducing these attribute or changes from the Objective-C side, we can make the generated Swift API more Swifty :)

The rule including these, the future contribute should also follow these rules:

+ Use property instead of `-(void)setXXX` , `-(id)XXX` to make the property available in Swift
+ Use class property with the correct name instead of `+(instanceType)sharedInstance` in singleton to make it more easy to use in Swift. The generated interface should be simple `open class var shared { get }`
+ Add all nullability annotation to avoid any `AnyObject!` implicitly unwrapped optionals(Except that `null_resettable`)
+ Add all Core Foundation Ownership using `CF_RETURNS_RETAINED` for 
 GET Rule and `CF_RETURNS_NOT_RETAINED` for Create Rule to avoid any `Unmanaged` CF value
+ Change all key for Dictionary with `NS_STRING_ENUM` to make it easy to use in Swift with dot syntax
+ Change all global value type which represent enum with `NS_TYPED_ENUM` to make it easy to use in Swift with dot syntax

Though most chanes will not affect our Objective-C user. This is API-breaking for Swift user. I'll list the API changes like these above during 4.x -> 5.x