### PR TITLE
Fix the default download config & cache config to readonly

### DIFF
--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -13,11 +13,10 @@
 @interface SDImageCacheConfig : NSObject <NSCopying>
 
 /**
- Gets/Sets the default cache config used for shared instance or initialization when it does not provide any cache config. Such as `SDImageCache.sharedImageCache`.
+ Gets the default cache config used for shared instance or initialization when it does not provide any cache config. Such as `SDImageCache.sharedImageCache`.
  @note You can modify the property on default cache config, which can be used for later created cache instance. The already created cache instance does not get affected.
- @note You should not pass nil to this value.
  */
-@property (nonatomic, class, nonnull) SDImageCacheConfig *defaultCacheConfig;
+@property (nonatomic, class, readonly, nonnull) SDImageCacheConfig *defaultCacheConfig;
 
 /**
  * Whether or not to disable iCloud backup

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -23,12 +23,6 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
     return _defaultCacheConfig;
 }
 
-+ (void)setDefaultCacheConfig:(SDImageCacheConfig *)defaultCacheConfig {
-    if (defaultCacheConfig) {
-        _defaultCacheConfig = defaultCacheConfig;
-    }
-}
-
 - (instancetype)init {
     if (self = [super init]) {
         _shouldDisableiCloud = YES;

--- a/SDWebImage/SDWebImageDownloaderConfig.h
+++ b/SDWebImage/SDWebImageDownloaderConfig.h
@@ -24,11 +24,10 @@ typedef NS_ENUM(NSInteger, SDWebImageDownloaderExecutionOrder) {
 @interface SDWebImageDownloaderConfig : NSObject <NSCopying>
 
 /**
- Gets/Sets the default downloader config used for shared instance or initialization when it does not provide any downloader config. Such as `SDWebImageDownloader.sharedDownloader`.
+ Gets the default downloader config used for shared instance or initialization when it does not provide any downloader config. Such as `SDWebImageDownloader.sharedDownloader`.
  @note You can modify the property on default downloader config, which can be used for later created downloader instance. The already created downloader instance does not get affected.
- @note You should not pass nil to this value.
  */
-@property (nonatomic, class, nonnull) SDWebImageDownloaderConfig *defaultDownloaderConfig;
+@property (nonatomic, class, readonly, nonnull) SDWebImageDownloaderConfig *defaultDownloaderConfig;
 
 /**
  * The maximum number of concurrent downloads.

--- a/SDWebImage/SDWebImageDownloaderConfig.m
+++ b/SDWebImage/SDWebImageDownloaderConfig.m
@@ -20,12 +20,6 @@ static SDWebImageDownloaderConfig * _defaultDownloaderConfig;
     return _defaultDownloaderConfig;
 }
 
-+ (void)setDefaultDownloaderConfig:(SDWebImageDownloaderConfig *)defaultDownloaderConfig {
-    if (defaultDownloaderConfig) {
-        _defaultDownloaderConfig = defaultDownloaderConfig;
-    }
-}
-
 - (instancetype)init {
     self = [super init];
     if (self) {


### PR DESCRIPTION
You can modify the property of config, but not the override the default config instance itself.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2282 

### Pull Request Description

@bpoplauschi Maybe this is the more suitable design for config instance.

The `default config` one is readonly, which use a `dispatch_once` to create its initial value. You can only modify the property on `config` level.

The downloader & cache instance's `config` property is using `copy`. Which will keep the already created instance not accidentally get effected by later config changes to the `default config`. It's the common design like NSURLSession.