### PR TITLE
Add a options to allow query the memory cache with data synchronously, but disk cache asynchronously

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -37,7 +37,7 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     /**
      * By combining `SDImageCacheQueryDataWhenInMemory`, this mask can force to query disk data synchronously when the memory cache hit.
      */
-    SDImageCacheQueryDataSync = 1 << 2
+    SDImageCacheQueryDataSyncWhenInMemory = 1 << 2
 };
 
 typedef void(^SDCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -31,9 +31,13 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
      */
     SDImageCacheQueryDataWhenInMemory = 1 << 0,
     /**
-     * By default, we query the memory cache synchronously, disk cache asynchronously. This mask can force to query disk cache synchronously.
+     * By default, we query the memory cache synchronously, disk cache asynchronously. This mask can force to query disk cache synchronously when the memory cache miss.
      */
-    SDImageCacheQueryDiskSync = 1 << 1
+    SDImageCacheQueryDiskSync = 1 << 1,
+    /**
+     * By combining `SDImageCacheQueryDataWhenInMemory`, this mask can force to query disk data synchronously when the memory cache hit.
+     */
+    SDImageCacheQueryDataSync = 1 << 2
 };
 
 typedef void(^SDCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -468,7 +468,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         return nil;
     }
     
-    // First check the in-memory cache...
+    // First check the in-memory cache
     UIImage *image = [self imageFromMemoryCacheForKey:key];
     BOOL shouldQueryMemoryOnly = (image && !(options & SDImageCacheQueryDataWhenInMemory));
     if (shouldQueryMemoryOnly) {
@@ -478,8 +478,13 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         return nil;
     }
     
+    // Second check the disk cache
     NSOperation *operation = [NSOperation new];
-    void(^queryDiskBlock)(void) =  ^{
+    // 1. in-memory cache hit & DataSync
+    // 2. in-memory cache miss & DiskSync
+    BOOL shouldQueryDiskSync = ((image && options & SDImageCacheQueryDataSync) ||
+                                (!image && options & SDImageCacheQueryDiskSync));
+    void(^queryDiskBlock)(void) = ^{
         if (operation.isCancelled) {
             // do not call the completion if cancelled
             return;
@@ -490,7 +495,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             UIImage *diskImage;
             SDImageCacheType cacheType = SDImageCacheTypeDisk;
             if (image) {
-                // the image is from in-memory cache
+                // the image is from in-memory cache, but need image data
                 diskImage = image;
                 cacheType = SDImageCacheTypeMemory;
             } else if (diskData) {
@@ -503,7 +508,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             }
             
             if (doneBlock) {
-                if (options & SDImageCacheQueryDiskSync) {
+                if (shouldQueryDiskSync) {
                     doneBlock(diskImage, diskData, cacheType);
                 } else {
                     dispatch_async(dispatch_get_main_queue(), ^{
@@ -514,7 +519,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         }
     };
     
-    if (options & SDImageCacheQueryDiskSync) {
+    if (shouldQueryDiskSync) {
         queryDiskBlock();
     } else {
         dispatch_async(self.ioQueue, queryDiskBlock);

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -482,7 +482,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     NSOperation *operation = [NSOperation new];
     // 1. in-memory cache hit & DataSync
     // 2. in-memory cache miss & DiskSync
-    BOOL shouldQueryDiskSync = ((image && options & SDImageCacheQueryDataSync) ||
+    BOOL shouldQueryDiskSync = ((image && options & SDImageCacheQueryDataSyncWhenInMemory) ||
                                 (!image && options & SDImageCacheQueryDiskSync));
     void(^queryDiskBlock)(void) = ^{
         if (operation.isCancelled) {

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -122,7 +122,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * By combining `SDWebImageQueryDataWhenInMemory`, this mask can force to query disk data synchronously when the memory cache hit.
      * This flag can avoid flashing during cell reuse if you need image data to render or in some other cases.
      */
-    SDWebImageQueryDataSync = 1 << 17
+    SDWebImageQueryDataSyncWhenInMemory = 1 << 17
 };
 
 typedef void(^SDExternalCompletionBlock)(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL);

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -98,12 +98,12 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     
     /**
      * By default, we do not query disk data when the image is cached in memory. This mask can force to query disk data at the same time.
-     * This flag is recommend to be used with `SDWebImageQueryDiskSync` to ensure the image is loaded in the same runloop.
+     * This flag is recommend to be used with `SDWebImageQueryDataSync` to ensure the image is loaded in the same runloop.
      */
     SDWebImageQueryDataWhenInMemory = 1 << 13,
     
     /**
-     * By default, we query the memory cache synchronously, disk cache asynchronously. This mask can force to query disk cache synchronously to ensure that image is loaded in the same runloop.
+     * By default, we query the memory cache synchronously, disk cache asynchronously. This mask can force to query disk cache synchronously when the memory cache miss.
      * This flag can avoid flashing during cell reuse if you disable memory cache or in some other cases.
      */
     SDWebImageQueryDiskSync = 1 << 14,
@@ -112,10 +112,17 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * By default, when the cache missed, the image is download from the network. This flag can prevent network to load from cache only.
      */
     SDWebImageFromCacheOnly = 1 << 15,
+    
     /**
      * By default, when you use `SDWebImageTransition` to do some view transition after the image load finished, this transition is only applied for image download from the network. This mask can force to apply view transition for memory and disk cache as well.
      */
-    SDWebImageForceTransition = 1 << 16
+    SDWebImageForceTransition = 1 << 16,
+    
+    /**
+     * By combining `SDWebImageQueryDataWhenInMemory`, this mask can force to query disk data synchronously when the memory cache hit.
+     * This flag can avoid flashing during cell reuse if you need image data to render or in some other cases.
+     */
+    SDWebImageQueryDataSync = 1 << 17
 };
 
 typedef void(^SDExternalCompletionBlock)(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL);

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -148,7 +148,7 @@
     SDImageCacheOptions cacheOptions = 0;
     if (options & SDWebImageQueryDataWhenInMemory) cacheOptions |= SDImageCacheQueryDataWhenInMemory;
     if (options & SDWebImageQueryDiskSync) cacheOptions |= SDImageCacheQueryDiskSync;
-    if (options & SDWebImageQueryDataSync) cacheOptions |= SDImageCacheQueryDataSync;
+    if (options & SDWebImageQueryDataSync) cacheOptions |= SDImageCacheQueryDataSyncWhenInMemory;
     
     __weak SDWebImageCombinedOperation *weakOperation = operation;
     operation.cacheOperation = [self.imageCache queryCacheOperationForKey:key options:cacheOptions done:^(UIImage *cachedImage, NSData *cachedData, SDImageCacheType cacheType) {

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -148,6 +148,7 @@
     SDImageCacheOptions cacheOptions = 0;
     if (options & SDWebImageQueryDataWhenInMemory) cacheOptions |= SDImageCacheQueryDataWhenInMemory;
     if (options & SDWebImageQueryDiskSync) cacheOptions |= SDImageCacheQueryDiskSync;
+    if (options & SDWebImageQueryDataSync) cacheOptions |= SDImageCacheQueryDataSync;
     
     __weak SDWebImageCombinedOperation *weakOperation = operation;
     operation.cacheOperation = [self.imageCache queryCacheOperationForKey:key options:cacheOptions done:^(UIImage *cachedImage, NSData *cachedData, SDImageCacheType cacheType) {


### PR DESCRIPTION
Currently two options can not cover this use case

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2216 #2162 

### Pull Request Description

It seems that during the refactory to remove the tricky code for `if (memoryImage.images) { // query disk cache sync}` in SDImageCache, we miss a use case.

At that time, we introduce two cache options to control the behavior when call `queryCacheOperationForKey:`. However, if I want this use case, I can't do this by combining the current two options:

+ Query the memory cache, if memory cache hit, query the disk cache synchronously
+ If memory cache miss, query the disk cache asynchronously

When you use `SDWebImageQueryDataWhenInMemory | SDWebImageQueryDiskSync`, however, this will cause the second one become 'If memory cache miss, query the disk cache synchronously'. So this acually does not cover this use case.

However,  this use case is the default behavior during SD 4.0 - 4.2. Though in 4.3 we change this and fix the FLAnimatedImageView rendering performance by using associated object to store the FLAnimatedImage instance into memory cache. I found recently some users still need this use case. So we should provide a way to give it back.

So now, for the use case above, I can use `SDWebImageQueryDataWhenInMemory | SDWebImageQueryDataSync` instead
