### PR TITLE
Use `SDWebImageAvoidDecodeImage` to allow user to control force decode feature for individual image request

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -41,13 +41,18 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
      */
     SDImageCacheTransformAnimatedImage = 1 << 2,
     /**
+     * By default, we will decode the image in the background during cache query and download from the network. This can help to improve performance because when rendering image on the screen, it need to be firstly decoded. But this happen on the main queue by Core Animation.
+     * However, this process may increase the memory usage as well. If you are experiencing a issue due to excessive memory consumption, This flag can prevent decode the image.
+     */
+    SDImageCacheAvoidDecodeImage = 1 << 3,
+    /**
      * By default, we decode the animated image. This flag can force decode the first frame only and produece the static image.
      */
-    SDImageCacheDecodeFirstFrameOnly = 1 << 3,
+    SDImageCacheDecodeFirstFrameOnly = 1 << 4,
     /**
      * By default, for `SDAnimatedImage`, we decode the animated image frame during rendering to reduce memory usage. This flag actually trigger `preloadAllAnimatedImageFrames = YES` after image load from disk cache
      */
-    SDImageCachePreloadAllFrames = 1 << 4
+    SDImageCachePreloadAllFrames = 1 << 5
 };
 
 typedef void(^SDCacheQueryCompletedBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -473,7 +473,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         if (!image) {
             image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:data options:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageCoderDecodeScaleFactor : @(scale)}];
         }
-        BOOL shouldDecode = YES;
+        BOOL shouldDecode = (options & SDImageCacheAvoidDecodeImage) == 0;
         if ([image conformsToProtocol:@protocol(SDAnimatedImage)]) {
             // `SDAnimatedImage` do not decode
             shouldDecode = NO;
@@ -482,9 +482,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
             shouldDecode = NO;
         }
         if (shouldDecode) {
-            if (self.config.shouldDecompressImages) {
-                image = [SDWebImageCoderHelper decodedImageWithImage:image];
-            }
+            image = [SDWebImageCoderHelper decodedImageWithImage:image];
         }
         return image;
     } else {

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -12,12 +12,6 @@
 @interface SDImageCacheConfig : NSObject
 
 /**
- * Decompressing images means pre-decoding the image that are downloaded and cached on background queue. This can avoid image view decode it on main queue when rendering. This can improve performance but can consume more memory.
- * Defaults to YES. Set this to NO if you are experiencing a crash due to excessive memory consumption.
- */
-@property (assign, nonatomic) BOOL shouldDecompressImages;
-
-/**
  * Whether or not to disable iCloud backup
  * Defaults to YES.
  */

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -14,7 +14,6 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
 
 - (instancetype)init {
     if (self = [super init]) {
-        _shouldDecompressImages = YES;
         _shouldDisableiCloud = YES;
         _shouldCacheImagesInMemory = YES;
         _diskCacheReadingOptions = 0;

--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -128,7 +128,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     /**
      * By default, images are decoded respecting their original size. On iOS, this flag will scale down the
      * images to a size compatible with the constrained memory of devices.
-     * If `SDWebImageProgressiveDownload` flag is set the scale down is deactivated.
+     * This flag take no effect if `SDWebImageAvoidDecodeImage` is set. And it will be ignored if `SDWebImageProgressiveDownload` is set.
      */
     SDWebImageScaleDownLargeImages = 1 << 12,
     
@@ -153,6 +153,12 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * By default, when you use `SDWebImageTransition` to do some view transition after the image load finished, this transition is only applied for image download from the network. This mask can force to apply view transition for memory and disk cache as well.
      */
     SDWebImageForceTransition = 1 << 16,
+    
+    /**
+     * By default, we will decode the image in the background during cache query and download from the network. This can help to improve performance because when rendering image on the screen, it need to be firstly decoded. But this happen on the main queue by Core Animation.
+     * However, this process may increase the memory usage as well. If you are experiencing a issue due to excessive memory consumption, This flag can prevent decode the image.
+     */
+    SDWebImageAvoidDecodeImage = 1 << 17,
     
     /**
      * By default, we decode the animated image. This flag can force decode the first frame only and produece the static image.

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -60,19 +60,27 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     SDWebImageDownloaderHighPriority = 1 << 7,
     
     /**
-     * Scale down the image
+     * By default, images are decoded respecting their original size. On iOS, this flag will scale down the
+     * images to a size compatible with the constrained memory of devices.
+     * This flag take no effect if `SDWebImageDownloaderAvoidDecodeImage` is set. And it will be ignored if `SDWebImageDownloaderProgressiveDownload` is set.
      */
     SDWebImageDownloaderScaleDownLargeImages = 1 << 8,
     
     /**
+     * By default, we will decode the image in the background during cache query and download from the network. This can help to improve performance because when rendering image on the screen, it need to be firstly decoded. But this happen on the main queue by Core Animation.
+     * However, this process may increase the memory usage as well. If you are experiencing a issue due to excessive memory consumption, This flag can prevent decode the image.
+     */
+    SDWebImageDownloaderAvoidDecodeImage = 1 << 9,
+    
+    /**
      * By default, we decode the animated image. This flag can force decode the first frame only and produece the static image.
      */
-    SDWebImageDownloaderDecodeFirstFrameOnly = 1 << 9,
+    SDWebImageDownloaderDecodeFirstFrameOnly = 1 << 10,
     
     /**
      * By default, for `SDAnimatedImage`, we decode the animated image frame during rendering to reduce memory usage. This flag actually trigger `preloadAllAnimatedImageFrames = YES` after image load from network
      */
-    SDWebImageDownloaderPreloadAllFrames = 1 << 10
+    SDWebImageDownloaderPreloadAllFrames = 1 << 11
 };
 
 FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadStartNotification;

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -198,7 +198,6 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
             operationClass = [SDWebImageDownloaderOperation class];
         }
         NSOperation<SDWebImageDownloaderOperation> *operation = [[operationClass alloc] initWithRequest:request inSession:sself.session options:options context:context];
-        operation.shouldDecompressImages = sself.config.shouldDecompressImages;
         
         if (sself.config.urlCredential) {
             operation.credential = sself.config.urlCredential;

--- a/SDWebImage/SDWebImageDownloaderConfig.h
+++ b/SDWebImage/SDWebImageDownloaderConfig.h
@@ -31,12 +31,6 @@ typedef NS_ENUM(NSInteger, SDWebImageDownloaderExecutionOrder) {
 @property (nonatomic, class, nonnull) SDWebImageDownloaderConfig *defaultDownloaderConfig;
 
 /**
- * Decompressing images that are downloaded and cached can improve performance but can consume lot of memory.
- * Defaults to YES. Set this to NO if you are experiencing a crash due to excessive memory consumption.
- */
-@property (nonatomic, assign) BOOL shouldDecompressImages;
-
-/**
  * The maximum number of concurrent downloads.
  * Defaults to 6.
  */

--- a/SDWebImage/SDWebImageDownloaderConfig.m
+++ b/SDWebImage/SDWebImageDownloaderConfig.m
@@ -29,7 +29,6 @@ static SDWebImageDownloaderConfig * _defaultDownloaderConfig;
 - (instancetype)init {
     self = [super init];
     if (self) {
-        _shouldDecompressImages = YES;
         _maxConcurrentDownloads = 6;
         _downloadTimeout = 15.0;
         _executionOrder = SDWebImageDownloaderFIFOExecutionOrder;
@@ -39,7 +38,6 @@ static SDWebImageDownloaderConfig * _defaultDownloaderConfig;
 
 - (id)copyWithZone:(NSZone *)zone {
     SDWebImageDownloaderConfig *config = [[[self class] allocWithZone:zone] init];
-    config.shouldDecompressImages = self.shouldDecompressImages;
     config.maxConcurrentDownloads = self.maxConcurrentDownloads;
     config.downloadTimeout = self.downloadTimeout;
     config.sessionConfiguration = [self.sessionConfiguration copyWithZone:zone];

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -36,9 +36,6 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 - (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                             completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock;
 
-- (BOOL)shouldDecompressImages;
-- (void)setShouldDecompressImages:(BOOL)value;
-
 - (nullable NSURLCredential *)credential;
 - (void)setCredential:(nullable NSURLCredential *)value;
 
@@ -69,12 +66,6 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
  * The operation's task
  */
 @property (strong, nonatomic, readonly, nullable) NSURLSessionTask *dataTask;
-
-/**
- * Decompressing images that are downloaded and cached can improve performance but can consume lot of memory.
- * Defaults to YES. Set this to NO if you are experiencing a crash due to excessive memory consumption.
- */
-@property (assign, nonatomic) BOOL shouldDecompressImages;
 
 /**
  * The credential used for authentication challenges in `-URLSession:task:didReceiveChallenge:completionHandler:`.

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -87,7 +87,6 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
                                 context:(nullable SDWebImageContext *)context {
     if ((self = [super init])) {
         _request = [request copy];
-        _shouldDecompressImages = YES;
         _options = options;
         _context = [context copy];
         _callbackBlocks = [NSMutableArray new];
@@ -379,7 +378,7 @@ didReceiveResponse:(NSURLResponse *)response
                 image = [self.progressiveCoder incrementalDecodedImageWithOptions:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageCoderDecodeScaleFactor : @(scale)}];
             }
             if (image) {
-                BOOL shouldDecode = self.shouldDecompressImages;
+                BOOL shouldDecode = (self.options & SDWebImageDownloaderAvoidDecodeImage) == 0;
                 if ([image conformsToProtocol:@protocol(SDAnimatedImage)]) {
                     // `SDAnimatedImage` do not decode
                     shouldDecode = NO;
@@ -479,7 +478,7 @@ didReceiveResponse:(NSURLResponse *)response
                             image = [[SDWebImageCodersManager sharedManager] decodedImageWithData:imageData options:@{SDWebImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDWebImageCoderDecodeScaleFactor : @(scale)}];
                         }
                         
-                        BOOL shouldDecode = self.shouldDecompressImages;
+                        BOOL shouldDecode = (self.options & SDWebImageDownloaderAvoidDecodeImage) == 0;
                         if ([image conformsToProtocol:@protocol(SDAnimatedImage)]) {
                             // `SDAnimatedImage` do not decode
                             shouldDecode = NO;

--- a/SDWebImage/UIImage+ForceDecode.h
+++ b/SDWebImage/UIImage+ForceDecode.h
@@ -16,27 +16,27 @@
 @property (nonatomic, assign) BOOL sd_isDecoded;
 
 /**
- Decompress (force decode before rendering) the provided image
+ Decode the provided image. This is useful if you want to force decode the image before rendering to improve performance.
 
- @param image The image to be decompressed
- @return The decompressed image
+ @param image The image to be decoded
+ @return The decoded image
  */
 + (nullable UIImage *)sd_decodedImageWithImage:(nullable UIImage *)image;
 
 /**
- Decompress and scale down the provided image
+ Decode and scale down the provided image
 
- @param image The image to be decompressed
- @return The decompressed and scaled down image
+ @param image The image to be decoded
+ @return The decoded and scaled down image
  */
 + (nullable UIImage *)sd_decodedAndScaledDownImageWithImage:(nullable UIImage *)image;
 
 /**
- Decompress and scale down the provided image and limit bytes
+ Decode and scale down the provided image with limit bytes
  
- @param image The image to be decompressed
+ @param image The image to be decoded
  @param bytes The limit bytes size. Provide 0 to use the build-in limit.
- @return The decompressed and scaled down image
+ @return The decoded and scaled down image
  */
 + (nullable UIImage *)sd_decodedAndScaledDownImageWithImage:(nullable UIImage *)image limitBytes:(NSUInteger)bytes;
 

--- a/Tests/Tests/SDWebImageTestDownloadOperation.h
+++ b/Tests/Tests/SDWebImageTestDownloadOperation.h
@@ -15,7 +15,6 @@
  */
 @interface SDWebImageTestDownloadOperation : NSOperation <SDWebImageDownloaderOperation>
 
-@property (nonatomic, assign) BOOL shouldDecompressImages;
 @property (nonatomic, strong, nullable) NSURLCredential *credential;
 @property (nonatomic, strong, nullable) NSURLRequest *request;
 @property (nonatomic, strong, nullable) NSURLResponse *response;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1927

### Pull Request Description

### Reason

This is about that `decompressImages` feature. We all know that what `decompressImages` will do. It actually call `sd_decodedImageWithImage:` in the background, to draw the image from Image/IO on the bitmap context, this can help to force decode the image. Then when we set this `UIImage` on the `UIImageView`, it does not cause any lag or blocking on the main queue to wait for `Core Animation` firstly decode it.

This options is good for performance, and it seems that most of application use this well. However, due to the force decode process, this will consume more memory, especially for huge images. It's a trade-off between Time & Space.

In previous SDWebImage, we have a option to enable/disable this feature. We have these:

+ `SDImageCache`: `SDImageCache.config.shouldDecompressImages`
+ `SDWebImageDownloader`: `SDWebImageDownloader.shouldDecompressImages`
+ `SDWebImageDownloadOperation`: `SDWebImageDownloadOperation.shouldDecompressImages`

But however, they are both central control. Which means if I disable on in shared downloader, or shared cache, this will effect all the image request for this. In most cases, we do not want this. Because if user want to set this option for individual image request, they have no way to do this, except create another `SDImageCache` and `SDWebImageDownloader` instance, which is really heavy on usage and cause many problem when syncing for shared cache/downloader.

From the real world application experience by our company(Such as Tik Tok), most images are small enough (less than 1000x1000), the force decode process can help to increase nearly 4-5 frame rates on common `UITableView` or `UIScrollView`. It's quite rare we need turn it off, unless some huge images which consume much memory.

So, we'd better move that option, into `SDWebImageOptions` level, to allow we control it for each image request from `sd_setImageWithURL:`

### Design

From the description above, we should treat `force decode` **ON** as the default value. And this options can be used both in `manager`, `cache`, `downloader`. So we just put it in the `SDWebImageOptions`. Naming it `SDWebImageAvoidDecodeImage` to specify that you can avoid this force decode feature.

There are also the correspond options for `SDImageCacheOptions` and `SDWebImageDownloaderOptions`, keep it the same name as usual.

### Implementation

```objective-c
/**
 * By default, we will decode the image in the background during cache query and download from the network. This can help to improve performance because when rendering image on the screen, it need to be firstly decoded. But this happen on the main queue by Core Animation.
 * However, this process may increase the memory usage as well. If you are experiencing a issue due to excessive memory consumption, This flag can prevent decode the image.
 */
SDWebImageAvoidDecodeImage = 1 << 17
```