### PR TITLE
Remove the extra calculation of image orientation for ImageIO coder & Fix macOS image orientation

### DIFF
--- a/Examples/SDWebImage OSX Demo/ViewController.m
+++ b/Examples/SDWebImage OSX Demo/ViewController.m
@@ -32,7 +32,7 @@
     self.imageView3.animates = YES;
     self.imageView4.animates = YES;
     self.imageView1.sd_imageIndicator = SDWebImageProgressIndicator.defaultIndicator;
-    [self.imageView1 sd_setImageWithURL:[NSURL URLWithString:@"http://s3.amazonaws.com/fast-image-cache/demo-images/FICDDemoImage001.jpg"]];
+    [self.imageView1 sd_setImageWithURL:[NSURL URLWithString:@"https://raw.githubusercontent.com/recurser/exif-orientation-examples/master/Landscape_2.jpg"] placeholderImage:nil options:SDWebImageProgressiveDownload];
     [self.imageView2 sd_setImageWithURL:[NSURL URLWithString:@"https:raw.githubusercontent.com/onevcat/APNGKit/master/TestImages/APNG-cube.apng"]];
     [self.imageView3 sd_setImageWithURL:[NSURL URLWithString:@"https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"]];
     self.imageView4.wantsLayer = YES;

--- a/SDWebImage/NSImage+Additions.h
+++ b/SDWebImage/NSImage+Additions.h
@@ -15,11 +15,11 @@
 @interface NSImage (Additions)
 
 /**
-The underlying Core Graphics image object. This will actually `CGImageForProposedRect` with the image size.
+The underlying Core Graphics image object. This will actually use `CGImageForProposedRect` with the image size.
  */
 @property (nonatomic, readonly, nullable) CGImageRef CGImage;
 /**
- The scale factor of the image. This wil actually use bitmap representation's size and pixel size to calculate the scale factor. If failed, use the default value 1.0. Should be greater than or equal to 1.0.
+ The scale factor of the image. This wil actually use `bestRepresentationForRect` with image size and pixel size to calculate the scale factor. If failed, use the default value 1.0. Should be greater than or equal to 1.0.
  */
 @property (nonatomic, readonly) CGFloat scale;
 
@@ -27,8 +27,8 @@ The underlying Core Graphics image object. This will actually `CGImageForPropose
 
 /**
  Returns an image object with the scale factor and orientation. The representation is created from the Core Graphics image object.
- @note The difference between this and `initWithCGImage:size` is that `initWithCGImage:size` will create a `NSCGImageSnapshotRep` but not `NSBitmapImageRep` instance. And it will always `backingScaleFactor` as scale factor.
- @note If the provided image orientation is not equal to Up orientation. This method will firstly rotate the CGImage to the correct orientation to work compatible with `NSImageView`.
+ @note The difference between this and `initWithCGImage:size` is that `initWithCGImage:size` will create a `NSCGImageSnapshotRep` but not `NSBitmapImageRep` instance. And it will always use `backingScaleFactor` as scale factor.
+ @note The difference between this and UIKit's `UIImage` equivalent method is the way to process orientation. If the provided image orientation is not equal to Up orientation, this method will firstly rotate the CGImage to the correct orientation to work compatible with `NSImageView`. However, UIKit will not actually rotate CGImage and just store it as `imageOrientation` property.
 
  @param cgImage A Core Graphics image object
  @param scale The image scale factor
@@ -39,7 +39,7 @@ The underlying Core Graphics image object. This will actually `CGImageForPropose
 
 /**
  Returns an image object with the scale factor. The representation is created from the image data.
- @note The difference between these this and `initWithData:` is that `initWithData:` will always `backingScaleFactor` as scale factor.
+ @note The difference between these this and `initWithData:` is that `initWithData:` will always use `backingScaleFactor` as scale factor.
 
  @param data The image data
  @param scale The image scale factor
@@ -52,8 +52,6 @@ The underlying Core Graphics image object. This will actually `CGImageForPropose
 @interface NSBitmapImageRep (Additions)
 
 // These methods' function is the same as `NSImage`'s function. For `NSBitmapImageRep`.
-
-@property (nonatomic, readonly) CGFloat scale;
 
 - (nonnull instancetype)initWithCGImage:(nonnull CGImageRef)cgImage scale:(CGFloat)scale orientation:(CGImagePropertyOrientation)orientation;
 - (nullable instancetype)initWithData:(nonnull NSData *)data scale:(CGFloat)scale;

--- a/SDWebImage/NSImage+Additions.h
+++ b/SDWebImage/NSImage+Additions.h
@@ -27,7 +27,7 @@ The underlying Core Graphics image object. This will actually use `CGImageForPro
 
 /**
  Returns an image object with the scale factor and orientation. The representation is created from the Core Graphics image object.
- @note The difference between this and `initWithCGImage:size` is that `initWithCGImage:size` will create a `NSCGImageSnapshotRep` but not `NSBitmapImageRep` instance. And it will always use `backingScaleFactor` as scale factor.
+ @note The difference between this and `initWithCGImage:size` is that `initWithCGImage:size` will use `backingScaleFactor` as scale factor if you specify `NSZeroSize` and does not support orientation.
  @note The difference between this and UIKit's `UIImage` equivalent method is the way to process orientation. If the provided image orientation is not equal to Up orientation, this method will firstly rotate the CGImage to the correct orientation to work compatible with `NSImageView`. However, UIKit will not actually rotate CGImage and just store it as `imageOrientation` property.
 
  @param cgImage A Core Graphics image object
@@ -45,15 +45,6 @@ The underlying Core Graphics image object. This will actually use `CGImageForPro
  @param scale The image scale factor
  @return The image object
  */
-- (nullable instancetype)initWithData:(nonnull NSData *)data scale:(CGFloat)scale;
-
-@end
-
-@interface NSBitmapImageRep (Additions)
-
-// These methods' function is the same as `NSImage`'s function. For `NSBitmapImageRep`.
-
-- (nonnull instancetype)initWithCGImage:(nonnull CGImageRef)cgImage scale:(CGFloat)scale orientation:(CGImagePropertyOrientation)orientation;
 - (nullable instancetype)initWithData:(nonnull NSData *)data scale:(CGFloat)scale;
 
 @end

--- a/SDWebImage/NSImage+Additions.h
+++ b/SDWebImage/NSImage+Additions.h
@@ -19,21 +19,23 @@ The underlying Core Graphics image object. This will actually `CGImageForPropose
  */
 @property (nonatomic, readonly, nullable) CGImageRef CGImage;
 /**
- The scale factor of the image. This wil actually use image size, and its `CGImage`'s pixel size to calculate the scale factor. Should be greater than or equal to 1.0.
+ The scale factor of the image. This wil actually use bitmap representation's size and pixel size to calculate the scale factor. If failed, use the default value 1.0. Should be greater than or equal to 1.0.
  */
 @property (nonatomic, readonly) CGFloat scale;
 
 // These are convenience methods to make AppKit's `NSImage` match UIKit's `UIImage` behavior. The scale factor should be greater than or equal to 1.0.
 
 /**
- Returns an image object with the scale factor. The representation is created from the Core Graphics image object.
+ Returns an image object with the scale factor and orientation. The representation is created from the Core Graphics image object.
  @note The difference between this and `initWithCGImage:size` is that `initWithCGImage:size` will create a `NSCGImageSnapshotRep` but not `NSBitmapImageRep` instance. And it will always `backingScaleFactor` as scale factor.
+ @note If the provided image orientation is not equal to Up orientation. This method will firstly rotate the CGImage to the correct orientation to work compatible with `NSImageView`.
 
  @param cgImage A Core Graphics image object
  @param scale The image scale factor
+ @param orientation The orientation of the image data
  @return The image object
  */
-- (nonnull instancetype)initWithCGImage:(nonnull CGImageRef)cgImage scale:(CGFloat)scale;
+- (nonnull instancetype)initWithCGImage:(nonnull CGImageRef)cgImage scale:(CGFloat)scale orientation:(CGImagePropertyOrientation)orientation;
 
 /**
  Returns an image object with the scale factor. The representation is created from the image data.
@@ -49,8 +51,11 @@ The underlying Core Graphics image object. This will actually `CGImageForPropose
 
 @interface NSBitmapImageRep (Additions)
 
-// These method's function is the same as `NSImage`'s function. For `NSBitmapImageRep`.
-- (nonnull instancetype)initWithCGImage:(nonnull CGImageRef)cgImage scale:(CGFloat)scale;
+// These methods' function is the same as `NSImage`'s function. For `NSBitmapImageRep`.
+
+@property (nonatomic, readonly) CGFloat scale;
+
+- (nonnull instancetype)initWithCGImage:(nonnull CGImageRef)cgImage scale:(CGFloat)scale orientation:(CGImagePropertyOrientation)orientation;
 - (nullable instancetype)initWithData:(nonnull NSData *)data scale:(CGFloat)scale;
 
 @end

--- a/SDWebImage/SDAnimatedImage.m
+++ b/SDWebImage/SDAnimatedImage.m
@@ -310,7 +310,7 @@ static NSArray *SDBundlePreferredScales() {
         return nil;
     }
 #if SD_MAC
-    self = [super initWithCGImage:image.CGImage scale:scale];
+    self = [super initWithCGImage:image.CGImage scale:scale orientation:kCGImagePropertyOrientationUp];
 #else
     self = [super initWithCGImage:image.CGImage scale:scale orientation:image.imageOrientation];
 #endif

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -297,7 +297,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
                 if (!data && image) {
                     // If we do not have any data to detect image format, check whether it contains alpha channel to use PNG or JPEG format
                     SDImageFormat format;
-                    if ([SDWebImageCoderHelper imageRefContainsAlpha:image.CGImage]) {
+                    if ([SDWebImageCoderHelper CGImageContainsAlpha:image.CGImage]) {
                         format = SDImageFormatPNG;
                     } else {
                         format = SDImageFormatJPEG;

--- a/SDWebImage/SDWebImageAPNGCoder.m
+++ b/SDWebImage/SDWebImageAPNGCoder.m
@@ -299,8 +299,8 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
             }
 #if SD_UIKIT || SD_WATCH
             image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:UIImageOrientationUp];
-#elif SD_MAC
-            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale];
+#else
+            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:kCGImagePropertyOrientationUp];
 #endif
             CGImageRelease(partialImageRef);
         }
@@ -403,7 +403,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         CGImageRelease(imageRef);
     }
 #if SD_MAC
-    UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef scale:_scale];
+    UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef scale:_scale orientation:kCGImagePropertyOrientationUp];
 #else
     UIImage *image = [UIImage imageWithCGImage:newImageRef scale:_scale orientation:UIImageOrientationUp];
 #endif

--- a/SDWebImage/SDWebImageAPNGCoder.m
+++ b/SDWebImage/SDWebImageAPNGCoder.m
@@ -396,7 +396,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         return nil;
     }
     // Image/IO create CGImage does not decompressed, so we do this because this is called background queue, this can avoid main queue block when rendering(especially when one more imageViews use the same image instance)
-    CGImageRef newImageRef = [SDWebImageCoderHelper imageRefCreateDecoded:imageRef];
+    CGImageRef newImageRef = [SDWebImageCoderHelper CGImageCreateDecoded:imageRef];
     if (!newImageRef) {
         newImageRef = imageRef;
     } else {

--- a/SDWebImage/SDWebImageCoder.h
+++ b/SDWebImage/SDWebImageCoder.h
@@ -33,7 +33,7 @@ FOUNDATION_EXPORT SDWebImageCoderOption _Nonnull const SDWebImageCoderDecodeScal
  */
 FOUNDATION_EXPORT SDWebImageCoderOption _Nonnull const SDWebImageCoderEncodeFirstFrameOnly;
 /**
- A double value between 0.0-1.0 indicating the encode compression quality to produce the image data. If not provide, use 1.0. (NSNumber)
+ A double value between 0.0-1.0 indicating the encode compression quality to produce the image data. 1.0 resulting in no compression and 0.0 resulting in the maximum compression possible. If not provide, use 1.0. (NSNumber)
  @note works for `SDWebImageCoder`
  */
 FOUNDATION_EXPORT SDWebImageCoderOption _Nonnull const SDWebImageCoderEncodeCompressionQuality;

--- a/SDWebImage/SDWebImageCoderHelper.h
+++ b/SDWebImage/SDWebImageCoderHelper.h
@@ -59,7 +59,7 @@
 + (BOOL)imageRefContainsAlpha:(_Nonnull CGImageRef)imageRef;
 
 /**
- Create a decoded image by the provided image. This follows The Create Rule and you are response to call release after usage.
+ Create a decoded CGImage by the provided CGImage. This follows The Create Rule and you are response to call release after usage.
  It will detect whether image contains alpha channel, then create a new bitmap context with the same size of image, and draw it. This can ensure that the image do not need extra decoding after been set to the imageView.
  @note This actually call `imageRefCreateDecoded:orientation` with the Up orientation.
 
@@ -69,7 +69,7 @@
 + (CGImageRef _Nullable)imageRefCreateDecoded:(_Nonnull CGImageRef)imageRef CF_RETURNS_RETAINED;
 
 /**
- Create a decoded image by the provided image. This follows The Create Rule and you are response to call release after usage.
+ Create a decoded CGImage by the provided CGImage and orientation. This follows The Create Rule and you are response to call release after usage.
  It will detect whether image contains alpha channel, then create a new bitmap context with the same size of image, and draw it. This can ensure that the image do not need extra decoding after been set to the imageView.
  
  @param imageRef The CGImage

--- a/SDWebImage/SDWebImageCoderHelper.h
+++ b/SDWebImage/SDWebImageCoderHelper.h
@@ -61,11 +61,22 @@
 /**
  Create a decoded image by the provided image. This follows The Create Rule and you are response to call release after usage.
  It will detect whether image contains alpha channel, then create a new bitmap context with the same size of image, and draw it. This can ensure that the image do not need extra decoding after been set to the imageView.
+ @note This actually call `imageRefCreateDecoded:orientation` with the Up orientation.
 
  @param imageRef The CGImage
  @return A new created decoded image
  */
 + (CGImageRef _Nullable)imageRefCreateDecoded:(_Nonnull CGImageRef)imageRef CF_RETURNS_RETAINED;
+
+/**
+ Create a decoded image by the provided image. This follows The Create Rule and you are response to call release after usage.
+ It will detect whether image contains alpha channel, then create a new bitmap context with the same size of image, and draw it. This can ensure that the image do not need extra decoding after been set to the imageView.
+ 
+ @param imageRef The CGImage
+ @param orientation The image orientation.
+ @return A new created decoded image
+ */
++ (CGImageRef _Nullable)imageRefCreateDecoded:(_Nonnull CGImageRef)imageRef orientation:(CGImagePropertyOrientation)orientation CF_RETURNS_RETAINED;
 
 /**
  Return the decoded image by the provided image. This one unlike `imageRefCreateDecoded:`, will not decode the image which contains alpha channel or animated image

--- a/SDWebImage/SDWebImageCoderHelper.h
+++ b/SDWebImage/SDWebImageCoderHelper.h
@@ -33,7 +33,7 @@
 + (NSArray<SDWebImageFrame *> * _Nullable)framesFromAnimatedImage:(UIImage * _Nullable)animatedImage NS_SWIFT_NAME(frames(from:));
 
 /**
- Return the shared device-dependent RGB color space.
+ Return the shared device-dependent RGB color space. This follows The Get Rule.
  On iOS, it's created with deviceRGB (if available, use sRGB).
  On macOS, it's from the screen colorspace (if failed, use deviceRGB)
  Because it's shared, you should not retain or release this object.
@@ -43,43 +43,35 @@
 + (CGColorSpaceRef _Nonnull)colorSpaceGetDeviceRGB CF_RETURNS_NOT_RETAINED;
 
 /**
- Retuen the color space of the CGImage
-
- @param imageRef The CGImage
- @return The color space of CGImage, or if not supported, return the device-dependent RGB color space
- */
-+ (CGColorSpaceRef _Nonnull)imageRefGetColorSpace:(_Nonnull CGImageRef)imageRef CF_RETURNS_NOT_RETAINED;
-
-/**
  Check whether CGImage contains alpha channel.
  
- @param imageRef The CGImage
+ @param cgImage The CGImage
  @return Return YES if CGImage contains alpha channel, otherwise return NO
  */
-+ (BOOL)imageRefContainsAlpha:(_Nonnull CGImageRef)imageRef;
++ (BOOL)CGImageContainsAlpha:(_Nonnull CGImageRef)cgImage;
 
 /**
  Create a decoded CGImage by the provided CGImage. This follows The Create Rule and you are response to call release after usage.
  It will detect whether image contains alpha channel, then create a new bitmap context with the same size of image, and draw it. This can ensure that the image do not need extra decoding after been set to the imageView.
- @note This actually call `imageRefCreateDecoded:orientation` with the Up orientation.
+ @note This actually call `CGImageCreateDecoded:orientation:` with the Up orientation.
 
- @param imageRef The CGImage
+ @param cgImage The CGImage
  @return A new created decoded image
  */
-+ (CGImageRef _Nullable)imageRefCreateDecoded:(_Nonnull CGImageRef)imageRef CF_RETURNS_RETAINED;
++ (CGImageRef _Nullable)CGImageCreateDecoded:(_Nonnull CGImageRef)cgImage CF_RETURNS_RETAINED;
 
 /**
  Create a decoded CGImage by the provided CGImage and orientation. This follows The Create Rule and you are response to call release after usage.
  It will detect whether image contains alpha channel, then create a new bitmap context with the same size of image, and draw it. This can ensure that the image do not need extra decoding after been set to the imageView.
  
- @param imageRef The CGImage
- @param orientation The image orientation.
+ @param cgImage The CGImage
+ @param orientation The EXIF image orientation.
  @return A new created decoded image
  */
-+ (CGImageRef _Nullable)imageRefCreateDecoded:(_Nonnull CGImageRef)imageRef orientation:(CGImagePropertyOrientation)orientation CF_RETURNS_RETAINED;
++ (CGImageRef _Nullable)CGImageCreateDecoded:(_Nonnull CGImageRef)cgImage orientation:(CGImagePropertyOrientation)orientation CF_RETURNS_RETAINED;
 
 /**
- Return the decoded image by the provided image. This one unlike `imageRefCreateDecoded:`, will not decode the image which contains alpha channel or animated image
+ Return the decoded image by the provided image. This one unlike `CGImageCreateDecoded:`, will not decode the image which contains alpha channel or animated image
  @param image The image to be decoded
  @return The decoded image
  */

--- a/SDWebImage/SDWebImageCoderHelper.m
+++ b/SDWebImage/SDWebImageCoderHelper.m
@@ -236,29 +236,29 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     return colorspaceRef;
 }
 
-+ (BOOL)imageRefContainsAlpha:(CGImageRef)imageRef {
-    if (!imageRef) {
++ (BOOL)CGImageContainsAlpha:(CGImageRef)cgImage {
+    if (!cgImage) {
         return NO;
     }
-    CGImageAlphaInfo alphaInfo = CGImageGetAlphaInfo(imageRef);
+    CGImageAlphaInfo alphaInfo = CGImageGetAlphaInfo(cgImage);
     BOOL hasAlpha = !(alphaInfo == kCGImageAlphaNone ||
                       alphaInfo == kCGImageAlphaNoneSkipFirst ||
                       alphaInfo == kCGImageAlphaNoneSkipLast);
     return hasAlpha;
 }
 
-+ (CGImageRef)imageRefCreateDecoded:(CGImageRef)imageRef {
-    return [self imageRefCreateDecoded:imageRef orientation:kCGImagePropertyOrientationUp];
++ (CGImageRef)CGImageCreateDecoded:(CGImageRef)cgImage {
+    return [self CGImageCreateDecoded:cgImage orientation:kCGImagePropertyOrientationUp];
 }
 
-+ (CGImageRef)imageRefCreateDecoded:(CGImageRef)imageRef orientation:(CGImagePropertyOrientation)orientation {
-    if (!imageRef) {
++ (CGImageRef)CGImageCreateDecoded:(CGImageRef)cgImage orientation:(CGImagePropertyOrientation)orientation {
+    if (!cgImage) {
         return NULL;
     }
-    size_t width = CGImageGetWidth(imageRef);
-    size_t height = CGImageGetHeight(imageRef);
+    size_t width = CGImageGetWidth(cgImage);
+    size_t height = CGImageGetHeight(cgImage);
     if (width == 0 || height == 0) return NULL;
-    BOOL hasAlpha = [self imageRefContainsAlpha:imageRef];
+    BOOL hasAlpha = [self CGImageContainsAlpha:cgImage];
     // iOS prefer BGRA8888 (premultiplied) or BGRX8888 bitmapInfo for screen rendering, which is same as `UIGraphicsBeginImageContext()` or `- [CALayer drawInContext:]`
     // Through you can use any supported bitmapInfo (see: https://developer.apple.com/library/content/documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/dq_context/dq_context.html#//apple_ref/doc/uid/TP30001066-CH203-BCIBHHBB ) and let Core Graphics reorder it when you call `CGContextDrawImage`
     // But since our build-in coders use this bitmapInfo, this can have a little performance benefit
@@ -287,7 +287,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
             break;
     }
     CGContextConcatCTM(context, transform);
-    CGContextDrawImage(context, rect, imageRef);
+    CGContextDrawImage(context, rect, cgImage);
     CGImageRef newImageRef = CGBitmapContextCreateImage(context);
     CGContextRelease(context);
     
@@ -302,7 +302,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         return image;
     }
     
-    CGImageRef imageRef = [self imageRefCreateDecoded:image.CGImage];
+    CGImageRef imageRef = [self CGImageCreateDecoded:image.CGImage];
     if (!imageRef) {
         return image;
     }
@@ -529,7 +529,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         return NO;
     }
     CGImageRef imageRef = image.CGImage;
-    BOOL hasAlpha = [self imageRefContainsAlpha:imageRef];
+    BOOL hasAlpha = [self CGImageContainsAlpha:imageRef];
     // do not decode images with alpha
     if (hasAlpha) {
         return NO;
@@ -570,7 +570,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 }
 #endif
 
-static CGAffineTransform SDCGContextTransformFromOrientation(CGImagePropertyOrientation orientation, CGSize size) {
+static inline CGAffineTransform SDCGContextTransformFromOrientation(CGImagePropertyOrientation orientation, CGSize size) {
     // Inspiration from @libfeihu
     // We need to calculate the proper transformation to make the image upright.
     // We do it in 2 steps: Rotate if Left/Right/Down, and then flip if Mirrored.

--- a/SDWebImage/SDWebImageCoderHelper.m
+++ b/SDWebImage/SDWebImageCoderHelper.m
@@ -183,7 +183,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
             // NSBitmapImageRep need to manually change frame. "Good taste" API
             [bitmapImageRep setProperty:NSImageCurrentFrame withValue:@(i)];
             float frameDuration = [[bitmapImageRep valueForProperty:NSImageCurrentFrameDuration] floatValue];
-            NSImage *frameImage = [[NSImage alloc] initWithCGImage:bitmapImageRep.CGImage scale:scale];
+            NSImage *frameImage = [[NSImage alloc] initWithCGImage:bitmapImageRep.CGImage scale:scale orientation:kCGImagePropertyOrientationUp];
             SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:frameImage duration:frameDuration];
             [frames addObject:frame];
         }

--- a/SDWebImage/SDWebImageDefine.m
+++ b/SDWebImage/SDWebImageDefine.m
@@ -106,7 +106,7 @@ inline UIImage * _Nullable SDScaledImageForScaleFactor(CGFloat scale, UIImage * 
 #if SD_UIKIT || SD_WATCH
         scaledImage = [[UIImage alloc] initWithCGImage:image.CGImage scale:scale orientation:image.imageOrientation];
 #else
-        scaledImage = [[NSImage alloc] initWithCGImage:image.CGImage scale:scale];
+        scaledImage = [[UIImage alloc] initWithCGImage:image.CGImage scale:scale orientation:kCGImagePropertyOrientationUp];
 #endif
     }
     scaledImage.sd_isIncremental = image.sd_isIncremental;

--- a/SDWebImage/SDWebImageGIFCoder.m
+++ b/SDWebImage/SDWebImageGIFCoder.m
@@ -236,8 +236,8 @@
             }
 #if SD_UIKIT || SD_WATCH
             image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:UIImageOrientationUp];
-#elif SD_MAC
-            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale];
+#else
+            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:kCGImagePropertyOrientationUp];
 #endif
             CGImageRelease(partialImageRef);
         }
@@ -395,7 +395,7 @@
         CGImageRelease(imageRef);
     }
 #if SD_MAC
-    UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef scale:_scale];
+    UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef scale:_scale orientation:kCGImagePropertyOrientationUp];
 #else
     UIImage *image = [[UIImage alloc] initWithCGImage:newImageRef scale:_scale orientation:UIImageOrientationUp];
 #endif

--- a/SDWebImage/SDWebImageGIFCoder.m
+++ b/SDWebImage/SDWebImageGIFCoder.m
@@ -388,7 +388,7 @@
         return nil;
     }
     // Image/IO create CGImage does not decode, so we do this because this is called background queue, this can avoid main queue block when rendering(especially when one more imageViews use the same image instance)
-    CGImageRef newImageRef = [SDWebImageCoderHelper imageRefCreateDecoded:imageRef];
+    CGImageRef newImageRef = [SDWebImageCoderHelper CGImageCreateDecoded:imageRef];
     if (!newImageRef) {
         newImageRef = imageRef;
     } else {

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -90,20 +90,7 @@
     }
     
     UIImage *image = [[UIImage alloc] initWithData:data scale:scale];
-#if SD_MAC
     return image;
-#else
-    if (!image) {
-        return nil;
-    }
-    
-    UIImageOrientation orientation = [[self class] sd_imageOrientationFromImageData:data];
-    if (orientation != UIImageOrientationUp) {
-        image = [[UIImage alloc] initWithCGImage:image.CGImage scale:image.scale orientation:orientation];
-    }
-    
-    return image;
-#endif
 }
 
 #pragma mark - Progressive Decode
@@ -313,28 +300,5 @@
     });
     return canEncode;
 }
-
-#if SD_UIKIT || SD_WATCH
-#pragma mark EXIF orientation tag converter
-+ (UIImageOrientation)sd_imageOrientationFromImageData:(nonnull NSData *)imageData {
-    UIImageOrientation result = UIImageOrientationUp;
-    CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
-    if (imageSource) {
-        CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
-        if (properties) {
-            CFTypeRef val;
-            NSInteger exifOrientation;
-            val = CFDictionaryGetValue(properties, kCGImagePropertyOrientation);
-            if (val) {
-                CFNumberGetValue(val, kCFNumberNSIntegerType, &exifOrientation);
-                result = [SDWebImageCoderHelper imageOrientationFromEXIFOrientation:(CGImagePropertyOrientation)exifOrientation];
-            } // else - if it's not set it remains at up
-            CFRelease((CFTypeRef) properties);
-        }
-        CFRelease(imageSource);
-    }
-    return result;
-}
-#endif
 
 @end

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -211,7 +211,7 @@
     }
     
     if (format == SDImageFormatUndefined) {
-        BOOL hasAlpha = [SDWebImageCoderHelper imageRefContainsAlpha:image.CGImage];
+        BOOL hasAlpha = [SDWebImageCoderHelper CGImageContainsAlpha:image.CGImage];
         if (hasAlpha) {
             format = SDImageFormatPNG;
         } else {

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -16,6 +16,8 @@
     size_t _width, _height;
 #if SD_UIKIT || SD_WATCH
     UIImageOrientation _orientation;
+#else
+    CGImagePropertyOrientation _orientation;
 #endif
     CGImageSourceRef _imageSource;
     NSUInteger _frameCount;
@@ -136,6 +138,8 @@
             // in didCompleteWithError.) So save it here and pass it on later.
 #if SD_UIKIT || SD_WATCH
             _orientation = [SDWebImageCoderHelper imageOrientationFromEXIFOrientation:(CGImagePropertyOrientation)orientationValue];
+#else
+            _orientation = (CGImagePropertyOrientation)orientationValue;
 #endif
         }
     }
@@ -177,8 +181,8 @@
             }
 #if SD_UIKIT || SD_WATCH
             image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:_orientation];
-#elif SD_MAC
-            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale];
+#else
+            image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:_orientation];
 #endif
             CGImageRelease(partialImageRef);
         }
@@ -227,9 +231,11 @@
     
     NSMutableDictionary *properties = [NSMutableDictionary dictionary];
 #if SD_UIKIT || SD_WATCH
-    NSInteger exifOrientation = [SDWebImageCoderHelper exifOrientationFromImageOrientation:image.imageOrientation];
-    [properties setValue:@(exifOrientation) forKey:(__bridge_transfer NSString *)kCGImagePropertyOrientation];
+    CGImagePropertyOrientation exifOrientation = [SDWebImageCoderHelper exifOrientationFromImageOrientation:image.imageOrientation];
+#else
+    CGImagePropertyOrientation exifOrientation = kCGImagePropertyOrientationUp;
 #endif
+    [properties setValue:@(exifOrientation) forKey:(__bridge_transfer NSString *)kCGImagePropertyOrientation];
     double compressionQuality = 1;
     if ([options valueForKey:SDWebImageCoderEncodeCompressionQuality]) {
         compressionQuality = [[options valueForKey:SDWebImageCoderEncodeCompressionQuality] doubleValue];

--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -131,7 +131,7 @@ dispatch_semaphore_signal(self->_lock);
 #if SD_UIKIT || SD_WATCH
         UIImage *staticImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
 #else
-        UIImage *staticImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale];
+        UIImage *staticImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:kCGImagePropertyOrientationUp];
 #endif
         CGImageRelease(imageRef);
         WebPDemuxDelete(demuxer);
@@ -153,7 +153,7 @@ dispatch_semaphore_signal(self->_lock);
 #if SD_UIKIT || SD_WATCH
         UIImage *firstFrameImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
 #else
-        UIImage *firstFrameImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale];
+        UIImage *firstFrameImage = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:kCGImagePropertyOrientationUp];
 #endif
         CGImageRelease(imageRef);
         WebPDemuxReleaseIterator(&iter);
@@ -184,7 +184,7 @@ dispatch_semaphore_signal(self->_lock);
 #if SD_UIKIT || SD_WATCH
             UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
 #else
-            UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale];
+            UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:kCGImagePropertyOrientationUp];
 #endif
             CGImageRelease(imageRef);
             
@@ -289,7 +289,7 @@ dispatch_semaphore_signal(self->_lock);
 #if SD_UIKIT || SD_WATCH
         image = [[UIImage alloc] initWithCGImage:newImageRef scale:scale orientation:UIImageOrientationUp];
 #else
-        image = [[UIImage alloc] initWithCGImage:newImageRef scale:scale];
+        image = [[UIImage alloc] initWithCGImage:newImageRef scale:scale orientation:kCGImagePropertyOrientationUp];
 #endif
         CGImageRelease(newImageRef);
         CGContextRelease(canvas);
@@ -680,7 +680,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
 #if SD_UIKIT || SD_WATCH
         image = [[UIImage alloc] initWithCGImage:imageRef scale:_scale orientation:UIImageOrientationUp];
 #else
-        image = [[UIImage alloc] initWithCGImage:imageRef scale:_scale];
+        image = [[UIImage alloc] initWithCGImage:imageRef scale:_scale orientation:kCGImagePropertyOrientationUp];
 #endif
         CGImageRelease(imageRef);
     } else {
@@ -710,7 +710,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
 #if SD_UIKIT || SD_WATCH
                     image = [[UIImage alloc] initWithCGImage:imageRef scale:_scale orientation:UIImageOrientationUp];
 #else
-                    image = [[UIImage alloc] initWithCGImage:imageRef scale:_scale];
+                    image = [[UIImage alloc] initWithCGImage:imageRef scale:_scale orientation:kCGImagePropertyOrientationUp];
 #endif
                     CGImageRelease(imageRef);
                 }

--- a/SDWebImage/UIImage+Transform.m
+++ b/SDWebImage/UIImage+Transform.m
@@ -90,7 +90,7 @@ static UIImage * SDGraphicsGetImageFromCurrentImageContext(void) {
         // Protect if x/y axis scale factor not equal
         scale = [NSScreen mainScreen].backingScaleFactor;
     }
-    NSImage *image = [[NSImage alloc] initWithCGImage:imageRef scale:scale];
+    NSImage *image = [[NSImage alloc] initWithCGImage:imageRef scale:scale orientation:kCGImagePropertyOrientationUp];
     CGImageRelease(imageRef);
     return image;
 #endif
@@ -322,7 +322,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 #if SD_UIKIT || SD_WATCH
     UIImage *image = [UIImage imageWithCGImage:imageRef scale:self.scale orientation:self.imageOrientation];
 #else
-    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:self.scale];
+    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:self.scale orientation:kCGImagePropertyOrientationUp];
 #endif
     CGImageRelease(imageRef);
     return image;
@@ -400,7 +400,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 #if SD_UIKIT || SD_WATCH
     UIImage *img = [UIImage imageWithCGImage:imgRef scale:self.scale orientation:self.imageOrientation];
 #else
-    UIImage *img = [[UIImage alloc] initWithCGImage:imgRef scale:self.scale];
+    UIImage *img = [[UIImage alloc] initWithCGImage:imgRef scale:self.scale orientation:kCGImagePropertyOrientationUp];
 #endif
     CGImageRelease(imgRef);
     CGContextRelease(context);
@@ -436,7 +436,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 #if SD_UIKIT || SD_WATCH
     UIImage *img = [UIImage imageWithCGImage:imgRef scale:self.scale orientation:self.imageOrientation];
 #else
-    UIImage *img = [[UIImage alloc] initWithCGImage:imgRef scale:self.scale];
+    UIImage *img = [[UIImage alloc] initWithCGImage:imgRef scale:self.scale orientation:kCGImagePropertyOrientationUp];
 #endif
     CGImageRelease(imgRef);
     return img;
@@ -453,7 +453,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 #if SD_UIKIT || SD_WATCH
         return [UIImage imageWithCGImage:self.CGImage scale:self.scale orientation:self.imageOrientation];
 #else
-        return [[UIImage alloc] initWithCGImage:self.CGImage scale:self.scale];
+        return [[UIImage alloc] initWithCGImage:self.CGImage scale:self.scale orientation:kCGImagePropertyOrientationUp];
 #endif
     }
     
@@ -670,7 +670,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 #if SD_UIKIT || SD_WATCH
     UIImage *outputImage = [UIImage imageWithCGImage:effectCGImage scale:self.scale orientation:self.imageOrientation];
 #else
-    UIImage *outputImage = [[UIImage alloc] initWithCGImage:effectCGImage scale:self.scale];
+    UIImage *outputImage = [[UIImage alloc] initWithCGImage:effectCGImage scale:self.scale orientation:kCGImagePropertyOrientationUp];
 #endif
     CGImageRelease(effectCGImage);
     
@@ -695,7 +695,7 @@ static inline UIColor * SDGetColorFromPixel(Pixel_8888 pixel, CGBitmapInfo bitma
 #if SD_UIKIT
     UIImage *image = [UIImage imageWithCGImage:imageRef scale:self.scale orientation:self.imageOrientation];
 #else
-    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:self.scale];
+    UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:self.scale orientation:kCGImagePropertyOrientationUp];
 #endif
     CGImageRelease(imageRef);
     

--- a/Tests/Tests/SDWebImageDecoderTests.m
+++ b/Tests/Tests/SDWebImageDecoderTests.m
@@ -87,20 +87,6 @@
     expect(decodedImage.size.width).to.equal(image.size.width);
     expect(decodedImage.size.height).to.equal(image.size.height);
 }
-
-- (void)test08ImageOrientationFromImageDataWithInvalidData {
-    // sync download image
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-    SEL selector = @selector(sd_imageOrientationFromImageData:);
-#pragma clang diagnostic pop
-    
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    UIImageOrientation orientation = (UIImageOrientation)[[SDWebImageImageIOCoder class] performSelector:selector withObject:nil];
-#pragma clang diagnostic pop
-    expect(orientation).to.equal(UIImageOrientationUp);
-}
 #endif
 
 - (void)test09ThatStaticWebPCoderWorks {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: See #316 

### Pull Request Description

`UIImage`'s initialize method `-[UIImage initWithData:scale:]` can handle EXIF orientation correctly. It does not work on earily iOS version. But after testing, it should works for above iOS 8.

And also, `NSImage`'s `-[NSImage initWithData:]` or its category method creating by our own `-[NSImage initWithData:scale]` works for EXIF orientationi as well. So we can put these logic together.