### PR TITLE
Refactor cache - Cache Path API

### DIFF
--- a/Examples/SDWebImage Demo/AppDelegate.m
+++ b/Examples/SDWebImage Demo/AppDelegate.m
@@ -21,7 +21,10 @@
 {
     //Add a custom read-only cache path
     NSString *bundledPath = [[NSBundle mainBundle].resourcePath stringByAppendingPathComponent:@"CustomPathImages"];
-    [[SDImageCache sharedImageCache] addReadOnlyCachePath:bundledPath];
+    [SDImageCache sharedImageCache].additionalCachePathBlock = ^NSString * _Nullable(NSString * _Nonnull key) {
+        NSString *fileName = [[SDImageCache sharedImageCache] cachePathForKey:key].lastPathComponent;
+        return [bundledPath stringByAppendingPathComponent:fileName.stringByDeletingPathExtension];
+    };
 
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     // Override point for customization after application launch.

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -58,6 +58,8 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 
 typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable error);
 
+typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * _Nonnull key);
+
 /**
  * SDImageCache maintains a memory cache and an optional disk cache. Disk cache write operations are performed
  * asynchronous so it doesn’t add unnecessary latency to the UI.
@@ -70,6 +72,18 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  *  Cache Config object - storing all kind of settings
  */
 @property (nonatomic, nonnull, readonly) SDImageCacheConfig *config;
+
+/**
+ *  The disk cache's root path
+ */
+@property (nonatomic, copy, nonnull, readonly) NSString *diskCachePath;
+
+/**
+ *  The additional disk cache path to check if the query from disk cache not exist;
+ *  The `key` param is the image cache key. The returned file path will be used to load the disk cache. If return nil, ignore it.
+ *  Useful if you want to bundle pre-loaded images with your app
+ */
+@property (nonatomic, copy, nullable) SDImageCacheAdditionalCachePathBlock additionalCachePathBlock;
 
 #pragma mark - Singleton and initialization
 
@@ -107,15 +121,13 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
 
 #pragma mark - Cache paths
 
-- (nullable NSString *)makeDiskCachePath:(nonnull NSString*)fullNamespace;
-
 /**
- * Add a read-only cache path to search for images pre-cached by SDImageCache
- * Useful if you want to bundle pre-loaded images with your app
- *
- * @param path The path to use for this read-only cache path
+ Get the cache path for a certain key
+ 
+ @param key The unique image cache key
+ @return The cache path. You can check `lastPathComponent` to grab the file name.
  */
-- (void)addReadOnlyCachePath:(nonnull NSString *)path;
+- (nullable NSString *)cachePathForKey:(nullable NSString *)key;
 
 #pragma mark - Store Ops
 
@@ -298,26 +310,5 @@ typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable er
  * Asynchronously calculate the disk cache's size.
  */
 - (void)calculateSizeWithCompletionBlock:(nullable SDWebImageCalculateSizeBlock)completionBlock;
-
-#pragma mark - Cache Paths
-
-/**
- *  Get the cache path for a certain key (needs the cache path root folder)
- *
- *  @param key  the key (can be obtained from url using cacheKeyForURL)
- *  @param path the cache path root folder
- *
- *  @return the cache path
- */
-- (nullable NSString *)cachePathForKey:(nullable NSString *)key inPath:(nonnull NSString *)path;
-
-/**
- *  Get the default cache path for a certain key
- *
- *  @param key the key (can be obtained from url using cacheKeyForURL)
- *
- *  @return the default cache path
- */
-- (nullable NSString *)defaultCachePathForKey:(nullable NSString *)key;
 
 @end

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -195,13 +195,13 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)test31DefaultCachePathForAnyKey{
-    NSString *path = [[SDImageCache sharedImageCache] defaultCachePathForKey:kImageTestKey];
+- (void)test31CachePathForAnyKey{
+    NSString *path = [[SDImageCache sharedImageCache] cachePathForKey:kImageTestKey];
     expect(path).toNot.beNil;
 }
 
-- (void)test32CachePathForNonExistingKey{
-    NSString *path = [[SDImageCache sharedImageCache] cachePathForKey:kImageTestKey inPath:[[SDImageCache sharedImageCache] defaultCachePathForKey:kImageTestKey]];
+- (void)test32CachePathForNilKey{
+    NSString *path = [[SDImageCache sharedImageCache] cachePathForKey:nil];
     expect(path).to.beNil;
 }
 
@@ -209,7 +209,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     XCTestExpectation *expectation = [self expectationWithDescription:@"cachePathForKey inPath"];
     [[SDImageCache sharedImageCache] storeImage:[self imageForTesting] forKey:kImageTestKey completion:^(NSError * _Nullable error) {
         expect(error).to.beNil();
-        NSString *path = [[SDImageCache sharedImageCache] cachePathForKey:kImageTestKey inPath:[[SDImageCache sharedImageCache] defaultCachePathForKey:kImageTestKey]];
+        NSString *path = [[SDImageCache sharedImageCache] cachePathForKey:kImageTestKey];
         expect(path).notTo.beNil;
         [[SDImageCache sharedImageCache] removeImageForKey:kImageTestKey withCompletion:^{
             [expectation fulfill];
@@ -219,14 +219,14 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
 }
 
 - (void)test34CachePathForSimpleKeyWithExtension {
-    NSString *cachePath = [[SDImageCache sharedImageCache] cachePathForKey:kTestJpegURL inPath:@""];
+    NSString *cachePath = [[SDImageCache sharedImageCache] cachePathForKey:kTestJpegURL];
     expect(cachePath).toNot.beNil();
     expect([cachePath pathExtension]).to.equal(@"jpg");
 }
 
 - (void)test35CachePathForKeyWithDotButNoExtension {
     NSString *urlString = @"https://maps.googleapis.com/maps/api/staticmap?center=48.8566,2.3522&format=png&maptype=roadmap&scale=2&size=375x200&zoom=15";
-    NSString *cachePath = [[SDImageCache sharedImageCache] cachePathForKey:urlString inPath:@""];
+    NSString *cachePath = [[SDImageCache sharedImageCache] cachePathForKey:urlString];
     expect(cachePath).toNot.beNil();
     expect([cachePath pathExtension]).to.equal(@"");
 }
@@ -242,7 +242,7 @@ NSString *kImageTestKey = @"TestImageKey.jpg";
     UIImage *storedImageFromMemory = [[SDImageCache sharedImageCache] imageFromMemoryCacheForKey:kImageTestKey];
     expect(storedImageFromMemory).to.equal(nil);
     
-    NSString *cachePath = [[SDImageCache sharedImageCache] defaultCachePathForKey:kImageTestKey];
+    NSString *cachePath = [[SDImageCache sharedImageCache] cachePathForKey:kImageTestKey];
     UIImage *cachedImage = [[UIImage alloc] initWithContentsOfFile:cachePath];
     NSData *storedImageData = UIImageJPEGRepresentation(cachedImage, 1.0);
     expect(storedImageData.length).to.beGreaterThan(0);


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1355 

### Pull Request Description

This PR is original from #2195, which seems to be a seperate part for cache refactory. So I seperate it to this one.

#### Cache Paths API
Some of current API like cache paths is really counter-intuitive. If I want to get the cache file name, I have to call `[SDImageCache sharedImageCache] cachePathForKey:"image.jpg" inPath:@""]`, really suck. It's looks like a internal API but should not publish to user.

Why cause this it's may because of the historic issue that we introduce one feature to let user customize the read only cache path. So we need to know both the folder and cache file name after MD5 hash. However, this should be refactor using a more common design.

### Design

#### Cache Paths API
And if we have custom disk cache. Current cache paths API may become a problem because we should not put something like `cachePathForKey:inPath` to the protocol. It's more like a internal tool function and it let user to provide a arbitrary parent directory. Which may confuse the user to need to write the custom disk cache.
So I think, for cache paths API. We just need to keep the one `cachePathForKey:`. Which can return the full file path for the cached data. It's simple and enough. For example, If you need the file name, just using NSString's API `lastPathComponent `.

For that current API of `addReadOnlyCachePath:`, which is used to allow custom cache path if the disk cache missed. This design may works, but not good at all. User have to add  a list of string and have no choice to rename their bundle resource to the hash function we used. This's is a little frustrating. What if user do not want to rename the images with MD5 hash and just want to use the cache? This problem can also trigger issue if thier custom disk cache's hash function is not the same as the built-in one(We use MD5, but not all user use).

To solve this is really simple, we provide a block to allow custom remapping from the key to the cache path. User can return the actual file path for the key after the query failed. And it's also allow custom disk cache work with this feature.

### Implementation

#### Cache Paths API

We use a custom block to allow user provide the cache path if query failed.

```objective-c
typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * _Nullable key);
/**
 *  The additional disk cache path to check if the query from disk cache not exist;
 *  The `key` param is the image cache key. You should return the specify file path to load image from disk. You can use built-in hash method(See `cacheFileNameForKey:` in SDDiskCache) or your own way to provide mapping between cache key and file path.
 *  Useful if you want to bundle pre-loaded images with your app
 */
@property (nonatomic, copy, nullable) SDImageCacheAdditionalCachePathBlock additionalCachePathBlock;
```
