### PR TITLE
Refactor error code

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -39,6 +39,18 @@
 		00733A731BC4880E00A5A117 /* SDWebImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4A2CAE031AB4BB5400B6BC39 /* SDWebImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		320224BB203979BA00E9F285 /* SDAnimatedImageRep.h in Headers */ = {isa = PBXBuildFile; fileRef = 320224B9203979BA00E9F285 /* SDAnimatedImageRep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		320224BC203979BA00E9F285 /* SDAnimatedImageRep.m in Sources */ = {isa = PBXBuildFile; fileRef = 320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */; };
+		320CAE152086F50500CFFC80 /* SDWebImageError.h in Headers */ = {isa = PBXBuildFile; fileRef = 320CAE132086F50500CFFC80 /* SDWebImageError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		320CAE162086F50500CFFC80 /* SDWebImageError.h in Headers */ = {isa = PBXBuildFile; fileRef = 320CAE132086F50500CFFC80 /* SDWebImageError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		320CAE172086F50500CFFC80 /* SDWebImageError.h in Headers */ = {isa = PBXBuildFile; fileRef = 320CAE132086F50500CFFC80 /* SDWebImageError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		320CAE182086F50500CFFC80 /* SDWebImageError.h in Headers */ = {isa = PBXBuildFile; fileRef = 320CAE132086F50500CFFC80 /* SDWebImageError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		320CAE192086F50500CFFC80 /* SDWebImageError.h in Headers */ = {isa = PBXBuildFile; fileRef = 320CAE132086F50500CFFC80 /* SDWebImageError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		320CAE1A2086F50500CFFC80 /* SDWebImageError.h in Headers */ = {isa = PBXBuildFile; fileRef = 320CAE132086F50500CFFC80 /* SDWebImageError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		320CAE1B2086F50500CFFC80 /* SDWebImageError.m in Sources */ = {isa = PBXBuildFile; fileRef = 320CAE142086F50500CFFC80 /* SDWebImageError.m */; };
+		320CAE1C2086F50500CFFC80 /* SDWebImageError.m in Sources */ = {isa = PBXBuildFile; fileRef = 320CAE142086F50500CFFC80 /* SDWebImageError.m */; };
+		320CAE1D2086F50500CFFC80 /* SDWebImageError.m in Sources */ = {isa = PBXBuildFile; fileRef = 320CAE142086F50500CFFC80 /* SDWebImageError.m */; };
+		320CAE1E2086F50500CFFC80 /* SDWebImageError.m in Sources */ = {isa = PBXBuildFile; fileRef = 320CAE142086F50500CFFC80 /* SDWebImageError.m */; };
+		320CAE1F2086F50500CFFC80 /* SDWebImageError.m in Sources */ = {isa = PBXBuildFile; fileRef = 320CAE142086F50500CFFC80 /* SDWebImageError.m */; };
+		320CAE202086F50500CFFC80 /* SDWebImageError.m in Sources */ = {isa = PBXBuildFile; fileRef = 320CAE142086F50500CFFC80 /* SDWebImageError.m */; };
 		321DB3612011D4D70015D2CB /* NSButton+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 321DB35F2011D4D60015D2CB /* NSButton+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		321DB3622011D4D70015D2CB /* NSButton+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 321DB3602011D4D60015D2CB /* NSButton+WebCache.m */; };
 		321E60861F38E8C800405457 /* SDWebImageCoder.h in Headers */ = {isa = PBXBuildFile; fileRef = 321E60841F38E8C800405457 /* SDWebImageCoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1481,6 +1493,8 @@
 		00733A4C1BC487C000A5A117 /* SDWebImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		320224B9203979BA00E9F285 /* SDAnimatedImageRep.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDAnimatedImageRep.h; sourceTree = "<group>"; };
 		320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDAnimatedImageRep.m; sourceTree = "<group>"; };
+		320CAE132086F50500CFFC80 /* SDWebImageError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageError.h; sourceTree = "<group>"; };
+		320CAE142086F50500CFFC80 /* SDWebImageError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageError.m; sourceTree = "<group>"; };
 		321DB35F2011D4D60015D2CB /* NSButton+WebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSButton+WebCache.h"; path = "SDWebImage/NSButton+WebCache.h"; sourceTree = "<group>"; };
 		321DB3602011D4D60015D2CB /* NSButton+WebCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSButton+WebCache.m"; path = "SDWebImage/NSButton+WebCache.m"; sourceTree = "<group>"; };
 		321E60841F38E8C800405457 /* SDWebImageCoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDWebImageCoder.h; sourceTree = "<group>"; };
@@ -2100,6 +2114,8 @@
 			children = (
 				53922D88148C56230056699D /* SDWebImageCompat.h */,
 				5340674F167780C40042B59E /* SDWebImageCompat.m */,
+				320CAE132086F50500CFFC80 /* SDWebImageError.h */,
+				320CAE142086F50500CFFC80 /* SDWebImageError.m */,
 				530E49E71646388E002868E7 /* SDWebImageOperation.h */,
 				324DF4B2200A14DC008A84CC /* SDWebImageDefine.h */,
 				324DF4B3200A14DC008A84CC /* SDWebImageDefine.m */,
@@ -2320,6 +2336,7 @@
 				431739591CDFC8B70008FEB9 /* mux.h in Headers */,
 				00733A6C1BC4880E00A5A117 /* UIButton+WebCache.h in Headers */,
 				80377DB01F2F66A700F89830 /* common_sse2.h in Headers */,
+				320CAE182086F50500CFFC80 /* SDWebImageError.h in Headers */,
 				80377DDB1F2F66A700F89830 /* msa_macro.h in Headers */,
 				4317395B1CDFC8B70008FEB9 /* types.h in Headers */,
 				80377C531F2F666300F89830 /* huffman_utils.h in Headers */,
@@ -2416,6 +2433,7 @@
 				4314D1701D0E0E3B004B36C9 /* mux.h in Headers */,
 				321E60871F38E8C800405457 /* SDWebImageCoder.h in Headers */,
 				80377EA21F2F66D400F89830 /* vp8i_dec.h in Headers */,
+				320CAE162086F50500CFFC80 /* SDWebImageError.h in Headers */,
 				3248476A201775F600AF9E5A /* SDAnimatedImageView.h in Headers */,
 				321E60951F38E8ED00405457 /* SDWebImageImageIOCoder.h in Headers */,
 				80377C211F2F666300F89830 /* quant_levels_dec_utils.h in Headers */,
@@ -2545,6 +2563,7 @@
 				43A62A1E1D0E0A800089D7DD /* format_constants.h in Headers */,
 				80377E111F2F66A800F89830 /* lossless_common.h in Headers */,
 				431BB6F61D06D2C1006A3455 /* UIImage+MultiFormat.h in Headers */,
+				320CAE192086F50500CFFC80 /* SDWebImageError.h in Headers */,
 				32F21B5520788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.h in Headers */,
 				807A122C1F89636300EC2A9B /* SDWebImageCodersManager.h in Headers */,
 				323F8BFA1F38EF770092B609 /* animi.h in Headers */,
@@ -2599,6 +2618,7 @@
 				4397D2CB1D0DDD8C00BB2784 /* UIImageView+HighlightedWebCache.h in Headers */,
 				4397D2CC1D0DDD8C00BB2784 /* mux.h in Headers */,
 				80377C911F2F666400F89830 /* thread_utils.h in Headers */,
+				320CAE1A2086F50500CFFC80 /* SDWebImageError.h in Headers */,
 				4397D2D01D0DDD8C00BB2784 /* SDWebImageDownloaderOperation.h in Headers */,
 				4397D2D11D0DDD8C00BB2784 /* decode.h in Headers */,
 				80377E481F2F66A800F89830 /* dsp.h in Headers */,
@@ -2695,6 +2715,7 @@
 				4A2CAE1F1AB4BB6C00B6BC39 /* SDImageCache.h in Headers */,
 				4A2CAE351AB4BB7500B6BC39 /* UIImageView+WebCache.h in Headers */,
 				80377D6B1F2F66A700F89830 /* common_sse2.h in Headers */,
+				320CAE172086F50500CFFC80 /* SDWebImageError.h in Headers */,
 				4A2CAE181AB4BB6400B6BC39 /* SDWebImageCompat.h in Headers */,
 				80377D961F2F66A700F89830 /* msa_macro.h in Headers */,
 				43CE75D11CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h in Headers */,
@@ -2826,6 +2847,7 @@
 				323F8B621F38EF770092B609 /* cost_enc.h in Headers */,
 				43CE75761CFE9427006C64D0 /* FLAnimatedImage.h in Headers */,
 				323F8BE41F38EF770092B609 /* vp8li_enc.h in Headers */,
+				320CAE152086F50500CFFC80 /* SDWebImageError.h in Headers */,
 				323F8B861F38EF770092B609 /* histogram_enc.h in Headers */,
 				323F8BF61F38EF770092B609 /* animi.h in Headers */,
 				321E60861F38E8C800405457 /* SDWebImageCoder.h in Headers */,
@@ -3090,6 +3112,7 @@
 				80377DC01F2F66A700F89830 /* enc_mips_dsp_r2.c in Sources */,
 				80377DA91F2F66A700F89830 /* alpha_processing_neon.c in Sources */,
 				43CE75D51CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.m in Sources */,
+				320CAE1E2086F50500CFFC80 /* SDWebImageError.m in Sources */,
 				80377DB71F2F66A700F89830 /* dec_mips_dsp_r2.c in Sources */,
 				80377DC31F2F66A700F89830 /* enc_neon.c in Sources */,
 				80377C501F2F666300F89830 /* huffman_encode_utils.c in Sources */,
@@ -3299,6 +3322,7 @@
 				80377D2A1F2F66A700F89830 /* cost.c in Sources */,
 				80377D411F2F66A700F89830 /* filters.c in Sources */,
 				80377D221F2F66A700F89830 /* alpha_processing.c in Sources */,
+				320CAE1C2086F50500CFFC80 /* SDWebImageError.m in Sources */,
 				80377D391F2F66A700F89830 /* enc_neon.c in Sources */,
 				80377D5B1F2F66A700F89830 /* upsampling_neon.c in Sources */,
 				80377D5F1F2F66A700F89830 /* yuv_mips32.c in Sources */,
@@ -3460,6 +3484,7 @@
 				80377DF91F2F66A800F89830 /* cost.c in Sources */,
 				80377E101F2F66A800F89830 /* filters.c in Sources */,
 				80377DF11F2F66A800F89830 /* alpha_processing.c in Sources */,
+				320CAE1F2086F50500CFFC80 /* SDWebImageError.m in Sources */,
 				80377E081F2F66A800F89830 /* enc_neon.c in Sources */,
 				80377E2A1F2F66A800F89830 /* upsampling_neon.c in Sources */,
 				80377E2E1F2F66A800F89830 /* yuv_mips32.c in Sources */,
@@ -3581,6 +3606,7 @@
 				328BB6CC2082581100760D6C /* SDDiskCache.m in Sources */,
 				323F8C0D1F38EF770092B609 /* muxedit.c in Sources */,
 				323F8B491F38EF770092B609 /* analysis_enc.c in Sources */,
+				320CAE202086F50500CFFC80 /* SDWebImageError.m in Sources */,
 				80377E6E1F2F66A800F89830 /* upsampling_msa.c in Sources */,
 				323F8B911F38EF770092B609 /* iterator_enc.c in Sources */,
 				3290FA0F1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
@@ -3740,6 +3766,7 @@
 				80377D641F2F66A700F89830 /* alpha_processing_neon.c in Sources */,
 				80377C361F2F666300F89830 /* huffman_encode_utils.c in Sources */,
 				80377D721F2F66A700F89830 /* dec_mips_dsp_r2.c in Sources */,
+				320CAE1D2086F50500CFFC80 /* SDWebImageError.m in Sources */,
 				80377D7E1F2F66A700F89830 /* enc_neon.c in Sources */,
 				4A2CAE321AB4BB7500B6BC39 /* UIImage+WebP.m in Sources */,
 				80377DA01F2F66A700F89830 /* upsampling_neon.c in Sources */,
@@ -3905,6 +3932,7 @@
 				80377CDA1F2F66A100F89830 /* alpha_processing_neon.c in Sources */,
 				80377C021F2F665300F89830 /* huffman_encode_utils.c in Sources */,
 				80377CE81F2F66A100F89830 /* dec_mips_dsp_r2.c in Sources */,
+				320CAE1B2086F50500CFFC80 /* SDWebImageError.m in Sources */,
 				80377CF41F2F66A100F89830 /* enc_neon.c in Sources */,
 				80377D161F2F66A100F89830 /* upsampling_neon.c in Sources */,
 				80377CDF1F2F66A100F89830 /* argb_sse2.c in Sources */,

--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -83,8 +83,6 @@
 #define NS_OPTIONS(_type, _name) enum _name : _type _name; enum _name : _type
 #endif
 
-FOUNDATION_EXPORT NSString *const _Nonnull SDWebImageErrorDomain;
-
 #ifndef dispatch_queue_async_safe
 #define dispatch_queue_async_safe(queue, block)\
     if (strcmp(dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL), dispatch_queue_get_label(queue)) == 0) {\

--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -15,5 +15,3 @@
 #if !OS_OBJECT_USE_OBJC
     #error SDWebImage need ARC for dispatch object
 #endif
-
-NSString *const SDWebImageErrorDomain = @"SDWebImageErrorDomain";

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -9,6 +9,7 @@
 #import "SDWebImageDownloader.h"
 #import "SDWebImageDownloaderConfig.h"
 #import "SDWebImageDownloaderOperation.h"
+#import "SDWebImageError.h"
 
 static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
 
@@ -244,7 +245,7 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
     // The URL will be used as the key to the callbacks dictionary so it cannot be nil. If it is nil immediately call the completed block with no image or data.
     if (url == nil) {
         if (completedBlock) {
-            NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Trying to download a nil url"}];
+            NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorInvalidURL userInfo:@{NSLocalizedDescriptionKey : @"Image url is nil"}];
             completedBlock(nil, nil, error, YES);
         }
         return nil;
@@ -257,7 +258,7 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
         if (!operation) {
             UNLOCK(self.operationsLock);
             if (completedBlock) {
-                NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Downloader operation is nil"}];
+                NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorInvalidDownloadOperation userInfo:@{NSLocalizedDescriptionKey : @"Downloader operation is nil"}];
                 completedBlock(nil, nil, error, YES);
             }
             return nil;

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -13,6 +13,7 @@
 #import "SDWebImageCodersManager.h"
 #import "SDWebImageCoderHelper.h"
 #import "SDAnimatedImage.h"
+#import "SDWebImageError.h"
 
 #define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
 #define UNLOCK(lock) dispatch_semaphore_signal(lock);
@@ -216,7 +217,7 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
             [[NSNotificationCenter defaultCenter] postNotificationName:SDWebImageDownloadStartNotification object:weakSelf];
         });
     } else {
-        [self callCompletionBlocksWithError:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUnknown userInfo:@{NSLocalizedDescriptionKey : @"Task can't be initialized"}]];
+        [self callCompletionBlocksWithError:[NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorInvalidDownloadOperation userInfo:@{NSLocalizedDescriptionKey : @"Task can't be initialized"}]];
         [self done];
         return;
     }

--- a/SDWebImage/SDWebImageError.h
+++ b/SDWebImage/SDWebImageError.h
@@ -1,0 +1,18 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ * (c) Jamie Pinkham
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDWebImageCompat.h"
+
+FOUNDATION_EXPORT NSErrorDomain const _Nonnull SDWebImageErrorDomain;
+
+typedef NS_ERROR_ENUM(SDWebImageErrorDomain, SDWebImageError) {
+    SDWebImageErrorInvalidURL = 1000, // The URL is invalid, such as nil URL or corrupted URL
+    SDWebImageErrorBadImageData = 1001, // The image data can not be decoded to image, or the image data is empty
+    SDWebImageErrorInvalidDownloadOperation = 2000, // The image download operation is invalid, such as nil operation or unexpected error occur when operation initialized
+};

--- a/SDWebImage/SDWebImageError.m
+++ b/SDWebImage/SDWebImageError.m
@@ -1,0 +1,12 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) Olivier Poitrey <rs@dailymotion.com>
+ * (c) Jamie Pinkham
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+#import "SDWebImageError.h"
+
+NSErrorDomain const _Nonnull SDWebImageErrorDomain = @"SDWebImageErrorDomain";

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -10,6 +10,7 @@
 #import "NSImage+Additions.h"
 #import "UIImage+WebCache.h"
 #import "SDAnimatedImage.h"
+#import "SDWebImageError.h"
 
 @interface SDWebImageCombinedOperation ()
 
@@ -146,7 +147,7 @@
     }
 
     if (url.absoluteString.length == 0 || (!(options & SDWebImageRetryFailed) && isFailedUrl)) {
-        [self callCompletionBlockForOperation:operation completion:completedBlock error:[NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorFileDoesNotExist userInfo:nil] url:url];
+        [self callCompletionBlockForOperation:operation completion:completedBlock error:[NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorInvalidURL userInfo:@{NSLocalizedDescriptionKey : @"Image url is nil"}] url:url];
         return operation;
     }
 

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -12,6 +12,7 @@
 
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
+#import "SDWebImageError.h"
 
 const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
 
@@ -178,7 +179,7 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
         [self sd_stopImageIndicator];
         dispatch_main_async_safe(^{
             if (completedBlock) {
-                NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:-1 userInfo:@{NSLocalizedDescriptionKey : @"Trying to load a nil url"}];
+                NSError *error = [NSError errorWithDomain:SDWebImageErrorDomain code:SDWebImageErrorInvalidURL userInfo:@{NSLocalizedDescriptionKey : @"Image url is nil"}];
                 completedBlock(nil, nil, error, SDImageCacheTypeNone, YES, url);
             }
         });

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -66,6 +66,7 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/UIImage+ForceDecode.h>
 #import <SDWebImage/NSData+ImageContentType.h>
 #import <SDWebImage/SDWebImageDefine.h>
+#import <SDWebImage/SDWebImageError.h>
 
 #if SD_MAC
     #import <SDWebImage/NSImage+Additions.h>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

###Reason

This is the re-orgnization of our `NSError` error code from our framework. Since there are many many error information, but at previous version we just through a arbitrary NSError, which the error code is not correct (Some different errors share the same error code -1, and some same error contains different error code 0...).

This will cause it hard to let developer find the actual reason of error. And it's hard to process something based on the error information (For example, If the url is nil, I want to use a extra log for this. But it's hard to seperate nil url error from others)


### Design

We can create a new files contains all the error information, use `NS_ERROR_ENUM` to provide a common error code, and it's also available in Swift as errorType.

### Implementation

```objective-c
FOUNDATION_EXPORT NSErrorDomain const _Nonnull SDWebImageErrorDomain;

typedef NS_ERROR_ENUM(SDWebImageErrorDomain, SDWebImageError) {
    SDWebImageErrorInvalidURL = 1000, // The URL is invalid, such as nil URL or corrupted URL
    SDWebImageErrorBadImageData = 1001, // The image data can not be decoded to image, or the image data is empty
    SDWebImageErrorInvalidDownloadOperation = 2000, // The image download operation is invalid, such as nil operation or unexpected error when operation initialized
};
```

The generated Swift API:

```swift
public let SDWebImageErrorDomain: String

public enum SDWebImageError.Code : Int {

    
    public typealias _ErrorType = SDWebImageError

    case invalidURL // The URL is invalid, such as nil URL or corrupted URL

    case badImageData // The image data can not be decoded to image, or the image data is empty

    case invalidDownloadOperation // The image download operation is invalid, such as nil operation or unexpected error when operation initialized
}
```
