### PR TITLE
Revert "Merge pull request #1898 from walkline/master into 5.x"

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -56,8 +56,6 @@ typedef void(^SDWebImageCheckCacheCompletionBlock)(BOOL isInCache);
 
 typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger totalSize);
 
-typedef void(^SDWebImageCompletionWithPossibleErrorBlock)(NSError * _Nullable error);
-
 typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * _Nonnull key);
 
 /**
@@ -140,7 +138,7 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
  */
 - (void)storeImage:(nullable UIImage *)image
             forKey:(nullable NSString *)key
-        completion:(nullable SDWebImageCompletionWithPossibleErrorBlock)completionBlock;
+        completion:(nullable SDWebImageNoParamsBlock)completionBlock;
 
 /**
  * Asynchronously store an image into memory and disk cache at the given key.
@@ -153,7 +151,7 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
 - (void)storeImage:(nullable UIImage *)image
             forKey:(nullable NSString *)key
             toDisk:(BOOL)toDisk
-        completion:(nullable SDWebImageCompletionWithPossibleErrorBlock)completionBlock;
+        completion:(nullable SDWebImageNoParamsBlock)completionBlock;
 
 /**
  * Asynchronously store an image into memory and disk cache at the given key.
@@ -170,18 +168,16 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
          imageData:(nullable NSData *)imageData
             forKey:(nullable NSString *)key
             toDisk:(BOOL)toDisk
-        completion:(nullable SDWebImageCompletionWithPossibleErrorBlock)completionBlock;
+        completion:(nullable SDWebImageNoParamsBlock)completionBlock;
 
 /**
  * Synchronously store image NSData into disk cache at the given key.
  *
  * @param imageData  The image data to store
  * @param key        The unique image cache key, usually it's image absolute URL
- * @param error      NSError pointer, for possible file I/O errors, See FoundationErrors.h
  */
-- (BOOL)storeImageDataToDisk:(nullable NSData *)imageData
-                      forKey:(nullable NSString *)key
-                       error:(NSError * _Nullable * _Nullable)error;
+- (void)storeImageDataToDisk:(nullable NSData *)imageData
+                      forKey:(nullable NSString *)key;
 
 
 #pragma mark - Query and Retrieve Ops

--- a/Tests/Tests/SDMockFileManager.h
+++ b/Tests/Tests/SDMockFileManager.h
@@ -11,6 +11,8 @@
 // This is a mock class to provide custom error for methods
 @interface SDMockFileManager : NSFileManager
 
+@property (nonatomic, strong, readonly, nullable) NSError *lastError;
+
 @property (nonatomic, copy, nullable) NSDictionary<NSString *, NSError *> *mockSelectors; // used to specify mocked selectors which will return NO with specify error instead of normal process. If you specify a NSNull, will use nil instead.
 
 @end

--- a/Tests/Tests/SDMockFileManager.m
+++ b/Tests/Tests/SDMockFileManager.m
@@ -10,11 +10,14 @@
 
 @interface SDMockFileManager ()
 
+@property (nonatomic, strong, nullable) NSError *lastError;
+
 @end
 
 @implementation SDMockFileManager
 
 - (BOOL)createDirectoryAtPath:(NSString *)path withIntermediateDirectories:(BOOL)createIntermediates attributes:(NSDictionary<NSFileAttributeKey,id> *)attributes error:(NSError * _Nullable __autoreleasing *)error {
+    self.lastError = nil;
     NSError *mockError = [self.mockSelectors objectForKey:NSStringFromSelector(_cmd)];
     if ([mockError isEqual:[NSNull null]]) {
         if (error) {
@@ -25,6 +28,7 @@
         if (error) {
             *error = mockError;
         }
+        self.lastError = mockError;
         return NO;
     } else {
         return [super createDirectoryAtPath:path withIntermediateDirectories:createIntermediates attributes:attributes error:error];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1898 

### Pull Request Description

The reason to revert the PR is list in #2195 . `SDImageCache` is a image memory-disk cache. However, memory cache does not contains `error` and this is really rare for most of people.

We introduce a more abstract solution for advanced user who need this information. Just subclass to use disk cache with your `errorHandler`, then grab the error information when you need from that.

However, this just rever the `NSError` pointer, the `NSFileManager` feature will be kept, but with the more abstract `config` property instead. See more in #2195 