### PR TITLE
Fix that force decode not works for alpha-channel images.

### DIFF
--- a/Tests/Tests/SDWebImageDecoderTests.m
+++ b/Tests/Tests/SDWebImageDecoderTests.m
@@ -43,12 +43,12 @@
     expect(decodedImage).to.equal(animatedImage);
 }
 
-- (void)test04ThatDecodedImageWithImageDoesNotDecodeImagesWithAlpha {
+- (void)test04ThatDecodedImageWithImageWorksWithAlphaImages {
     NSString * testImagePath = [[NSBundle bundleForClass:[self class]] pathForResource:@"TestImage" ofType:@"png"];
     UIImage *image = [UIImage imageWithContentsOfFile:testImagePath];
     UIImage *decodedImage = [UIImage decodedImageWithImage:image];
     expect(decodedImage).toNot.beNil();
-    expect(decodedImage).to.equal(image);
+    expect(decodedImage).toNot.equal(image);
 }
 
 - (void)test05ThatDecodedImageWithImageWorksEvenWithMonochromeImage {


### PR DESCRIPTION
This should only exclude animated images. All other images should use the display alpha info based on whether contains alpha or not to force decode

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: 4cfb12c01cef5e4f45aa1215d38afcbb2381b594

### Pull Request Description

It seems there is a bug in implementation for our `force decode` method. Which will be used if you prefer `shouldDecompressImages` to ON and let we do background decoding before seting image to imageView to enhance performance.

I guess this may be a mistake to exclude alpha-channel image to be force decode. Because this PR contains some knowledge about bitmap alpha info. I can describe it for people who are not familiar with it.

First, what is bitmap alpha info is the order for `R, G, B, A` pixels vector layout. (Each of it is a `uint8`, represent 0-255 value. The pixels vector is just a `uint8` array). So if we say `ARGB8888`, it means the pixels vector may looks like `A R G B A R G B ...`

Second, from Apple's [documentation](https://developer.apple.com/library/content/documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/dq_context/dq_context.html#//apple_ref/doc/uid/TP30001066-CH203-BCIBHHBB) and experience. iOS prefer to use `BGRA8888` for alpha-based context, `BGRX8888` for non-alpha context. This is the same bitmap alpha as the current bitmap context when `-[UIView drawRect:]` called, or the convenience method `UIGraphicsGetCurrentContext`

But, when we want to force decode a CGImage from outside. We can not directlly use `CGImageGetAlphaInfo` because some of alpha info is not support by iOS and will cause `CGBitmapContext` return NULL. However, we can use "whether this CGImage contains alpha" this rule, to choose to use `BGRA8888` or `BGRX8888` to create a context, finally draw it. This can solve problem and let force decode works for all non-animated image.

This code can be check from other image framework as well. See [YYImage](https://github.com/ibireme/YYWebImage/blob/master/YYWebImage/Image/YYImageCoder.m#L874-L893), it's works and well-practiced.