### PR TITLE
Fix the wrong declaration of NSArray generics

### DIFF
--- a/SDWebImage/SDWebImageCodersManager.h
+++ b/SDWebImage/SDWebImageCodersManager.h
@@ -39,7 +39,7 @@
 /**
  All coders in coders manager. The coders array is a priority queue, which means the later added coder will have the highest priority
  */
-@property (nonatomic, strong, readwrite, nullable) NSArray<SDWebImageCoder>* coders;
+@property (nonatomic, strong, readwrite, nullable) NSArray<id<SDWebImageCoder>> *coders;
 
 /**
  Add a new coder to the end of coders array. Which has the highest priority.

--- a/SDWebImage/SDWebImageCodersManager.m
+++ b/SDWebImage/SDWebImageCodersManager.m
@@ -59,15 +59,15 @@
     });
 }
 
-- (NSArray<SDWebImageCoder> *)coders {
-    __block NSArray<SDWebImageCoder> *sortedCoders = nil;
+- (NSArray<id<SDWebImageCoder>> *)coders {
+    __block NSArray<id<SDWebImageCoder>> *sortedCoders = nil;
     dispatch_sync(self.mutableCodersAccessQueue, ^{
-        sortedCoders = (NSArray<SDWebImageCoder> *)[[[self.mutableCoders copy] reverseObjectEnumerator] allObjects];
+        sortedCoders = (NSArray<id<SDWebImageCoder>> *)[[[self.mutableCoders copy] reverseObjectEnumerator] allObjects];
     });
     return sortedCoders;
 }
 
-- (void)setCoders:(NSArray<SDWebImageCoder> *)coders {
+- (void)setCoders:(NSArray<id<SDWebImageCoder>> *)coders {
     dispatch_barrier_sync(self.mutableCodersAccessQueue, ^{
         self.mutableCoders = [coders mutableCopy];
     });


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x]  I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

The `coders` property in `SDWebImageCodersManager` declaration is wrong. Which should represent an `Array of id<SDWebImageCoder>`. But now means that `NSArray` itself conform to `SDWebImageCoder`. However, Xcode can not show this wrong as a warning...

