### PR TITLE
Feature scale factor

### DIFF
--- a/SDWebImage/NSImage+Additions.h
+++ b/SDWebImage/NSImage+Additions.h
@@ -8,16 +8,50 @@
 
 #import "SDWebImageCompat.h"
 
-// This category is provided to easily write cross-platform code. For common usage, see `UIImage+WebCache`.
+// This category is provided to easily write cross-platform(AppKit/UIKit) code. For common usage, see `UIImage+WebCache`.
 
 #if SD_MAC
 
 @interface NSImage (Additions)
 
+/**
+The underlying Core Graphics image object. This will actually `CGImageForProposedRect` with the image size.
+ */
 @property (nonatomic, readonly, nullable) CGImageRef CGImage;
-@property (nonatomic, readonly, nullable) NSArray<NSImage *> *images;
+/**
+ The scale factor of the image. This wil actually use image size, and its `CGImage`'s pixel size to calculate the scale factor. Should be greater than or equal to 1.0.
+ */
 @property (nonatomic, readonly) CGFloat scale;
-@property (nonatomic, readonly, nullable) NSBitmapImageRep *bitmapImageRep;
+
+// These are convenience methods to make AppKit's `NSImage` match UIKit's `UIImage` behavior. The scale factor should be greater than or equal to 1.0.
+
+/**
+ Returns an image object with the scale factor. The representation is created from the Core Graphics image object.
+ @note The difference between this and `initWithCGImage:size` is that `initWithCGImage:size` will create a `NSCGImageSnapshotRep` but not `NSBitmapImageRep` instance. And it will always `backingScaleFactor` as scale factor.
+
+ @param cgImage A Core Graphics image object
+ @param scale The image scale factor
+ @return The image object
+ */
+- (nonnull instancetype)initWithCGImage:(nonnull CGImageRef)cgImage scale:(CGFloat)scale;
+
+/**
+ Returns an image object with the scale factor. The representation is created from the image data.
+ @note The difference between these this and `initWithData:` is that `initWithData:` will always `backingScaleFactor` as scale factor.
+
+ @param data The image data
+ @param scale The image scale factor
+ @return The image object
+ */
+- (nullable instancetype)initWithData:(nonnull NSData *)data scale:(CGFloat)scale;
+
+@end
+
+@interface NSBitmapImageRep (Additions)
+
+// These method's function is the same as `NSImage`'s function. For `NSBitmapImageRep`.
+- (nonnull instancetype)initWithCGImage:(nonnull CGImageRef)cgImage scale:(CGFloat)scale;
+- (nullable instancetype)initWithData:(nonnull NSData *)data scale:(CGFloat)scale;
 
 @end
 

--- a/SDWebImage/NSImage+Additions.m
+++ b/SDWebImage/NSImage+Additions.m
@@ -18,28 +18,72 @@
     return cgImage;
 }
 
-- (NSArray<NSImage *> *)images {
-    return nil;
-}
-
 - (CGFloat)scale {
     CGFloat scale = 1;
     CGFloat width = self.size.width;
     if (width > 0) {
-        // Use CGImage to get pixel width, NSImageRep.pixelsWide always double on Retina screen
+        // Use CGImage to get pixel width, NSImageRep.pixelsWide may be double on Retina screen
         NSUInteger pixelWidth = CGImageGetWidth(self.CGImage);
         scale = pixelWidth / width;
     }
     return scale;
 }
 
-- (NSBitmapImageRep *)bitmapImageRep {
-    NSRect imageRect = NSMakeRect(0, 0, self.size.width, self.size.height);
-    NSImageRep *imageRep = [self bestRepresentationForRect:imageRect context:nil hints:nil];
-    if ([imageRep isKindOfClass:[NSBitmapImageRep class]]) {
-        return (NSBitmapImageRep *)imageRep;
+- (instancetype)initWithCGImage:(CGImageRef)cgImage scale:(CGFloat)scale {
+    if (scale < 1) {
+        scale = 1;
     }
-    return nil;
+    NSBitmapImageRep *imageRep = [[NSBitmapImageRep alloc] initWithCGImage:cgImage scale:scale];
+    NSSize size = NSMakeSize(imageRep.pixelsWide / scale, imageRep.pixelsHigh / scale);
+    self = [self initWithSize:size];
+    if (self) {
+        [self addRepresentation:imageRep];
+    }
+    return self;
+}
+
+- (instancetype)initWithData:(NSData *)data scale:(CGFloat)scale {
+    if (scale < 1) {
+        scale = 1;
+    }
+    NSBitmapImageRep *imageRep = [[NSBitmapImageRep alloc] initWithData:data scale:scale];
+    if (!imageRep) {
+        return nil;
+    }
+    NSSize size = NSMakeSize(imageRep.pixelsWide / scale, imageRep.pixelsHigh / scale);
+    self = [self initWithSize:size];
+    if (self) {
+        [self addRepresentation:imageRep];
+    }
+    return self;
+}
+
+@end
+
+@implementation NSBitmapImageRep (Additions)
+
+- (instancetype)initWithCGImage:(CGImageRef)cgImage scale:(CGFloat)scale {
+    self = [self initWithCGImage:cgImage];
+    if (self) {
+        if (scale < 1) {
+            scale = 1;
+        }
+        NSSize size = NSMakeSize(self.pixelsWide / scale, self.pixelsHigh / scale);
+        self.size = size;
+    }
+    return self;
+}
+
+- (instancetype)initWithData:(NSData *)data scale:(CGFloat)scale {
+    self = [self initWithData:data];
+    if (self) {
+        if (scale < 1) {
+            scale = 1;
+        }
+        NSSize size = NSMakeSize(self.pixelsWide / scale, self.pixelsHigh / scale);
+        self.size = size;
+    }
+    return self;
 }
 
 @end

--- a/SDWebImage/SDAnimatedImage.m
+++ b/SDWebImage/SDAnimatedImage.m
@@ -310,7 +310,7 @@ static NSArray *SDBundlePreferredScales() {
         return nil;
     }
 #if SD_MAC
-    self = [super initWithCGImage:image.CGImage size:NSZeroSize];
+    self = [super initWithCGImage:image.CGImage scale:scale];
 #else
     self = [super initWithCGImage:image.CGImage scale:scale orientation:image.imageOrientation];
 #endif
@@ -353,7 +353,10 @@ static NSArray *SDBundlePreferredScales() {
     NSNumber *scale = [aDecoder decodeObjectOfClass:[NSNumber class] forKey:NSStringFromSelector(@selector(scale))];
     NSData *animatedImageData = [aDecoder decodeObjectOfClass:[NSData class] forKey:NSStringFromSelector(@selector(animatedImageData))];
     if (animatedImageData) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-designated-initializers"
         return [self initWithData:animatedImageData scale:scale.doubleValue];
+#pragma clang diagnostic pop
     } else {
         return [super initWithCoder:aDecoder];
     }

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -485,7 +485,8 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     if (data) {
         UIImage *image;
         BOOL decodeFirstFrame = options & SDImageCacheDecodeFirstFrameOnly;
-        CGFloat scale = [context valueForKey:SDWebImageContextImageScaleFactor] ? [[context valueForKey:SDWebImageContextImageScaleFactor] doubleValue] : SDImageScaleForKey(key);
+        NSNumber *scaleValue = [context valueForKey:SDWebImageContextImageScaleFactor];
+        CGFloat scale = scaleValue.doubleValue >= 1 ? scaleValue.doubleValue : SDImageScaleFactorForKey(key);
         if (!decodeFirstFrame) {
             // check whether we should use `SDAnimatedImage`
             if ([context valueForKey:SDWebImageContextAnimatedImageClass]) {
@@ -499,7 +500,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             }
         }
         if (!image) {
-            image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:data options:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageContextImageScaleFactor : @(scale)}];
+            image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:data options:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageCoderDecodeScaleFactor : @(scale)}];
         }
         BOOL shouldDecode = YES;
         if ([image conformsToProtocol:@protocol(SDAnimatedImage)]) {

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -485,12 +485,12 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     if (data) {
         UIImage *image;
         BOOL decodeFirstFrame = options & SDImageCacheDecodeFirstFrameOnly;
+        CGFloat scale = [context valueForKey:SDWebImageContextImageScaleFactor] ? [[context valueForKey:SDWebImageContextImageScaleFactor] doubleValue] : SDImageScaleForKey(key);
         if (!decodeFirstFrame) {
             // check whether we should use `SDAnimatedImage`
             if ([context valueForKey:SDWebImageContextAnimatedImageClass]) {
                 Class animatedImageClass = [context valueForKey:SDWebImageContextAnimatedImageClass];
                 if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)]) {
-                    CGFloat scale = SDImageScaleForKey(key);
                     image = [[animatedImageClass alloc] initWithData:data scale:scale];
                     if (options & SDImageCachePreloadAllFrames && [image respondsToSelector:@selector(preloadAllFrames)]) {
                         [((id<SDAnimatedImage>)image) preloadAllFrames];
@@ -499,8 +499,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             }
         }
         if (!image) {
-            image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:data options:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame)}];
-            image = [self scaledImageForKey:key image:image];
+            image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:data options:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageContextImageScaleFactor : @(scale)}];
         }
         BOOL shouldDecode = YES;
         if ([image conformsToProtocol:@protocol(SDAnimatedImage)]) {
@@ -519,10 +518,6 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     } else {
         return nil;
     }
-}
-
-- (nullable UIImage *)scaledImageForKey:(nullable NSString *)key image:(nullable UIImage *)image {
-    return SDScaledImageForKey(key, image);
 }
 
 - (nullable NSOperation *)queryCacheOperationForKey:(NSString *)key done:(SDCacheQueryCompletedBlock)doneBlock {

--- a/SDWebImage/SDWebImageAPNGCoder.m
+++ b/SDWebImage/SDWebImageAPNGCoder.m
@@ -95,11 +95,15 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         return nil;
     }
     size_t count = CGImageSourceGetCount(source);
-    
+    CGFloat scale = 1.0;
+    if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+        scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+        scale = MAX(1.0, scale);
+    }
     UIImage *animatedImage;
     
     if (count <= 1) {
-        animatedImage = [[UIImage alloc] initWithData:data];
+        animatedImage = [[UIImage alloc] initWithData:data scale:scale];
     } else {
         NSMutableArray<SDWebImageFrame *> *frames = [NSMutableArray array];
         
@@ -110,7 +114,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
             }
             
             float duration = [self sd_frameDurationAtIndex:i source:source];
-            UIImage *image = [[UIImage alloc] initWithCGImage:imageRef];
+            UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
             CGImageRelease(imageRef);
             
             SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:image duration:duration];

--- a/SDWebImage/SDWebImageAPNGCoder.m
+++ b/SDWebImage/SDWebImageAPNGCoder.m
@@ -95,10 +95,12 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         return nil;
     }
     size_t count = CGImageSourceGetCount(source);
-    CGFloat scale = 1.0;
+    CGFloat scale = 1;
     if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
         scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
-        scale = MAX(1.0, scale);
+        if (scale < 1) {
+            scale = 1;
+        }
     }
     UIImage *animatedImage;
     

--- a/SDWebImage/SDWebImageAPNGCoder.m
+++ b/SDWebImage/SDWebImageAPNGCoder.m
@@ -82,10 +82,19 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
     if (!data) {
         return nil;
     }
+    CGFloat scale = 1;
+    if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+        scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+        if (scale < 1) {
+            scale = 1;
+        }
+    }
     
 #if SD_MAC
     SDAnimatedImageRep *imageRep = [[SDAnimatedImageRep alloc] initWithData:data];
-    NSImage *animatedImage = [[NSImage alloc] initWithSize:imageRep.size];
+    NSSize size = NSMakeSize(imageRep.pixelsWide / scale, imageRep.pixelsHigh / scale);
+    imageRep.size = size;
+    NSImage *animatedImage = [[NSImage alloc] initWithSize:size];
     [animatedImage addRepresentation:imageRep];
     return animatedImage;
 #else
@@ -95,13 +104,6 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         return nil;
     }
     size_t count = CGImageSourceGetCount(source);
-    CGFloat scale = 1;
-    if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
-        scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
-        if (scale < 1) {
-            scale = 1;
-        }
-    }
     UIImage *animatedImage;
     
     if (count <= 1) {
@@ -277,10 +279,17 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         CGImageRef partialImageRef = CGImageSourceCreateImageAtIndex(_imageSource, 0, NULL);
         
         if (partialImageRef) {
+            CGFloat scale = 1;
+            if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+                scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+                if (scale < 1) {
+                    scale = 1;
+                }
+            }
 #if SD_UIKIT || SD_WATCH
-            image = [[UIImage alloc] initWithCGImage:partialImageRef];
+            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:UIImageOrientationUp];
 #elif SD_MAC
-            image = [[UIImage alloc] initWithCGImage:partialImageRef size:NSZeroSize];
+            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale];
 #endif
             CGImageRelease(partialImageRef);
         }
@@ -375,7 +384,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         CGImageRelease(imageRef);
     }
 #if SD_MAC
-    UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef size:NSZeroSize];
+    UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef scale:1];
 #else
     UIImage *image = [UIImage imageWithCGImage:newImageRef];
 #endif

--- a/SDWebImage/SDWebImageCoder.h
+++ b/SDWebImage/SDWebImageCoder.h
@@ -18,6 +18,10 @@ typedef NSDictionary<SDWebImageCoderOption, id> SDWebImageCoderOptions;
  */
 FOUNDATION_EXPORT SDWebImageCoderOption _Nonnull const SDWebImageCoderDecodeFirstFrameOnly;
 /**
+ A CGFloat value which is greater than or equal to 1.0. This value specify the image scale factor for decoding. If not provide, use 1.0. (NSNumber)
+ */
+FOUNDATION_EXPORT SDWebImageCoderOption _Nonnull const SDWebImageCoderDecodeScaleFactor;
+/**
  A double value between 0.0-1.0 indicating the encode compression quality to produce the image data. If not provide, use 1.0. (NSNumber)
  */
 FOUNDATION_EXPORT SDWebImageCoderOption _Nonnull const SDWebImageCoderEncodeCompressionQuality;

--- a/SDWebImage/SDWebImageCoder.m
+++ b/SDWebImage/SDWebImageCoder.m
@@ -9,4 +9,5 @@
 #import "SDWebImageCoder.h"
 
 SDWebImageCoderOption const SDWebImageCoderDecodeFirstFrameOnly = @"decodeFirstFrameOnly";
+SDWebImageCoderOption const SDWebImageCoderDecodeScaleFactor = @"decodeScaleFactor";
 SDWebImageCoderOption const SDWebImageCoderEncodeCompressionQuality = @"encodeCompressionQuality";

--- a/SDWebImage/SDWebImageCodersManager.m
+++ b/SDWebImage/SDWebImageCodersManager.m
@@ -100,29 +100,11 @@
     if (!data) {
         return nil;
     }
-    BOOL decodeFirstFrame = [[options valueForKey:SDWebImageCoderDecodeFirstFrameOnly] boolValue];
-    CGFloat scale = 1;
-    if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
-        scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
-        if (scale < 1) {
-            scale = 1;
-        }
-    }
     UIImage *image;
     for (id<SDWebImageCoder> coder in self.coders) {
         if ([coder canDecodeFromData:data]) {
             image = [coder decodedImageWithData:data options:options];
             break;
-        }
-    }
-    if (image) {
-        // Check static image
-        if (decodeFirstFrame && image.images.count > 0) {
-            image = image.images.firstObject;
-        }
-        // Check image scale
-        if (scale > 1 && scale != image.scale) {
-            image = SDScaledImageForScaleFactor(scale, image);
         }
     }
     

--- a/SDWebImage/SDWebImageCodersManager.m
+++ b/SDWebImage/SDWebImageCodersManager.m
@@ -15,6 +15,7 @@
 #endif
 #import "NSImage+Additions.h"
 #import "UIImage+WebCache.h"
+#import "SDWebImageDefine.h"
 
 @interface SDWebImageCodersManager ()
 
@@ -100,6 +101,13 @@
         return nil;
     }
     BOOL decodeFirstFrame = [[options valueForKey:SDWebImageCoderDecodeFirstFrameOnly] boolValue];
+    CGFloat scale = 1;
+    if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+        scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+        if (scale < 1) {
+            scale = 1;
+        }
+    }
     UIImage *image;
     for (id<SDWebImageCoder> coder in self.coders) {
         if ([coder canDecodeFromData:data]) {
@@ -107,8 +115,15 @@
             break;
         }
     }
-    if (decodeFirstFrame && image.images.count > 0) {
-        image = image.images.firstObject;
+    if (image) {
+        // Check static image
+        if (decodeFirstFrame && image.images.count > 0) {
+            image = image.images.firstObject;
+        }
+        // Check image scale
+        if (scale > 1 && scale != image.scale) {
+            image = SDScaledImageForScaleFactor(scale, image);
+        }
     }
     
     return image;

--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -177,6 +177,11 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextCustom
 FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextCustomTransformer;
 
 /**
+ A CGFloat value which specify the image scale factor. The number should be greater than or equal to 1.0. If not provide or the number is invalid, we will use the cache key to specify the scale factor. (NSNumber)
+ */
+FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageScaleFactor;
+
+/**
  A Class object which the instance is a `UIImage/NSImage` subclass and adopt `SDAnimatedImage` protocol. We will call `initWithData:scale:` to create the instance (or `initWithAnimatedCoder:scale` when using progressive download) . If the instance create failed, fallback to normal `UIImage/NSImage`.
  This can be used to improve animated images rendering performance (especially memory usage on big animated images) with `SDAnimatedImageView` (Class).
  */

--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -16,22 +16,35 @@ typedef NSMutableDictionary<SDWebImageContextOption, id> SDWebImageMutableContex
 #pragma mark - Image scale
 
 /**
- Return the image scale from the specify key, supports file name and url key
+ Return the image scale factor for the specify key, supports file name and url key.
+ This is the built-in way to check the scale factor when we have no context about it. Because scale factor is not stored in image data (It's typically from filename).
+ However, you can also provide custom scale factor as well, see `SDWebImageContextImageScaleFactor`.
 
  @param key The image cache key
  @return The scale factor for image
  */
-FOUNDATION_EXPORT CGFloat SDImageScaleForKey(NSString * _Nullable key);
+FOUNDATION_EXPORT CGFloat SDImageScaleFactorForKey(NSString * _Nullable key);
 
 /**
- Scale the image with the scale factor from the specify key. If no need to scale, return the original image
- This only works for `UIImage`(UIKit) or `NSImage`(AppKit).
+ Scale the image with the scale factor for the specify key. If no need to scale, return the original image.
+ This works for `UIImage`(UIKit) or `NSImage`(AppKit). And this function also preserve the associated value in `UIImage+WebCache`.
+ @note This is actually a convenience function, which firstlly call `SDImageScaleFactorForKey` and then call `SDScaledImageForScaleFactor`, kept for backward compatibility.
 
  @param key The image cache key
  @param image The image
  @return The scaled image
  */
 FOUNDATION_EXPORT UIImage * _Nullable SDScaledImageForKey(NSString * _Nullable key, UIImage * _Nullable image);
+
+/**
+ Scale the image with the scale factor. If no need to scale, return the original image.
+ This works for `UIImage`(UIKit) or `NSImage`(AppKit). And this function also preserve the associated value in `UIImage+WebCache`.
+ 
+ @param scale The image scale factor
+ @param image The image
+ @return The scaled image
+ */
+FOUNDATION_EXPORT UIImage * _Nullable SDScaledImageForScaleFactor(CGFloat scale, UIImage * _Nullable image);
 
 #pragma mark - WebCache Options
 

--- a/SDWebImage/SDWebImageDefine.m
+++ b/SDWebImage/SDWebImageDefine.m
@@ -88,18 +88,25 @@ inline UIImage * _Nullable SDScaledImageForScaleFactor(CGFloat scale, UIImage * 
         animatedImage = [UIImage animatedImageWithImages:scaledImages duration:image.duration];
         animatedImage.sd_imageLoopCount = image.sd_imageLoopCount;
 #else
-        // Animated GIF for `NSImage` need to grab `NSBitmapImageRep`
-        NSSize size = NSMakeSize(image.size.width / scale, image.size.height / scale);
-        animatedImage = [[NSImage alloc] initWithSize:size];
-        NSBitmapImageRep *bitmapImageRep = image.bitmapImageRep;
-        [animatedImage addRepresentation:bitmapImageRep];
+        // Animated GIF for `NSImage` need to grab `NSBitmapImageRep`;
+        NSRect imageRect = NSMakeRect(0, 0, image.size.width, image.size.height);
+        NSImageRep *imageRep = [image bestRepresentationForRect:imageRect context:nil hints:nil];
+        NSBitmapImageRep *bitmapImageRep;
+        if ([imageRep isKindOfClass:[NSBitmapImageRep class]]) {
+            bitmapImageRep = (NSBitmapImageRep *)imageRep;
+        }
+        if (bitmapImageRep) {
+            NSSize size = NSMakeSize(image.size.width / scale, image.size.height / scale);
+            animatedImage = [[NSImage alloc] initWithSize:size];
+            [animatedImage addRepresentation:bitmapImageRep];
+        }
 #endif
         scaledImage = animatedImage;
     } else {
 #if SD_UIKIT || SD_WATCH
         scaledImage = [[UIImage alloc] initWithCGImage:image.CGImage scale:scale orientation:image.imageOrientation];
 #else
-        scaledImage = [[NSImage alloc] initWithCGImage:image.CGImage size:NSZeroSize];
+        scaledImage = [[NSImage alloc] initWithCGImage:image.CGImage scale:scale];
 #endif
     }
     scaledImage.sd_isIncremental = image.sd_isIncremental;

--- a/SDWebImage/SDWebImageDefine.m
+++ b/SDWebImage/SDWebImageDefine.m
@@ -103,4 +103,5 @@ SDWebImageContextOption const SDWebImageContextSetImageOperationKey = @"setImage
 SDWebImageContextOption const SDWebImageContextSetImageGroup = @"setImageGroup";
 SDWebImageContextOption const SDWebImageContextCustomManager = @"customManager";
 SDWebImageContextOption const SDWebImageContextCustomTransformer = @"customTransformer";
+SDWebImageContextOption const SDWebImageContextImageScaleFactor = @"imageScaleFactor";
 SDWebImageContextOption const SDWebImageContextAnimatedImageClass = @"animatedImageClass";

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -364,7 +364,8 @@ didReceiveResponse:(NSURLResponse *)response
             // check whether we should use `SDAnimatedImage`
             UIImage *image;
             BOOL decodeFirstFrame = self.options & SDWebImageDownloaderDecodeFirstFrameOnly;
-            CGFloat scale = [self.context valueForKey:SDWebImageContextImageScaleFactor] ? [[self.context valueForKey:SDWebImageContextImageScaleFactor] doubleValue] : SDImageScaleForKey(self.cacheKey);
+            NSNumber *scaleValue = [self.context valueForKey:SDWebImageContextImageScaleFactor];
+            CGFloat scale = scaleValue.doubleValue >= 1 ? scaleValue.doubleValue : SDImageScaleFactorForKey(self.cacheKey);
             if (!decodeFirstFrame) {
                 // check whether we should use `SDAnimatedImage`
                 if ([self.context valueForKey:SDWebImageContextAnimatedImageClass]) {
@@ -375,7 +376,7 @@ didReceiveResponse:(NSURLResponse *)response
                 }
             }
             if (!image) {
-                image = [self.progressiveCoder incrementalDecodedImageWithOptions:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageContextImageScaleFactor : @(scale)}];
+                image = [self.progressiveCoder incrementalDecodedImageWithOptions:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageCoderDecodeScaleFactor : @(scale)}];
             }
             if (image) {
                 BOOL shouldDecode = self.shouldDecompressImages;
@@ -456,7 +457,8 @@ didReceiveResponse:(NSURLResponse *)response
                     // decode the image in coder queue
                     dispatch_async(self.coderQueue, ^{
                         BOOL decodeFirstFrame = self.options & SDWebImageDownloaderDecodeFirstFrameOnly;
-                        CGFloat scale = [self.context valueForKey:SDWebImageContextImageScaleFactor] ? [[self.context valueForKey:SDWebImageContextImageScaleFactor] doubleValue] : SDImageScaleForKey(self.cacheKey);
+                        NSNumber *scaleValue = [self.context valueForKey:SDWebImageContextImageScaleFactor];
+                        CGFloat scale = scaleValue.doubleValue >= 1 ? scaleValue.doubleValue : SDImageScaleFactorForKey(self.cacheKey);
                         if (scale < 1) {
                             scale = 1;
                         }
@@ -474,7 +476,7 @@ didReceiveResponse:(NSURLResponse *)response
                             }
                         }
                         if (!image) {
-                            image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:imageData options:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageContextImageScaleFactor : @(scale)}];
+                            image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:imageData options:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageCoderDecodeScaleFactor : @(scale)}];
                         }
                         
                         BOOL shouldDecode = self.shouldDecompressImages;

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -363,17 +363,19 @@ didReceiveResponse:(NSURLResponse *)response
         dispatch_async(self.coderQueue, ^{
             // check whether we should use `SDAnimatedImage`
             UIImage *image;
-            if ([self.context valueForKey:SDWebImageContextAnimatedImageClass]) {
-                Class animatedImageClass = [self.context valueForKey:SDWebImageContextAnimatedImageClass];
-                if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)] && [self.progressiveCoder conformsToProtocol:@protocol(SDWebImageAnimatedCoder)]) {
-                    CGFloat scale = SDImageScaleForKey(self.cacheKey);
-                    image = [[animatedImageClass alloc] initWithAnimatedCoder:(id<SDWebImageAnimatedCoder>)self.progressiveCoder scale:scale];
+            BOOL decodeFirstFrame = self.options & SDWebImageDownloaderDecodeFirstFrameOnly;
+            CGFloat scale = [self.context valueForKey:SDWebImageContextImageScaleFactor] ? [[self.context valueForKey:SDWebImageContextImageScaleFactor] doubleValue] : SDImageScaleForKey(self.cacheKey);
+            if (!decodeFirstFrame) {
+                // check whether we should use `SDAnimatedImage`
+                if ([self.context valueForKey:SDWebImageContextAnimatedImageClass]) {
+                    Class animatedImageClass = [self.context valueForKey:SDWebImageContextAnimatedImageClass];
+                    if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)] && [self.progressiveCoder conformsToProtocol:@protocol(SDWebImageAnimatedCoder)]) {
+                        image = [[animatedImageClass alloc] initWithAnimatedCoder:(id<SDWebImageAnimatedCoder>)self.progressiveCoder scale:scale];
+                    }
                 }
             }
             if (!image) {
-                BOOL decodeFirstFrame = self.options & SDWebImageDownloaderDecodeFirstFrameOnly;
-                image = [self.progressiveCoder incrementalDecodedImageWithOptions:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame)}];
-                image = [self scaledImageForKey:self.cacheKey image:image];
+                image = [self.progressiveCoder incrementalDecodedImageWithOptions:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageContextImageScaleFactor : @(scale)}];
             }
             if (image) {
                 BOOL shouldDecode = self.shouldDecompressImages;
@@ -454,13 +456,16 @@ didReceiveResponse:(NSURLResponse *)response
                     // decode the image in coder queue
                     dispatch_async(self.coderQueue, ^{
                         BOOL decodeFirstFrame = self.options & SDWebImageDownloaderDecodeFirstFrameOnly;
+                        CGFloat scale = [self.context valueForKey:SDWebImageContextImageScaleFactor] ? [[self.context valueForKey:SDWebImageContextImageScaleFactor] doubleValue] : SDImageScaleForKey(self.cacheKey);
+                        if (scale < 1) {
+                            scale = 1;
+                        }
                         UIImage *image;
                         if (!decodeFirstFrame) {
                             // check whether we should use `SDAnimatedImage`
                             if ([self.context valueForKey:SDWebImageContextAnimatedImageClass]) {
                                 Class animatedImageClass = [self.context valueForKey:SDWebImageContextAnimatedImageClass];
                                 if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)]) {
-                                    CGFloat scale = SDImageScaleForKey(self.cacheKey);
                                     image = [[animatedImageClass alloc] initWithData:imageData scale:scale];
                                     if (self.options & SDWebImageDownloaderPreloadAllFrames && [image respondsToSelector:@selector(preloadAllFrames)]) {
                                         [((id<SDAnimatedImage>)image) preloadAllFrames];
@@ -469,8 +474,7 @@ didReceiveResponse:(NSURLResponse *)response
                             }
                         }
                         if (!image) {
-                            image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:imageData options:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame)}];
-                            image = [self scaledImageForKey:self.cacheKey image:image];
+                            image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:imageData options:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageContextImageScaleFactor : @(scale)}];
                         }
                         
                         BOOL shouldDecode = self.shouldDecompressImages;
@@ -545,10 +549,6 @@ didReceiveResponse:(NSURLResponse *)response
         _cacheKey = [[SDWebImageManager sharedManager] cacheKeyForURL:self.request.URL];
     }
     return _cacheKey;
-}
-
-- (nullable UIImage *)scaledImageForKey:(nullable NSString *)key image:(nullable UIImage *)image {
-    return SDScaledImageForKey(key, image);
 }
 
 - (BOOL)shouldContinueWhenAppEntersBackground {

--- a/SDWebImage/SDWebImageGIFCoder.m
+++ b/SDWebImage/SDWebImageGIFCoder.m
@@ -72,10 +72,19 @@
     if (!data) {
         return nil;
     }
+    CGFloat scale = 1;
+    if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+        scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+        if (scale < 1) {
+            scale = 1;
+        }
+    }
     
 #if SD_MAC
     SDAnimatedImageRep *imageRep = [[SDAnimatedImageRep alloc] initWithData:data];
-    NSImage *animatedImage = [[NSImage alloc] initWithSize:imageRep.size];
+    NSSize size = NSMakeSize(imageRep.pixelsWide / scale, imageRep.pixelsHigh / scale);
+    imageRep.size = size;
+    NSImage *animatedImage = [[NSImage alloc] initWithSize:size];
     [animatedImage addRepresentation:imageRep];
     return animatedImage;
 #else
@@ -85,13 +94,6 @@
         return nil;
     }
     size_t count = CGImageSourceGetCount(source);
-    CGFloat scale = 1;
-    if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
-        scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
-        if (scale < 1) {
-            scale = 1;
-        }
-    }
     UIImage *animatedImage;
     
     BOOL decodeFirstFrame = [options[SDWebImageCoderDecodeFirstFrameOnly] boolValue];
@@ -224,10 +226,17 @@
         CGImageRef partialImageRef = CGImageSourceCreateImageAtIndex(_imageSource, 0, NULL);
         
         if (partialImageRef) {
+            CGFloat scale = 1;
+            if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+                scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+                if (scale < 1) {
+                    scale = 1;
+                }
+            }
 #if SD_UIKIT || SD_WATCH
-            image = [[UIImage alloc] initWithCGImage:partialImageRef];
+            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:UIImageOrientationUp];
 #elif SD_MAC
-            image = [[UIImage alloc] initWithCGImage:partialImageRef size:NSZeroSize];
+            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale];
 #endif
             CGImageRelease(partialImageRef);
         }
@@ -375,7 +384,7 @@
         CGImageRelease(imageRef);
     }
 #if SD_MAC
-    UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef size:NSZeroSize];
+    UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef scale:1];
 #else
     UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef];
 #endif

--- a/SDWebImage/SDWebImageGIFCoder.m
+++ b/SDWebImage/SDWebImageGIFCoder.m
@@ -85,7 +85,11 @@
         return nil;
     }
     size_t count = CGImageSourceGetCount(source);
-    
+    CGFloat scale = 1.0;
+    if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+        scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+        scale = MAX(1.0, scale);
+    }
     UIImage *animatedImage;
     
     BOOL decodeFirstFrame = [options[SDWebImageCoderDecodeFirstFrameOnly] boolValue];
@@ -101,7 +105,7 @@
             }
             
             float duration = [self sd_frameDurationAtIndex:i source:source];
-            UIImage *image = [[UIImage alloc] initWithCGImage:imageRef];
+            UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
             CGImageRelease(imageRef);
             
             SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:image duration:duration];

--- a/SDWebImage/SDWebImageGIFCoder.m
+++ b/SDWebImage/SDWebImageGIFCoder.m
@@ -85,10 +85,12 @@
         return nil;
     }
     size_t count = CGImageSourceGetCount(source);
-    CGFloat scale = 1.0;
+    CGFloat scale = 1;
     if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
         scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
-        scale = MAX(1.0, scale);
+        if (scale < 1) {
+            scale = 1;
+        }
     }
     UIImage *animatedImage;
     

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -86,10 +86,12 @@
     UIImage *image = [[UIImage alloc] initWithData:data];
     return image;
 #else
-    CGFloat scale = 1.0;
+    CGFloat scale = 1;
     if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
         scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
-        scale = MAX(1.0, scale);
+        if (scale < 1) {
+            scale = 1;
+        }
     }
     UIImage *image = [[UIImage alloc] initWithData:data scale:scale];
     if (!image) {

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -82,11 +82,16 @@
         return nil;
     }
     
-    UIImage *image = [[UIImage alloc] initWithData:data];
-    
 #if SD_MAC
+    UIImage *image = [[UIImage alloc] initWithData:data];
     return image;
 #else
+    CGFloat scale = 1.0;
+    if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+        scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+        scale = MAX(1.0, scale);
+    }
+    UIImage *image = [[UIImage alloc] initWithData:data scale:scale];
     if (!image) {
         return nil;
     }

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -81,11 +81,6 @@
     if (!data) {
         return nil;
     }
-    
-#if SD_MAC
-    UIImage *image = [[UIImage alloc] initWithData:data];
-    return image;
-#else
     CGFloat scale = 1;
     if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
         scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
@@ -93,7 +88,11 @@
             scale = 1;
         }
     }
+    
     UIImage *image = [[UIImage alloc] initWithData:data scale:scale];
+#if SD_MAC
+    return image;
+#else
     if (!image) {
         return nil;
     }
@@ -182,10 +181,17 @@
 #endif
         
         if (partialImageRef) {
+            CGFloat scale = 1;
+            if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+                scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+                if (scale < 1) {
+                    scale = 1;
+                }
+            }
 #if SD_UIKIT || SD_WATCH
-            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:1 orientation:_orientation];
+            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:_orientation];
 #elif SD_MAC
-            image = [[UIImage alloc] initWithCGImage:partialImageRef size:NSZeroSize];
+            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale];
 #endif
             CGImageRelease(partialImageRef);
         }

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -261,7 +261,7 @@
 
                     if (options & SDWebImageRefreshCached && cachedImage && !downloadedImage) {
                         // Image refresh hit the NSURLCache cache, do not call the completion block
-                    } else if (downloadedImage && (!downloadedImage.images || (options & SDWebImageTransformAnimatedImage)) && transformer) {
+                    } else if (downloadedImage && (!downloadedImage.sd_isAnimated || (options & SDWebImageTransformAnimatedImage)) && transformer) {
                         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
                             UIImage *transformedImage = [transformer transformedImageWithImage:downloadedImage forKey:key];
                             if (transformedImage && finished) {

--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -114,7 +114,6 @@ dispatch_semaphore_signal(self->_lock);
     uint32_t flags = WebPDemuxGetI(demuxer, WEBP_FF_FORMAT_FLAGS);
     BOOL hasAnimation = flags & ANIMATION_FLAG;
     BOOL decodeFirstFrame = [[options valueForKey:SDWebImageCoderDecodeFirstFrameOnly] boolValue];
-#if SD_UIKIT || SD_WATCH
     CGFloat scale = 1;
     if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
         scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
@@ -122,7 +121,6 @@ dispatch_semaphore_signal(self->_lock);
             scale = 1;
         }
     }
-#endif
     if (!hasAnimation) {
         // for static single webp image
         CGImageRef imageRef = [self sd_createWebpImageWithData:webpData];
@@ -132,7 +130,7 @@ dispatch_semaphore_signal(self->_lock);
 #if SD_UIKIT || SD_WATCH
         UIImage *staticImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
 #else
-        UIImage *staticImage = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
+        UIImage *staticImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale];
 #endif
         CGImageRelease(imageRef);
         WebPDemuxDelete(demuxer);
@@ -154,7 +152,7 @@ dispatch_semaphore_signal(self->_lock);
 #if SD_UIKIT || SD_WATCH
         UIImage *firstFrameImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
 #else
-        UIImage *firstFrameImage = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
+        UIImage *firstFrameImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale];
 #endif
         CGImageRelease(imageRef);
         WebPDemuxReleaseIterator(&iter);
@@ -185,7 +183,7 @@ dispatch_semaphore_signal(self->_lock);
 #if SD_UIKIT || SD_WATCH
             UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
 #else
-            UIImage *image = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
+            UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale];
 #endif
             CGImageRelease(imageRef);
             
@@ -279,11 +277,18 @@ dispatch_semaphore_signal(self->_lock);
             CGContextRelease(canvas);
             return nil;
         }
+        CGFloat scale = 1;
+        if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+            scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+            if (scale < 1) {
+                scale = 1;
+            }
+        }
         
 #if SD_UIKIT || SD_WATCH
-        image = [[UIImage alloc] initWithCGImage:newImageRef];
+        image = [[UIImage alloc] initWithCGImage:newImageRef scale:scale orientation:UIImageOrientationUp];
 #else
-        image = [[UIImage alloc] initWithCGImage:newImageRef size:NSZeroSize];
+        image = [[UIImage alloc] initWithCGImage:newImageRef scale:scale];
 #endif
         CGImageRelease(newImageRef);
         CGContextRelease(canvas);
@@ -664,7 +669,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
 #if SD_UIKIT || SD_WATCH
         image = [[UIImage alloc] initWithCGImage:imageRef];
 #else
-        image = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
+        image = [[UIImage alloc] initWithCGImage:imageRef scale:1];
 #endif
         CGImageRelease(imageRef);
     } else {
@@ -694,7 +699,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
 #if SD_UIKIT || SD_WATCH
                     image = [[UIImage alloc] initWithCGImage:imageRef];
 #else
-                    image = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
+                    image = [[UIImage alloc] initWithCGImage:imageRef scale:1];
 #endif
                     CGImageRelease(imageRef);
                 }

--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -114,9 +114,25 @@ dispatch_semaphore_signal(self->_lock);
     uint32_t flags = WebPDemuxGetI(demuxer, WEBP_FF_FORMAT_FLAGS);
     BOOL hasAnimation = flags & ANIMATION_FLAG;
     BOOL decodeFirstFrame = [[options valueForKey:SDWebImageCoderDecodeFirstFrameOnly] boolValue];
+#if SD_UIKIT || SD_WATCH
+    CGFloat scale = 1.0;
+    if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
+        scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
+        scale = MAX(1.0, scale);
+    }
+#endif
     if (!hasAnimation) {
         // for static single webp image
-        UIImage *staticImage = [self sd_rawWebpImageWithData:webpData];
+        CGImageRef imageRef = [self sd_createWebpImageWithData:webpData];
+        if (!imageRef) {
+            return nil;
+        }
+#if SD_UIKIT || SD_WATCH
+        UIImage *staticImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
+#else
+        UIImage *staticImage = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
+#endif
+        CGImageRelease(imageRef);
         WebPDemuxDelete(demuxer);
         return staticImage;
     }
@@ -132,7 +148,13 @@ dispatch_semaphore_signal(self->_lock);
     
     if (decodeFirstFrame) {
         // first frame for animated webp image
-        UIImage *firstFrameImage = [self sd_rawWebpImageWithData:iter.fragment];
+        CGImageRef imageRef = [self sd_createWebpImageWithData:iter.fragment];
+#if SD_UIKIT || SD_WATCH
+        UIImage *firstFrameImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
+#else
+        UIImage *firstFrameImage = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
+#endif
+        CGImageRelease(imageRef);
         WebPDemuxReleaseIterator(&iter);
         WebPDemuxDelete(demuxer);
         return firstFrameImage;
@@ -154,10 +176,16 @@ dispatch_semaphore_signal(self->_lock);
     
     do {
         @autoreleasepool {
-            UIImage *image = [self sd_drawnWebpImageWithCanvas:canvas iterator:iter];
-            if (!image) {
+            CGImageRef imageRef = [self sd_drawnWebpImageWithCanvas:canvas iterator:iter];
+            if (!imageRef) {
                 continue;
             }
+#if SD_UIKIT || SD_WATCH
+            UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
+#else
+            UIImage *image = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
+#endif
+            CGImageRelease(imageRef);
             
             NSTimeInterval duration = [self sd_frameDurationWithIterator:iter];
             SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:image duration:duration];
@@ -271,8 +299,8 @@ dispatch_semaphore_signal(self->_lock);
     if (iter.dispose_method == WEBP_MUX_DISPOSE_BACKGROUND) {
         CGContextClearRect(canvas, imageRect);
     } else {
-        UIImage *image = [self sd_rawWebpImageWithData:iter.fragment];
-        if (!image) {
+        CGImageRef imageRef = [self sd_createWebpImageWithData:iter.fragment];
+        if (!imageRef) {
             return;
         }
         BOOL shouldBlend = iter.blend_method == WEBP_MUX_BLEND;
@@ -280,13 +308,14 @@ dispatch_semaphore_signal(self->_lock);
         if (!shouldBlend) {
             CGContextClearRect(canvas, imageRect);
         }
-        CGContextDrawImage(canvas, imageRect, image.CGImage);
+        CGContextDrawImage(canvas, imageRect, imageRef);
+        CGImageRelease(imageRef);
     }
 }
 
-- (nullable UIImage *)sd_drawnWebpImageWithCanvas:(CGContextRef)canvas iterator:(WebPIterator)iter {
-    UIImage *image = [self sd_rawWebpImageWithData:iter.fragment];
-    if (!image) {
+- (nullable CGImageRef)sd_drawnWebpImageWithCanvas:(CGContextRef)canvas iterator:(WebPIterator)iter CF_RETURNS_RETAINED {
+    CGImageRef imageRef = [self sd_createWebpImageWithData:iter.fragment];
+    if (!imageRef) {
         return nil;
     }
     
@@ -300,25 +329,19 @@ dispatch_semaphore_signal(self->_lock);
     if (!shouldBlend) {
         CGContextClearRect(canvas, imageRect);
     }
-    CGContextDrawImage(canvas, imageRect, image.CGImage);
+    CGContextDrawImage(canvas, imageRect, imageRef);
     CGImageRef newImageRef = CGBitmapContextCreateImage(canvas);
     
-#if SD_UIKIT || SD_WATCH
-    image = [[UIImage alloc] initWithCGImage:newImageRef];
-#elif SD_MAC
-    image = [[UIImage alloc] initWithCGImage:newImageRef size:NSZeroSize];
-#endif
-    
-    CGImageRelease(newImageRef);
+    CGImageRelease(imageRef);
     
     if (iter.dispose_method == WEBP_MUX_DISPOSE_BACKGROUND) {
         CGContextClearRect(canvas, imageRect);
     }
     
-    return image;
+    return newImageRef;
 }
 
-- (nullable UIImage *)sd_rawWebpImageWithData:(WebPData)webpData {
+- (nullable CGImageRef)sd_createWebpImageWithData:(WebPData)webpData CF_RETURNS_RETAINED {
     WebPDecoderConfig config;
     if (!WebPInitDecoderConfig(&config)) {
         return nil;
@@ -361,14 +384,7 @@ dispatch_semaphore_signal(self->_lock);
     
     CGDataProviderRelease(provider);
     
-#if SD_UIKIT || SD_WATCH
-    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef];
-#else
-    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
-#endif
-    CGImageRelease(imageRef);
-    
-    return image;
+    return imageRef;
 }
 
 - (NSTimeInterval)sd_frameDurationWithIterator:(WebPIterator)iter {
@@ -639,7 +655,16 @@ static void FreeImageData(void *info, const void *data, size_t size) {
             WebPDemuxReleaseIterator(&iter);
             return nil;
         }
-        image = [self sd_drawnWebpImageWithCanvas:_canvas iterator:iter];
+        CGImageRef imageRef = [self sd_drawnWebpImageWithCanvas:_canvas iterator:iter];
+        if (!imageRef) {
+            return nil;
+        }
+#if SD_UIKIT || SD_WATCH
+        image = [[UIImage alloc] initWithCGImage:imageRef];
+#else
+        image = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
+#endif
+        CGImageRelease(imageRef);
     } else {
         // Else, this can happen when one image set to different imageViews or one loop end. So we should clear the shared cavans.
         if (_currentBlendIndex != NSNotFound) {
@@ -660,7 +685,16 @@ static void FreeImageData(void *info, const void *data, size_t size) {
                 if ((size_t)iter.frame_num == endIndex) {
                     [self sd_blendWebpImageWithCanvas:_canvas iterator:iter];
                 } else {
-                    image = [self sd_drawnWebpImageWithCanvas:_canvas iterator:iter];
+                    CGImageRef imageRef = [self sd_drawnWebpImageWithCanvas:_canvas iterator:iter];
+                    if (!imageRef) {
+                        return nil;
+                    }
+#if SD_UIKIT || SD_WATCH
+                    image = [[UIImage alloc] initWithCGImage:imageRef];
+#else
+                    image = [[UIImage alloc] initWithCGImage:imageRef size:NSZeroSize];
+#endif
+                    CGImageRelease(imageRef);
                 }
             }
         } while ((size_t)iter.frame_num < (endIndex + 1) && WebPDemuxNextFrame(&iter));

--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -115,10 +115,12 @@ dispatch_semaphore_signal(self->_lock);
     BOOL hasAnimation = flags & ANIMATION_FLAG;
     BOOL decodeFirstFrame = [[options valueForKey:SDWebImageCoderDecodeFirstFrameOnly] boolValue];
 #if SD_UIKIT || SD_WATCH
-    CGFloat scale = 1.0;
+    CGFloat scale = 1;
     if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {
         scale = [[options valueForKey:SDWebImageCoderDecodeScaleFactor] doubleValue];
-        scale = MAX(1.0, scale);
+        if (scale < 1) {
+            scale = 1;
+        }
     }
 #endif
     if (!hasAnimation) {

--- a/SDWebImage/UIImage+WebCache.h
+++ b/SDWebImage/UIImage+WebCache.h
@@ -25,7 +25,7 @@
  * UIKit:
  * Check the `images` array property
  * AppKit:
- * NSImage currently only support animated via GIF imageRep unlike UIImage. It will check all the imageRef
+ * NSImage currently only support animated via GIF imageRep unlike UIImage. It will check the imageRep's frame count.
  */
 @property (nonatomic, assign, readonly) BOOL sd_isAnimated;
 

--- a/SDWebImage/UIImage+WebCache.m
+++ b/SDWebImage/UIImage+WebCache.m
@@ -51,7 +51,12 @@
 
 - (NSUInteger)sd_imageLoopCount {
     NSUInteger imageLoopCount = 0;
-    NSBitmapImageRep *bitmapImageRep = self.bitmapImageRep;
+    NSRect imageRect = NSMakeRect(0, 0, self.size.width, self.size.height);
+    NSImageRep *imageRep = [self bestRepresentationForRect:imageRect context:nil hints:nil];
+    NSBitmapImageRep *bitmapImageRep;
+    if ([imageRep isKindOfClass:[NSBitmapImageRep class]]) {
+        bitmapImageRep = (NSBitmapImageRep *)imageRep;
+    }
     if (bitmapImageRep) {
         imageLoopCount = [[bitmapImageRep valueForProperty:NSImageLoopCount] unsignedIntegerValue];
     }
@@ -59,7 +64,12 @@
 }
 
 - (void)setSd_imageLoopCount:(NSUInteger)sd_imageLoopCount {
-    NSBitmapImageRep *bitmapImageRep = self.bitmapImageRep;
+    NSRect imageRect = NSMakeRect(0, 0, self.size.width, self.size.height);
+    NSImageRep *imageRep = [self bestRepresentationForRect:imageRect context:nil hints:nil];
+    NSBitmapImageRep *bitmapImageRep;
+    if ([imageRep isKindOfClass:[NSBitmapImageRep class]]) {
+        bitmapImageRep = (NSBitmapImageRep *)imageRep;
+    }
     if (bitmapImageRep) {
         [bitmapImageRep setProperty:NSImageLoopCount withValue:@(sd_imageLoopCount)];
     }
@@ -67,7 +77,12 @@
 
 - (BOOL)sd_isAnimated {
     BOOL isGIF = NO;
-    NSBitmapImageRep *bitmapImageRep = self.bitmapImageRep;
+    NSRect imageRect = NSMakeRect(0, 0, self.size.width, self.size.height);
+    NSImageRep *imageRep = [self bestRepresentationForRect:imageRect context:nil hints:nil];
+    NSBitmapImageRep *bitmapImageRep;
+    if ([imageRep isKindOfClass:[NSBitmapImageRep class]]) {
+        bitmapImageRep = (NSBitmapImageRep *)imageRep;
+    }
     if (bitmapImageRep) {
         NSUInteger frameCount = [[bitmapImageRep valueForProperty:NSImageFrameCount] unsignedIntegerValue];
         isGIF = frameCount > 1 ? YES : NO;

--- a/Tests/Tests/SDWebImageDecoderTests.m
+++ b/Tests/Tests/SDWebImageDecoderTests.m
@@ -170,7 +170,9 @@
     UIImage *outputImage = [coder decodedImageWithData:outputImageData options:nil];
     expect(outputImage.size).to.equal(inputImage.size);
     expect(outputImage.scale).to.equal(inputImage.scale);
+#if SD_UIKIT
     expect(outputImage.images.count).to.equal(inputImage.images.count);
+#endif
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1793 #1884 #1554 

### Pull Request Description

### Reason
The `image scale factor` is a quite frustrating problem for image download from network. Actually, scale factor this concept is created by Apple only. It's used for Retina display but not other level. For image format, it only care about pixel resolution. So the scale factor is not stored as a metadata or something into image data. It only from filename or some other information such as Xcode's asset JSON description. Means, for image from network, we does not have the context to know its scale 😅 

#### First Problem
For our framework's solution, we grab the scale factor from `URL` and `cache key` in the history by using `SDScaledImageForKey`. It search the string to check whether it contains `@2x, @3x`.  However, since the Internet is not so standard. Some image may loss their scale because of URL changed, or URL encoded. And we also face the problem when storing the image to cache, we may lose their scale because the cache key may not equal to the URL or filename. Some user may also want their own logic way to scale the image, but not based on our algorithm, but however, they can not do this in 4.x.

#### Second Problem
Another problem, since some user may subclass (like we do :)) `UIImage`, or store some associated object into `UIImage` instance. So if we call `SDScaledImageForKey`, this information will be lost as well. So arbitrarily call that function is not a good idea. 😕 

#1793 #1884 #1554 talk about something about these problems as well. In 5.x, since we can use a `context` option to hold extra things beyond `SDWebImageOptions`. We also contains a `options` arg in custom coder protocol method. So I think it's time to change now.

### Design
We produce a custom scale factor in `SDWebImageContext` value, which allow user to provide their custom scale factor. And then we use this value instead of `SDImageScaleFactorForKey` our built-in way to sepcify image scale. This can solve the first problem above.

And also, we do not need to do extra scale at most cases. We pass the `scale factor` to custom coder. Let the coder create the image which already contains the correct scale factor (Such as using `- [UIImage imageWithCGImage:scale:orientation]`. This can solve the second problem above.

### Implementation
Context option:

```objective-c
/**
 A CGFloat value which specify the image scale factor. The number should be greater than or equal to 1.0. If not provide or the number is invalid, we will use the cache key to specify the scale factor. (NSNumber)
 */
FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextImageScaleFactor;
```

Coder option:

```objective-c
/**
 A CGFloat value which is greater than or equal to 1.0. This value specify the image scale factor for decoding. If not provide, use 1.0. (NSNumber)
 */
FOUNDATION_EXPORT SDWebImageCoderOption _Nonnull const SDWebImageCoderDecodeScaleFactor;
```
