### PR TITLE
Fix the custom cache protocol naming

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -508,18 +508,18 @@
 		32CF1C101FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
 		32CF1C111FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
 		32CF1C121FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
-		32D1221E2080B2EB003685A3 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D1221F2080B2EB003685A3 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D122202080B2EB003685A3 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D122212080B2EB003685A3 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D122222080B2EB003685A3 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D122232080B2EB003685A3 /* SDWebImageCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDWebImageCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D122242080B2EB003685A3 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDWebImageCache.m */; };
-		32D122252080B2EB003685A3 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDWebImageCache.m */; };
-		32D122262080B2EB003685A3 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDWebImageCache.m */; };
-		32D122272080B2EB003685A3 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDWebImageCache.m */; };
-		32D122282080B2EB003685A3 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDWebImageCache.m */; };
-		32D122292080B2EB003685A3 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDWebImageCache.m */; };
+		32D1221E2080B2EB003685A3 /* SDImageCacheDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D1221F2080B2EB003685A3 /* SDImageCacheDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D122202080B2EB003685A3 /* SDImageCacheDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D122212080B2EB003685A3 /* SDImageCacheDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D122222080B2EB003685A3 /* SDImageCacheDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D122232080B2EB003685A3 /* SDImageCacheDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D122242080B2EB003685A3 /* SDImageCacheDefine.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDImageCacheDefine.m */; };
+		32D122252080B2EB003685A3 /* SDImageCacheDefine.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDImageCacheDefine.m */; };
+		32D122262080B2EB003685A3 /* SDImageCacheDefine.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDImageCacheDefine.m */; };
+		32D122272080B2EB003685A3 /* SDImageCacheDefine.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDImageCacheDefine.m */; };
+		32D122282080B2EB003685A3 /* SDImageCacheDefine.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDImageCacheDefine.m */; };
+		32D122292080B2EB003685A3 /* SDImageCacheDefine.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDImageCacheDefine.m */; };
 		32D1222A2080B2EB003685A3 /* SDImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */; };
 		32D1222B2080B2EB003685A3 /* SDImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */; };
 		32D1222C2080B2EB003685A3 /* SDImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */; };
@@ -1596,8 +1596,8 @@
 		32C0FDE02013426C001B8F2D /* SDWebImageIndicator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageIndicator.m; sourceTree = "<group>"; };
 		32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageCoderHelper.h; sourceTree = "<group>"; };
 		32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageCoderHelper.m; sourceTree = "<group>"; };
-		32D1221A2080B2EB003685A3 /* SDWebImageCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDWebImageCache.h; sourceTree = "<group>"; };
-		32D1221B2080B2EB003685A3 /* SDWebImageCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageCache.m; sourceTree = "<group>"; };
+		32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDImageCacheDefine.h; sourceTree = "<group>"; };
+		32D1221B2080B2EB003685A3 /* SDImageCacheDefine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDImageCacheDefine.m; sourceTree = "<group>"; };
 		32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDImageCachesManager.m; sourceTree = "<group>"; };
 		32D1221D2080B2EB003685A3 /* SDImageCachesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDImageCachesManager.h; sourceTree = "<group>"; };
 		32F21B4F20788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageDownloaderRequestModifier.h; sourceTree = "<group>"; };
@@ -2118,8 +2118,8 @@
 				328BB6C02082581100760D6C /* SDMemoryCache.m */,
 				328BB6BD2082581100760D6C /* SDDiskCache.h */,
 				328BB6BE2082581100760D6C /* SDDiskCache.m */,
-				32D1221A2080B2EB003685A3 /* SDWebImageCache.h */,
-				32D1221B2080B2EB003685A3 /* SDWebImageCache.m */,
+				32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */,
+				32D1221B2080B2EB003685A3 /* SDImageCacheDefine.m */,
 				32D1221D2080B2EB003685A3 /* SDImageCachesManager.h */,
 				32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */,
 			);
@@ -2342,7 +2342,7 @@
 				323F8B531F38EF770092B609 /* backward_references_enc.h in Headers */,
 				4317395A1CDFC8B70008FEB9 /* mux_types.h in Headers */,
 				431739561CDFC8B70008FEB9 /* demux.h in Headers */,
-				32D122212080B2EB003685A3 /* SDWebImageCache.h in Headers */,
+				32D122212080B2EB003685A3 /* SDImageCacheDefine.h in Headers */,
 				32B9B53A206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */,
 				328BB6AD2081FEE500760D6C /* SDWebImageCacheSerializer.h in Headers */,
 				80377C4A1F2F666300F89830 /* bit_writer_utils.h in Headers */,
@@ -2440,7 +2440,7 @@
 				80377C1D1F2F666300F89830 /* huffman_encode_utils.h in Headers */,
 				321E60B11F38E90100405457 /* SDWebImageWebPCoder.h in Headers */,
 				80377E9A1F2F66D400F89830 /* common_dec.h in Headers */,
-				32D1221F2080B2EB003685A3 /* SDWebImageCache.h in Headers */,
+				32D1221F2080B2EB003685A3 /* SDImageCacheDefine.h in Headers */,
 				327054D5206CD8B3006EA328 /* SDWebImageAPNGCoder.h in Headers */,
 				328BB6AB2081FEE500760D6C /* SDWebImageCacheSerializer.h in Headers */,
 				32B9B538206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */,
@@ -2609,7 +2609,7 @@
 				32F7C0732030114C00873181 /* SDWebImageTransformer.h in Headers */,
 				431BB6FA1D06D2C1006A3455 /* SDWebImageDownloader.h in Headers */,
 				3248476D201775F600AF9E5A /* SDAnimatedImageView.h in Headers */,
-				32D122222080B2EB003685A3 /* SDWebImageCache.h in Headers */,
+				32D122222080B2EB003685A3 /* SDImageCacheDefine.h in Headers */,
 				80377DF51F2F66A800F89830 /* common_sse2.h in Headers */,
 				323F8BDC1F38EF770092B609 /* vp8i_enc.h in Headers */,
 				80377ED21F2F66D500F89830 /* vp8i_dec.h in Headers */,
@@ -2630,7 +2630,7 @@
 				32F7C0892030719600873181 /* UIImage+Transform.h in Headers */,
 				80377EDA1F2F66D500F89830 /* common_dec.h in Headers */,
 				80377EE61F2F66D500F89830 /* webpi_dec.h in Headers */,
-				32D122232080B2EB003685A3 /* SDWebImageCache.h in Headers */,
+				32D122232080B2EB003685A3 /* SDImageCacheDefine.h in Headers */,
 				32B9B53C206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */,
 				328BB6AF2081FEE500760D6C /* SDWebImageCacheSerializer.h in Headers */,
 				4397D2BA1D0DDD8C00BB2784 /* demux.h in Headers */,
@@ -2729,7 +2729,7 @@
 				323F8B521F38EF770092B609 /* backward_references_enc.h in Headers */,
 				4317394F1CDFC8B70008FEB9 /* demux.h in Headers */,
 				43CE757D1CFE9427006C64D0 /* FLAnimatedImageView.h in Headers */,
-				32D122202080B2EB003685A3 /* SDWebImageCache.h in Headers */,
+				32D122202080B2EB003685A3 /* SDImageCacheDefine.h in Headers */,
 				32B9B539206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */,
 				328BB6AC2081FEE500760D6C /* SDWebImageCacheSerializer.h in Headers */,
 				80377C301F2F666300F89830 /* bit_writer_utils.h in Headers */,
@@ -2901,7 +2901,7 @@
 				323F8B6E1F38EF770092B609 /* delta_palettization_enc.h in Headers */,
 				438096721CDFC08200DC626B /* MKAnnotationView+WebCache.h in Headers */,
 				43CE757C1CFE9427006C64D0 /* FLAnimatedImageView.h in Headers */,
-				32D1221E2080B2EB003685A3 /* SDWebImageCache.h in Headers */,
+				32D1221E2080B2EB003685A3 /* SDImageCacheDefine.h in Headers */,
 				80377E8A1F2F66D000F89830 /* common_dec.h in Headers */,
 				AB615303192DA24600A2D8E9 /* UIView+WebCacheOperation.h in Headers */,
 				323F8B501F38EF770092B609 /* backward_references_enc.h in Headers */,
@@ -3261,7 +3261,7 @@
 				80377DB51F2F66A700F89830 /* cpu.c in Sources */,
 				80377EC51F2F66D500F89830 /* webp_dec.c in Sources */,
 				80377DD61F2F66A700F89830 /* lossless_neon.c in Sources */,
-				32D122272080B2EB003685A3 /* SDWebImageCache.m in Sources */,
+				32D122272080B2EB003685A3 /* SDImageCacheDefine.m in Sources */,
 				00733A5C1BC4880000A5A117 /* UIButton+WebCache.m in Sources */,
 				80377EC01F2F66D500F89830 /* vp8_dec.c in Sources */,
 				80377C521F2F666300F89830 /* huffman_utils.c in Sources */,
@@ -3345,7 +3345,7 @@
 				4314D1341D0E0E3B004B36C9 /* UIImage+WebP.m in Sources */,
 				80377D3D1F2F66A700F89830 /* filters_mips_dsp_r2.c in Sources */,
 				323F8B751F38EF770092B609 /* filter_enc.c in Sources */,
-				32D122252080B2EB003685A3 /* SDWebImageCache.m in Sources */,
+				32D122252080B2EB003685A3 /* SDImageCacheDefine.m in Sources */,
 				80377D401F2F66A700F89830 /* filters_sse2.c in Sources */,
 				80377D1E1F2F66A700F89830 /* alpha_processing_mips_dsp_r2.c in Sources */,
 				80377D291F2F66A700F89830 /* cost_sse2.c in Sources */,
@@ -3509,7 +3509,7 @@
 				323F8BE21F38EF770092B609 /* vp8l_enc.c in Sources */,
 				431BB6A31D06D2C1006A3455 /* UIImageView+WebCache.m in Sources */,
 				80377E0C1F2F66A800F89830 /* filters_mips_dsp_r2.c in Sources */,
-				32D122282080B2EB003685A3 /* SDWebImageCache.m in Sources */,
+				32D122282080B2EB003685A3 /* SDImageCacheDefine.m in Sources */,
 				323F8B781F38EF770092B609 /* filter_enc.c in Sources */,
 				4369C2821D9807EC007E863A /* UIView+WebCache.m in Sources */,
 				80377E0F1F2F66A800F89830 /* filters_sse2.c in Sources */,
@@ -3705,7 +3705,7 @@
 				80377E381F2F66A800F89830 /* argb_sse2.c in Sources */,
 				323F8B9B1F38EF770092B609 /* near_lossless_enc.c in Sources */,
 				32F21B5C20788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.m in Sources */,
-				32D122292080B2EB003685A3 /* SDWebImageCache.m in Sources */,
+				32D122292080B2EB003685A3 /* SDImageCacheDefine.m in Sources */,
 				80377E3B1F2F66A800F89830 /* cost_mips_dsp_r2.c in Sources */,
 				4397D29B1D0DDD8C00BB2784 /* SDWebImageDownloader.m in Sources */,
 				80377E711F2F66A800F89830 /* upsampling.c in Sources */,
@@ -3923,7 +3923,7 @@
 				80377D8C1F2F66A700F89830 /* lossless_enc_sse2.c in Sources */,
 				4A2CAE2C1AB4BB7500B6BC39 /* UIButton+WebCache.m in Sources */,
 				80377EB51F2F66D400F89830 /* webp_dec.c in Sources */,
-				32D122262080B2EB003685A3 /* SDWebImageCache.m in Sources */,
+				32D122262080B2EB003685A3 /* SDImageCacheDefine.m in Sources */,
 				80377D701F2F66A700F89830 /* cpu.c in Sources */,
 				80377D911F2F66A700F89830 /* lossless_neon.c in Sources */,
 				80377EB01F2F66D400F89830 /* vp8_dec.c in Sources */,
@@ -4091,7 +4091,7 @@
 				A18A6CC9172DC28500419892 /* UIImage+GIF.m in Sources */,
 				80377E951F2F66D000F89830 /* webp_dec.c in Sources */,
 				80377CE61F2F66A100F89830 /* cpu.c in Sources */,
-				32D122242080B2EB003685A3 /* SDWebImageCache.m in Sources */,
+				32D122242080B2EB003685A3 /* SDImageCacheDefine.m in Sources */,
 				80377D071F2F66A100F89830 /* lossless_neon.c in Sources */,
 				80377E901F2F66D000F89830 /* vp8_dec.c in Sources */,
 				80377C041F2F665300F89830 /* huffman_utils.c in Sources */,

--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -520,18 +520,18 @@
 		32D122272080B2EB003685A3 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDWebImageCache.m */; };
 		32D122282080B2EB003685A3 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDWebImageCache.m */; };
 		32D122292080B2EB003685A3 /* SDWebImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221B2080B2EB003685A3 /* SDWebImageCache.m */; };
-		32D1222A2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDWebImageCachesManager.m */; };
-		32D1222B2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDWebImageCachesManager.m */; };
-		32D1222C2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDWebImageCachesManager.m */; };
-		32D1222D2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDWebImageCachesManager.m */; };
-		32D1222E2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDWebImageCachesManager.m */; };
-		32D1222F2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDWebImageCachesManager.m */; };
-		32D122302080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D122312080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D122322080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D122332080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D122342080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32D122352080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDWebImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D1222A2080B2EB003685A3 /* SDImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */; };
+		32D1222B2080B2EB003685A3 /* SDImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */; };
+		32D1222C2080B2EB003685A3 /* SDImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */; };
+		32D1222D2080B2EB003685A3 /* SDImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */; };
+		32D1222E2080B2EB003685A3 /* SDImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */; };
+		32D1222F2080B2EB003685A3 /* SDImageCachesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */; };
+		32D122302080B2EB003685A3 /* SDImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D122312080B2EB003685A3 /* SDImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D122322080B2EB003685A3 /* SDImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D122332080B2EB003685A3 /* SDImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D122342080B2EB003685A3 /* SDImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32D122352080B2EB003685A3 /* SDImageCachesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221D2080B2EB003685A3 /* SDImageCachesManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32EB6D8E206D132E005CAEF6 /* SDAnimatedImageRep.m in Sources */ = {isa = PBXBuildFile; fileRef = 320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */; };
 		32EB6D8F206D132E005CAEF6 /* SDAnimatedImageRep.m in Sources */ = {isa = PBXBuildFile; fileRef = 320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */; };
 		32EB6D90206D132E005CAEF6 /* SDAnimatedImageRep.m in Sources */ = {isa = PBXBuildFile; fileRef = 320224BA203979BA00E9F285 /* SDAnimatedImageRep.m */; };
@@ -1598,8 +1598,8 @@
 		32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageCoderHelper.m; sourceTree = "<group>"; };
 		32D1221A2080B2EB003685A3 /* SDWebImageCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDWebImageCache.h; sourceTree = "<group>"; };
 		32D1221B2080B2EB003685A3 /* SDWebImageCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageCache.m; sourceTree = "<group>"; };
-		32D1221C2080B2EB003685A3 /* SDWebImageCachesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDWebImageCachesManager.m; sourceTree = "<group>"; };
-		32D1221D2080B2EB003685A3 /* SDWebImageCachesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDWebImageCachesManager.h; sourceTree = "<group>"; };
+		32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDImageCachesManager.m; sourceTree = "<group>"; };
+		32D1221D2080B2EB003685A3 /* SDImageCachesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDImageCachesManager.h; sourceTree = "<group>"; };
 		32F21B4F20788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageDownloaderRequestModifier.h; sourceTree = "<group>"; };
 		32F21B5020788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDownloaderRequestModifier.m; sourceTree = "<group>"; };
 		32F7C06D2030114C00873181 /* SDWebImageTransformer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageTransformer.h; sourceTree = "<group>"; };
@@ -2120,8 +2120,8 @@
 				328BB6BE2082581100760D6C /* SDDiskCache.m */,
 				32D1221A2080B2EB003685A3 /* SDWebImageCache.h */,
 				32D1221B2080B2EB003685A3 /* SDWebImageCache.m */,
-				32D1221D2080B2EB003685A3 /* SDWebImageCachesManager.h */,
-				32D1221C2080B2EB003685A3 /* SDWebImageCachesManager.m */,
+				32D1221D2080B2EB003685A3 /* SDImageCachesManager.h */,
+				32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */,
 			);
 			name = Cache;
 			sourceTree = "<group>";
@@ -2412,7 +2412,7 @@
 				3248476C201775F600AF9E5A /* SDAnimatedImageView.h in Headers */,
 				80377C5F1F2F666300F89830 /* utils.h in Headers */,
 				80377C5B1F2F666300F89830 /* rescaler_utils.h in Headers */,
-				32D122332080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */,
+				32D122332080B2EB003685A3 /* SDImageCachesManager.h in Headers */,
 				323F8BF91F38EF770092B609 /* animi.h in Headers */,
 				32F7C0872030719600873181 /* UIImage+Transform.h in Headers */,
 				80377C4F1F2F666300F89830 /* filters_utils.h in Headers */,
@@ -2482,7 +2482,7 @@
 				80377C271F2F666300F89830 /* rescaler_utils.h in Headers */,
 				323F8B511F38EF770092B609 /* backward_references_enc.h in Headers */,
 				325312C9200F09910046BF1E /* SDWebImageTransition.h in Headers */,
-				32D122312080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */,
+				32D122312080B2EB003685A3 /* SDImageCachesManager.h in Headers */,
 				43A918651D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
 				4314D1741D0E0E3B004B36C9 /* types.h in Headers */,
 				4314D1761D0E0E3B004B36C9 /* decode.h in Headers */,
@@ -2564,7 +2564,7 @@
 				80377E211F2F66A800F89830 /* neon.h in Headers */,
 				80377C711F2F666400F89830 /* quant_levels_utils.h in Headers */,
 				323F8B541F38EF770092B609 /* backward_references_enc.h in Headers */,
-				32D122342080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */,
+				32D122342080B2EB003685A3 /* SDImageCachesManager.h in Headers */,
 				32F7C0882030719600873181 /* UIImage+Transform.h in Headers */,
 				43A62A1F1D0E0A800089D7DD /* mux.h in Headers */,
 				431BB6E91D06D2C1006A3455 /* SDWebImageDownloaderOperation.h in Headers */,
@@ -2700,7 +2700,7 @@
 				321E608B1F38E8C800405457 /* SDWebImageCoder.h in Headers */,
 				323F8B731F38EF770092B609 /* delta_palettization_enc.h in Headers */,
 				321E60C31F38E91700405457 /* UIImage+ForceDecode.h in Headers */,
-				32D122352080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */,
+				32D122352080B2EB003685A3 /* SDImageCachesManager.h in Headers */,
 				32484768201775F600AF9E5A /* SDAnimatedImageView+WebCache.h in Headers */,
 				80377E561F2F66A800F89830 /* lossless_common.h in Headers */,
 				4397D2E91D0DDD8C00BB2784 /* UIImage+WebP.h in Headers */,
@@ -2799,7 +2799,7 @@
 				3248476B201775F600AF9E5A /* SDAnimatedImageView.h in Headers */,
 				4A2CAE311AB4BB7500B6BC39 /* UIImage+WebP.h in Headers */,
 				323F8BF81F38EF770092B609 /* animi.h in Headers */,
-				32D122322080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */,
+				32D122322080B2EB003685A3 /* SDImageCachesManager.h in Headers */,
 				80377C351F2F666300F89830 /* filters_utils.h in Headers */,
 				32F7C0862030719600873181 /* UIImage+Transform.h in Headers */,
 				80377C321F2F666300F89830 /* color_cache_utils.h in Headers */,
@@ -2853,7 +2853,7 @@
 				431738BD1CDFC2660008FEB9 /* decode.h in Headers */,
 				80377D0B1F2F66A100F89830 /* mips_macro.h in Headers */,
 				329A18591FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */,
-				32D122302080B2EB003685A3 /* SDWebImageCachesManager.h in Headers */,
+				32D122302080B2EB003685A3 /* SDImageCachesManager.h in Headers */,
 				5376131A155AD0D5005750A4 /* SDWebImageDownloader.h in Headers */,
 				328BB6CD2082581100760D6C /* SDMemoryCache.h in Headers */,
 				4369C2771D9807EC007E863A /* UIView+WebCache.h in Headers */,
@@ -3218,7 +3218,7 @@
 				80377DDE1F2F66A700F89830 /* rescaler_mips32.c in Sources */,
 				80377DCA1F2F66A700F89830 /* filters_sse2.c in Sources */,
 				80377EBE1F2F66D500F89830 /* quant_dec.c in Sources */,
-				32D1222D2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */,
+				32D1222D2080B2EB003685A3 /* SDImageCachesManager.m in Sources */,
 				80377DB61F2F66A700F89830 /* dec_clip_tables.c in Sources */,
 				80377C5E1F2F666300F89830 /* utils.c in Sources */,
 				32B9B540206ED4230026769D /* SDWebImageDownloaderConfig.m in Sources */,
@@ -3389,7 +3389,7 @@
 				80377D2F1F2F66A700F89830 /* dec_msa.c in Sources */,
 				323F8C151F38EF770092B609 /* muxinternal.c in Sources */,
 				80377D571F2F66A700F89830 /* rescaler_sse2.c in Sources */,
-				32D1222B2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */,
+				32D1222B2080B2EB003685A3 /* SDImageCachesManager.m in Sources */,
 				43C892A11D9D6DDC0022038D /* demux.c in Sources */,
 				80377C131F2F666300F89830 /* bit_reader_utils.c in Sources */,
 				80377E9C1F2F66D400F89830 /* idec_dec.c in Sources */,
@@ -3553,7 +3553,7 @@
 				323F8BBE1F38EF770092B609 /* predictor_enc.c in Sources */,
 				80377E261F2F66A800F89830 /* rescaler_sse2.c in Sources */,
 				323F8C181F38EF770092B609 /* muxinternal.c in Sources */,
-				32D1222E2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */,
+				32D1222E2080B2EB003685A3 /* SDImageCachesManager.m in Sources */,
 				80377C741F2F666400F89830 /* rescaler_utils.c in Sources */,
 				431BB6B11D06D2C1006A3455 /* UIView+WebCacheOperation.m in Sources */,
 				80377DF01F2F66A800F89830 /* alpha_processing_sse41.c in Sources */,
@@ -3692,7 +3692,7 @@
 				321E60C91F38E91700405457 /* UIImage+ForceDecode.m in Sources */,
 				80377E551F2F66A800F89830 /* filters.c in Sources */,
 				80377E731F2F66A800F89830 /* yuv_mips32.c in Sources */,
-				32D1222F2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */,
+				32D1222F2080B2EB003685A3 /* SDImageCachesManager.m in Sources */,
 				4397D2911D0DDD8C00BB2784 /* MKAnnotationView+WebCache.m in Sources */,
 				4397D2921D0DDD8C00BB2784 /* SDWebImagePrefetcher.m in Sources */,
 				323F8BBF1F38EF770092B609 /* predictor_enc.c in Sources */,
@@ -3880,7 +3880,7 @@
 				80377C441F2F666300F89830 /* utils.c in Sources */,
 				80377D8D1F2F66A700F89830 /* lossless_enc_sse41.c in Sources */,
 				80377EAE1F2F66D400F89830 /* quant_dec.c in Sources */,
-				32D1222C2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */,
+				32D1222C2080B2EB003685A3 /* SDImageCachesManager.m in Sources */,
 				80377D6E1F2F66A700F89830 /* cost_sse2.c in Sources */,
 				80377D991F2F66A700F89830 /* rescaler_mips32.c in Sources */,
 				32B9B53F206ED4230026769D /* SDWebImageDownloaderConfig.m in Sources */,
@@ -4048,7 +4048,7 @@
 				80377D031F2F66A100F89830 /* lossless_enc_sse41.c in Sources */,
 				80377E8E1F2F66D000F89830 /* quant_dec.c in Sources */,
 				80377CE41F2F66A100F89830 /* cost_sse2.c in Sources */,
-				32D1222A2080B2EB003685A3 /* SDWebImageCachesManager.m in Sources */,
+				32D1222A2080B2EB003685A3 /* SDImageCachesManager.m in Sources */,
 				80377D0F1F2F66A100F89830 /* rescaler_mips32.c in Sources */,
 				323F8C081F38EF770092B609 /* muxedit.c in Sources */,
 				32B9B53D206ED4230026769D /* SDWebImageDownloaderConfig.m in Sources */,

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -324,8 +324,8 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
 @end
 
 /**
- * SDImageCache is the built-in image cache implementation for web image manager. It adopts `SDWebImageCache` protocol to provide the function for web image manager to use for image loading process.
+ * SDImageCache is the built-in image cache implementation for web image manager. It adopts `SDImageCache` protocol to provide the function for web image manager to use for image loading process.
  */
-@interface SDImageCache (SDWebImageCache) <SDImageCache>
+@interface SDImageCache (SDImageCache) <SDImageCache>
 
 @end

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -10,7 +10,7 @@
 #import "SDWebImageCompat.h"
 #import "SDWebImageDefine.h"
 #import "SDImageCacheConfig.h"
-#import "SDWebImageCache.h"
+#import "SDImageCacheDefine.h"
 
 typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     /**
@@ -46,14 +46,8 @@ typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     SDImageCachePreloadAllFrames = 1 << 6
 };
 
-typedef void(^SDImageCacheCheckCompletionBlock)(BOOL isInCache);
-
-typedef void(^SDImageCacheCalculateSizeBlock)(NSUInteger fileCount, NSUInteger totalSize);
-
-typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * _Nonnull key);
-
 /**
- * SDImageCache maintains a memory cache and an optional disk cache. Disk cache write operations are performed
+ * SDImageCache maintains a memory cache and a disk cache. Disk cache write operations are performed
  * asynchronous so it doesn’t add unnecessary latency to the UI.
  */
 @interface SDImageCache : NSObject
@@ -332,6 +326,6 @@ typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * 
 /**
  * SDImageCache is the built-in image cache implementation for web image manager. It adopts `SDWebImageCache` protocol to provide the function for web image manager to use for image loading process.
  */
-@interface SDImageCache (SDWebImageCache) <SDWebImageCache>
+@interface SDImageCache (SDWebImageCache) <SDImageCache>
 
 @end

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -59,10 +59,10 @@
                        diskCacheDirectory:(nonnull NSString *)directory
                                    config:(nullable SDImageCacheConfig *)config {
     if ((self = [super init])) {
-        NSString *fullNamespace = [@"com.hackemist.SDWebImageCache." stringByAppendingString:ns];
+        NSString *fullNamespace = [@"com.hackemist.SDImageCache." stringByAppendingString:ns];
         
         // Create IO serial queue
-        _ioQueue = dispatch_queue_create("com.hackemist.SDWebImageCache", DISPATCH_QUEUE_SERIAL);
+        _ioQueue = dispatch_queue_create("com.hackemist.SDImageCache", DISPATCH_QUEUE_SERIAL);
         
         if (!config) {
             config = SDImageCacheConfig.defaultCacheConfig;
@@ -317,7 +317,7 @@
 
 - (nullable UIImage *)diskImageForKey:(nullable NSString *)key data:(nullable NSData *)data options:(SDImageCacheOptions)options context:(SDWebImageContext *)context {
     if (data) {
-        UIImage *image = SDWebImageCacheDecodeImageData(data, key, [[self class] imageOptionsFromCacheOptions:options], context);
+        UIImage *image = SDImageCacheDecodeImageData(data, key, [[self class] imageOptionsFromCacheOptions:options], context);
         return image;
     } else {
         return nil;
@@ -568,9 +568,9 @@
 
 @end
 
-@implementation SDImageCache (SDWebImageCache)
+@implementation SDImageCache (SDImageCache)
 
-#pragma mark - SDWebImageCache
+#pragma mark - SDImageCache
 
 - (id<SDWebImageOperation>)queryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context completion:(nullable SDImageCacheQueryCompletionBlock)completionBlock {
     SDImageCacheOptions cacheOptions = 0;

--- a/SDWebImage/SDImageCacheDefine.h
+++ b/SDWebImage/SDImageCacheDefine.h
@@ -50,12 +50,12 @@ typedef void(^SDImageCacheContainsCompletionBlock)(SDImageCacheType containsCach
  @param context The context arg from the input
  @return The decoded image for current image data query from cache
  */
-FOUNDATION_EXPORT UIImage * _Nullable SDWebImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context);
+FOUNDATION_EXPORT UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context);
 
 /**
  This is the image cache protocol to provide custom image cache for `SDWebImageManager`.
  Though the best practice to custom image cache, is to write your own class which conform `SDMemoryCache` or `SDDiskCache` protocol for `SDImageCache` class (See more on `SDImageCacheConfig.memoryCacheClass & SDImageCacheConfig.diskCacheClass`).
- However, if your own cache implementation contains more advanced feature beyond `SDImageCache` itself, you can consider to provide this instead. For example, you can even use a cache manager like `SDWebImageCachesManager` to register multiple caches.
+ However, if your own cache implementation contains more advanced feature beyond `SDImageCache` itself, you can consider to provide this instead. For example, you can even use a cache manager like `SDImageCachesManager` to register multiple caches.
  */
 @protocol SDImageCache <NSObject>
 

--- a/SDWebImage/SDImageCacheDefine.h
+++ b/SDWebImage/SDImageCacheDefine.h
@@ -34,6 +34,9 @@ typedef NS_ENUM(NSInteger, SDImageCacheType) {
     SDImageCacheTypeAll
 };
 
+typedef void(^SDImageCacheCheckCompletionBlock)(BOOL isInCache);
+typedef void(^SDImageCacheCalculateSizeBlock)(NSUInteger fileCount, NSUInteger totalSize);
+typedef NSString * _Nullable (^SDImageCacheAdditionalCachePathBlock)(NSString * _Nonnull key);
 typedef void(^SDImageCacheQueryCompletionBlock)(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType);
 typedef void(^SDImageCacheContainsCompletionBlock)(SDImageCacheType containsCacheType);
 
@@ -54,7 +57,7 @@ FOUNDATION_EXPORT UIImage * _Nullable SDWebImageCacheDecodeImageData(NSData * _N
  Though the best practice to custom image cache, is to write your own class which conform `SDMemoryCache` or `SDDiskCache` protocol for `SDImageCache` class (See more on `SDImageCacheConfig.memoryCacheClass & SDImageCacheConfig.diskCacheClass`).
  However, if your own cache implementation contains more advanced feature beyond `SDImageCache` itself, you can consider to provide this instead. For example, you can even use a cache manager like `SDWebImageCachesManager` to register multiple caches.
  */
-@protocol SDWebImageCache <NSObject>
+@protocol SDImageCache <NSObject>
 
 @required
 /**

--- a/SDWebImage/SDImageCacheDefine.m
+++ b/SDWebImage/SDImageCacheDefine.m
@@ -12,7 +12,7 @@
 #import "SDAnimatedImage.h"
 #import "UIImage+WebCache.h"
 
-UIImage * _Nullable SDWebImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context) {
+UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context) {
     UIImage *image;
     BOOL decodeFirstFrame = options & SDWebImageDecodeFirstFrameOnly;
     NSNumber *scaleValue = [context valueForKey:SDWebImageContextImageScaleFactor];

--- a/SDWebImage/SDImageCacheDefine.m
+++ b/SDWebImage/SDImageCacheDefine.m
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCache.h"
+#import "SDImageCacheDefine.h"
 #import "SDWebImageCodersManager.h"
 #import "SDWebImageCoderHelper.h"
 #import "SDAnimatedImage.h"

--- a/SDWebImage/SDImageCachesManager.h
+++ b/SDWebImage/SDImageCachesManager.h
@@ -9,19 +9,19 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCache.h"
 
-typedef NS_ENUM(NSUInteger, SDWebImageCachesManagerOperationPolicy) {
-    SDWebImageCachesManagerOperationPolicySerial, // process all caches serially (from the highest priority to the lowest priority cache by order)
-    SDWebImageCachesManagerOperationPolicyConcurrent, // process all caches concurrently
-    SDWebImageCachesManagerOperationPolicyHighestOnly, // process the highest priority cache only
-    SDWebImageCachesManagerOperationPolicyLowestOnly // process the lowest priority cache only
+typedef NS_ENUM(NSUInteger, SDImageCachesManagerOperationPolicy) {
+    SDImageCachesManagerOperationPolicySerial, // process all caches serially (from the highest priority to the lowest priority cache by order)
+    SDImageCachesManagerOperationPolicyConcurrent, // process all caches concurrently
+    SDImageCachesManagerOperationPolicyHighestOnly, // process the highest priority cache only
+    SDImageCachesManagerOperationPolicyLowestOnly // process the lowest priority cache only
 };
 
-@interface SDWebImageCachesManager : NSObject <SDWebImageCache>
+@interface SDImageCachesManager : NSObject <SDWebImageCache>
 
 /**
  Returns the global shared caches manager instance.
  */
-@property (nonatomic, class, readonly, nonnull) SDWebImageCachesManager *sharedManager;
+@property (nonatomic, class, readonly, nonnull) SDImageCachesManager *sharedManager;
 
 // These are op policy for cache manager.
 
@@ -29,31 +29,31 @@ typedef NS_ENUM(NSUInteger, SDWebImageCachesManagerOperationPolicy) {
  Operation policy for query op.
  Defaults to `Serial`, means query all caches serially (one completion called then next begin) until one cache query success (`image` != nil).
  */
-@property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy queryOperationPolicy;
+@property (nonatomic, assign) SDImageCachesManagerOperationPolicy queryOperationPolicy;
 
 /**
  Operation policy for store op.
  Defaults to `HighestOnly`, means store to the highest priority cache only.
  */
-@property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy storeOperationPolicy;
+@property (nonatomic, assign) SDImageCachesManagerOperationPolicy storeOperationPolicy;
 
 /**
  Operation policy for remove op.
  Defaults to `Concurrent`, means remove all caches concurrently.
  */
-@property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy removeOperationPolicy;
+@property (nonatomic, assign) SDImageCachesManagerOperationPolicy removeOperationPolicy;
 
 /**
  Operation policy for contains op.
  Defaults to `Serial`, means check all caches serially (one completion called then next begin) until one cache check success (`containsCacheType` != None).
  */
-@property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy containsOperationPolicy;
+@property (nonatomic, assign) SDImageCachesManagerOperationPolicy containsOperationPolicy;
 
 /**
  Operation policy for clear op.
  Defaults to `Concurrent`, means clear all caches concurrently.
  */
-@property (nonatomic, assign) SDWebImageCachesManagerOperationPolicy clearOperationPolicy;
+@property (nonatomic, assign) SDImageCachesManagerOperationPolicy clearOperationPolicy;
 
 /**
  All caches in caches manager. The caches array is a priority queue, which means the later added cache will have the highest priority

--- a/SDWebImage/SDImageCachesManager.h
+++ b/SDWebImage/SDImageCachesManager.h
@@ -7,7 +7,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SDWebImageCache.h"
+#import "SDImageCacheDefine.h"
 
 typedef NS_ENUM(NSUInteger, SDImageCachesManagerOperationPolicy) {
     SDImageCachesManagerOperationPolicySerial, // process all caches serially (from the highest priority to the lowest priority cache by order)
@@ -16,7 +16,7 @@ typedef NS_ENUM(NSUInteger, SDImageCachesManagerOperationPolicy) {
     SDImageCachesManagerOperationPolicyLowestOnly // process the lowest priority cache only
 };
 
-@interface SDImageCachesManager : NSObject <SDWebImageCache>
+@interface SDImageCachesManager : NSObject <SDImageCache>
 
 /**
  Returns the global shared caches manager instance.
@@ -58,20 +58,20 @@ typedef NS_ENUM(NSUInteger, SDImageCachesManagerOperationPolicy) {
 /**
  All caches in caches manager. The caches array is a priority queue, which means the later added cache will have the highest priority
  */
-@property (atomic, copy, readwrite, nullable) NSArray<id<SDWebImageCache>> *caches;
+@property (atomic, copy, readwrite, nullable) NSArray<id<SDImageCache>> *caches;
 
 /**
  Add a new cache to the end of caches array. Which has the highest priority.
  
  @param cache cache
  */
-- (void)addCache:(nonnull id<SDWebImageCache>)cache;
+- (void)addCache:(nonnull id<SDImageCache>)cache;
 
 /**
  Remove a cache in the caches array.
  
  @param cache cache
  */
-- (void)removeCache:(nonnull id<SDWebImageCache>)cache;
+- (void)removeCache:(nonnull id<SDImageCache>)cache;
 
 @end

--- a/SDWebImage/SDImageCachesManager.m
+++ b/SDWebImage/SDImageCachesManager.m
@@ -6,10 +6,10 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCachesManager.h"
+#import "SDImageCachesManager.h"
 
 // This is used for operation management, but not for operation queue execute
-@interface SDWebImageCachesManagerOperation : NSOperation
+@interface SDImageCachesManagerOperation : NSOperation
 
 @property (nonatomic, assign, readonly) NSUInteger pendingCount;
 
@@ -19,7 +19,7 @@
 
 @end
 
-@implementation SDWebImageCachesManagerOperation
+@implementation SDImageCachesManagerOperation
 
 @synthesize executing = _executing;
 @synthesize finished = _finished;
@@ -70,13 +70,13 @@
 
 @end
 
-@implementation SDWebImageCachesManager
+@implementation SDImageCachesManager
 
-+ (SDWebImageCachesManager *)sharedManager {
++ (SDImageCachesManager *)sharedManager {
     static dispatch_once_t onceToken;
-    static SDWebImageCachesManager *manager;
+    static SDImageCachesManager *manager;
     dispatch_once(&onceToken, ^{
-        manager = [[SDWebImageCachesManager alloc] init];
+        manager = [[SDImageCachesManager alloc] init];
     });
     return manager;
 }
@@ -84,11 +84,11 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        self.queryOperationPolicy = SDWebImageCachesManagerOperationPolicySerial;
-        self.storeOperationPolicy = SDWebImageCachesManagerOperationPolicyHighestOnly;
-        self.removeOperationPolicy = SDWebImageCachesManagerOperationPolicyConcurrent;
-        self.containsOperationPolicy = SDWebImageCachesManagerOperationPolicySerial;
-        self.clearOperationPolicy = SDWebImageCachesManagerOperationPolicyConcurrent;
+        self.queryOperationPolicy = SDImageCachesManagerOperationPolicySerial;
+        self.storeOperationPolicy = SDImageCachesManagerOperationPolicyHighestOnly;
+        self.removeOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
+        self.containsOperationPolicy = SDImageCachesManagerOperationPolicySerial;
+        self.clearOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
     }
     return self;
 }
@@ -130,25 +130,25 @@
         return [caches.firstObject queryImageForKey:key options:options context:context completion:completionBlock];
     }
     switch (self.queryOperationPolicy) {
-        case SDWebImageCachesManagerOperationPolicyHighestOnly: {
+        case SDImageCachesManagerOperationPolicyHighestOnly: {
             id<SDWebImageCache> cache = caches.lastObject;
             return [cache queryImageForKey:key options:options context:context completion:completionBlock];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicyLowestOnly: {
+        case SDImageCachesManagerOperationPolicyLowestOnly: {
             id<SDWebImageCache> cache = caches.firstObject;
             return [cache queryImageForKey:key options:options context:context completion:completionBlock];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicyConcurrent: {
-            SDWebImageCachesManagerOperation *operation = [SDWebImageCachesManagerOperation new];
+        case SDImageCachesManagerOperationPolicyConcurrent: {
+            SDImageCachesManagerOperation *operation = [SDImageCachesManagerOperation new];
             [operation beginWithTotalCount:caches.count];
             [self concurrentQueryImageForKey:key options:options context:context completion:completionBlock enumerator:caches.reverseObjectEnumerator operation:operation];
             return operation;
         }
             break;
-        case SDWebImageCachesManagerOperationPolicySerial: {
-            SDWebImageCachesManagerOperation *operation = [SDWebImageCachesManagerOperation new];
+        case SDImageCachesManagerOperationPolicySerial: {
+            SDImageCachesManagerOperation *operation = [SDImageCachesManagerOperation new];
             [operation beginWithTotalCount:caches.count];
             [self serialQueryImageForKey:key options:options context:context completion:completionBlock enumerator:caches.reverseObjectEnumerator operation:operation];
             return operation;
@@ -173,23 +173,23 @@
         return;
     }
     switch (self.storeOperationPolicy) {
-        case SDWebImageCachesManagerOperationPolicyHighestOnly: {
+        case SDImageCachesManagerOperationPolicyHighestOnly: {
             id<SDWebImageCache> cache = caches.lastObject;
             [cache storeImage:image imageData:imageData forKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicyLowestOnly: {
+        case SDImageCachesManagerOperationPolicyLowestOnly: {
             id<SDWebImageCache> cache = caches.firstObject;
             [cache storeImage:image imageData:imageData forKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicyConcurrent: {
-            SDWebImageCachesManagerOperation *operation = [SDWebImageCachesManagerOperation new];
+        case SDImageCachesManagerOperationPolicyConcurrent: {
+            SDImageCachesManagerOperation *operation = [SDImageCachesManagerOperation new];
             [operation beginWithTotalCount:caches.count];
             [self concurrentStoreImage:image imageData:imageData forKey:key cacheType:cacheType completion:completionBlock enumerator:caches.reverseObjectEnumerator operation:operation];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicySerial: {
+        case SDImageCachesManagerOperationPolicySerial: {
             [self serialStoreImage:image imageData:imageData forKey:key cacheType:cacheType completion:completionBlock enumerator:caches.reverseObjectEnumerator];
         }
             break;
@@ -211,23 +211,23 @@
         return;
     }
     switch (self.removeOperationPolicy) {
-        case SDWebImageCachesManagerOperationPolicyHighestOnly: {
+        case SDImageCachesManagerOperationPolicyHighestOnly: {
             id<SDWebImageCache> cache = caches.lastObject;
             [cache removeImageForKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicyLowestOnly: {
+        case SDImageCachesManagerOperationPolicyLowestOnly: {
             id<SDWebImageCache> cache = caches.firstObject;
             [cache removeImageForKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicyConcurrent: {
-            SDWebImageCachesManagerOperation *operation = [SDWebImageCachesManagerOperation new];
+        case SDImageCachesManagerOperationPolicyConcurrent: {
+            SDImageCachesManagerOperation *operation = [SDImageCachesManagerOperation new];
             [operation beginWithTotalCount:caches.count];
             [self concurrentRemoveImageForKey:key cacheType:cacheType completion:completionBlock enumerator:caches.reverseObjectEnumerator operation:operation];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicySerial: {
+        case SDImageCachesManagerOperationPolicySerial: {
             [self serialRemoveImageForKey:key cacheType:cacheType completion:completionBlock enumerator:caches.reverseObjectEnumerator];
         }
             break;
@@ -249,24 +249,24 @@
         return;
     }
     switch (self.clearOperationPolicy) {
-        case SDWebImageCachesManagerOperationPolicyHighestOnly: {
+        case SDImageCachesManagerOperationPolicyHighestOnly: {
             id<SDWebImageCache> cache = caches.lastObject;
             [cache containsImageForKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicyLowestOnly: {
+        case SDImageCachesManagerOperationPolicyLowestOnly: {
             id<SDWebImageCache> cache = caches.firstObject;
             [cache containsImageForKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicyConcurrent: {
-            SDWebImageCachesManagerOperation *operation = [SDWebImageCachesManagerOperation new];
+        case SDImageCachesManagerOperationPolicyConcurrent: {
+            SDImageCachesManagerOperation *operation = [SDImageCachesManagerOperation new];
             [operation beginWithTotalCount:caches.count];
             [self concurrentContainsImageForKey:key cacheType:cacheType completion:completionBlock enumerator:caches.reverseObjectEnumerator operation:operation];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicySerial: {
-            SDWebImageCachesManagerOperation *operation = [SDWebImageCachesManagerOperation new];
+        case SDImageCachesManagerOperationPolicySerial: {
+            SDImageCachesManagerOperation *operation = [SDImageCachesManagerOperation new];
             [operation beginWithTotalCount:caches.count];
             [self serialContainsImageForKey:key cacheType:cacheType completion:completionBlock enumerator:caches.reverseObjectEnumerator operation:operation];
         }
@@ -286,23 +286,23 @@
         return;
     }
     switch (self.clearOperationPolicy) {
-        case SDWebImageCachesManagerOperationPolicyHighestOnly: {
+        case SDImageCachesManagerOperationPolicyHighestOnly: {
             id<SDWebImageCache> cache = caches.lastObject;
             [cache clearWithCacheType:cacheType completion:completionBlock];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicyLowestOnly: {
+        case SDImageCachesManagerOperationPolicyLowestOnly: {
             id<SDWebImageCache> cache = caches.firstObject;
             [cache clearWithCacheType:cacheType completion:completionBlock];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicyConcurrent: {
-            SDWebImageCachesManagerOperation *operation = [SDWebImageCachesManagerOperation new];
+        case SDImageCachesManagerOperationPolicyConcurrent: {
+            SDImageCachesManagerOperation *operation = [SDImageCachesManagerOperation new];
             [operation beginWithTotalCount:caches.count];
             [self concurrentClearWithCacheType:cacheType completion:completionBlock enumerator:caches.reverseObjectEnumerator operation:operation];
         }
             break;
-        case SDWebImageCachesManagerOperationPolicySerial: {
+        case SDImageCachesManagerOperationPolicySerial: {
             [self serialClearWithCacheType:cacheType completion:completionBlock enumerator:caches.reverseObjectEnumerator];
         }
             break;
@@ -313,7 +313,7 @@
 
 #pragma mark - Concurrent Operation
 
-- (void)concurrentQueryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDWebImageCachesManagerOperation *)operation {
+- (void)concurrentQueryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
     for (id<SDWebImageCache> cache in enumerator) {
@@ -346,7 +346,7 @@
     }
 }
 
-- (void)concurrentStoreImage:(UIImage *)image imageData:(NSData *)imageData forKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDWebImageCachesManagerOperation *)operation {
+- (void)concurrentStoreImage:(UIImage *)image imageData:(NSData *)imageData forKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
     for (id<SDWebImageCache> cache in enumerator) {
@@ -371,7 +371,7 @@
     }
 }
 
-- (void)concurrentRemoveImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDWebImageCachesManagerOperation *)operation {
+- (void)concurrentRemoveImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
     for (id<SDWebImageCache> cache in enumerator) {
@@ -396,7 +396,7 @@
     }
 }
 
-- (void)concurrentContainsImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDImageCacheContainsCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDWebImageCachesManagerOperation *)operation {
+- (void)concurrentContainsImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDImageCacheContainsCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
     for (id<SDWebImageCache> cache in enumerator) {
@@ -429,7 +429,7 @@
     }
 }
 
-- (void)concurrentClearWithCacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDWebImageCachesManagerOperation *)operation {
+- (void)concurrentClearWithCacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
     for (id<SDWebImageCache> cache in enumerator) {
@@ -456,7 +456,7 @@
 
 #pragma mark - Serial Operation
 
-- (void)serialQueryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDWebImageCachesManagerOperation *)operation {
+- (void)serialQueryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
     id<SDWebImageCache> cache = enumerator.nextObject;
@@ -526,7 +526,7 @@
     }];
 }
 
-- (void)serialContainsImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDImageCacheContainsCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDWebImageCachesManagerOperation *)operation {
+- (void)serialContainsImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDImageCacheContainsCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
     id<SDWebImageCache> cache = enumerator.nextObject;

--- a/SDWebImage/SDImageCachesManager.m
+++ b/SDWebImage/SDImageCachesManager.m
@@ -95,11 +95,11 @@
 
 #pragma mark - Cache IO operations
 
-- (void)addCache:(id<SDWebImageCache>)cache {
-    if (![cache conformsToProtocol:@protocol(SDWebImageCache)]) {
+- (void)addCache:(id<SDImageCache>)cache {
+    if (![cache conformsToProtocol:@protocol(SDImageCache)]) {
         return;
     }
-    NSMutableArray<id<SDWebImageCache>> *mutableCaches = [self.caches mutableCopy];
+    NSMutableArray<id<SDImageCache>> *mutableCaches = [self.caches mutableCopy];
     if (!mutableCaches) {
         mutableCaches = [NSMutableArray array];
     }
@@ -107,11 +107,11 @@
     self.caches = [mutableCaches copy];
 }
 
-- (void)removeCache:(id<SDWebImageCache>)cache {
-    if (![cache conformsToProtocol:@protocol(SDWebImageCache)]) {
+- (void)removeCache:(id<SDImageCache>)cache {
+    if (![cache conformsToProtocol:@protocol(SDImageCache)]) {
         return;
     }
-    NSMutableArray<id<SDWebImageCache>> *mutableCaches = [self.caches mutableCopy];
+    NSMutableArray<id<SDImageCache>> *mutableCaches = [self.caches mutableCopy];
     [mutableCaches removeObject:cache];
     self.caches = [mutableCaches copy];
 }
@@ -122,7 +122,7 @@
     if (!key) {
         return nil;
     }
-    NSArray<id<SDWebImageCache>> *caches = [self.caches copy];
+    NSArray<id<SDImageCache>> *caches = [self.caches copy];
     NSUInteger count = caches.count;
     if (count == 0) {
         return nil;
@@ -131,12 +131,12 @@
     }
     switch (self.queryOperationPolicy) {
         case SDImageCachesManagerOperationPolicyHighestOnly: {
-            id<SDWebImageCache> cache = caches.lastObject;
+            id<SDImageCache> cache = caches.lastObject;
             return [cache queryImageForKey:key options:options context:context completion:completionBlock];
         }
             break;
         case SDImageCachesManagerOperationPolicyLowestOnly: {
-            id<SDWebImageCache> cache = caches.firstObject;
+            id<SDImageCache> cache = caches.firstObject;
             return [cache queryImageForKey:key options:options context:context completion:completionBlock];
         }
             break;
@@ -164,7 +164,7 @@
     if (!key) {
         return;
     }
-    NSArray<id<SDWebImageCache>> *caches = [self.caches copy];
+    NSArray<id<SDImageCache>> *caches = [self.caches copy];
     NSUInteger count = caches.count;
     if (count == 0) {
         return;
@@ -174,12 +174,12 @@
     }
     switch (self.storeOperationPolicy) {
         case SDImageCachesManagerOperationPolicyHighestOnly: {
-            id<SDWebImageCache> cache = caches.lastObject;
+            id<SDImageCache> cache = caches.lastObject;
             [cache storeImage:image imageData:imageData forKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
         case SDImageCachesManagerOperationPolicyLowestOnly: {
-            id<SDWebImageCache> cache = caches.firstObject;
+            id<SDImageCache> cache = caches.firstObject;
             [cache storeImage:image imageData:imageData forKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
@@ -202,7 +202,7 @@
     if (!key) {
         return;
     }
-    NSArray<id<SDWebImageCache>> *caches = [self.caches copy];
+    NSArray<id<SDImageCache>> *caches = [self.caches copy];
     NSUInteger count = caches.count;
     if (count == 0) {
         return;
@@ -212,12 +212,12 @@
     }
     switch (self.removeOperationPolicy) {
         case SDImageCachesManagerOperationPolicyHighestOnly: {
-            id<SDWebImageCache> cache = caches.lastObject;
+            id<SDImageCache> cache = caches.lastObject;
             [cache removeImageForKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
         case SDImageCachesManagerOperationPolicyLowestOnly: {
-            id<SDWebImageCache> cache = caches.firstObject;
+            id<SDImageCache> cache = caches.firstObject;
             [cache removeImageForKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
@@ -240,7 +240,7 @@
     if (!key) {
         return;
     }
-    NSArray<id<SDWebImageCache>> *caches = [self.caches copy];
+    NSArray<id<SDImageCache>> *caches = [self.caches copy];
     NSUInteger count = caches.count;
     if (count == 0) {
         return;
@@ -250,12 +250,12 @@
     }
     switch (self.clearOperationPolicy) {
         case SDImageCachesManagerOperationPolicyHighestOnly: {
-            id<SDWebImageCache> cache = caches.lastObject;
+            id<SDImageCache> cache = caches.lastObject;
             [cache containsImageForKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
         case SDImageCachesManagerOperationPolicyLowestOnly: {
-            id<SDWebImageCache> cache = caches.firstObject;
+            id<SDImageCache> cache = caches.firstObject;
             [cache containsImageForKey:key cacheType:cacheType completion:completionBlock];
         }
             break;
@@ -277,7 +277,7 @@
 }
 
 - (void)clearWithCacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock {
-    NSArray<id<SDWebImageCache>> *caches = [self.caches copy];
+    NSArray<id<SDImageCache>> *caches = [self.caches copy];
     NSUInteger count = caches.count;
     if (count == 0) {
         return;
@@ -287,12 +287,12 @@
     }
     switch (self.clearOperationPolicy) {
         case SDImageCachesManagerOperationPolicyHighestOnly: {
-            id<SDWebImageCache> cache = caches.lastObject;
+            id<SDImageCache> cache = caches.lastObject;
             [cache clearWithCacheType:cacheType completion:completionBlock];
         }
             break;
         case SDImageCachesManagerOperationPolicyLowestOnly: {
-            id<SDWebImageCache> cache = caches.firstObject;
+            id<SDImageCache> cache = caches.firstObject;
             [cache clearWithCacheType:cacheType completion:completionBlock];
         }
             break;
@@ -313,10 +313,10 @@
 
 #pragma mark - Concurrent Operation
 
-- (void)concurrentQueryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
+- (void)concurrentQueryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
-    for (id<SDWebImageCache> cache in enumerator) {
+    for (id<SDImageCache> cache in enumerator) {
         [cache queryImageForKey:key options:options context:context completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
             if (operation.isCancelled) {
                 // Cancelled
@@ -346,10 +346,10 @@
     }
 }
 
-- (void)concurrentStoreImage:(UIImage *)image imageData:(NSData *)imageData forKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
+- (void)concurrentStoreImage:(UIImage *)image imageData:(NSData *)imageData forKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
-    for (id<SDWebImageCache> cache in enumerator) {
+    for (id<SDImageCache> cache in enumerator) {
         [cache storeImage:image imageData:imageData forKey:key cacheType:cacheType completion:^{
             if (operation.isCancelled) {
                 // Cancelled
@@ -371,10 +371,10 @@
     }
 }
 
-- (void)concurrentRemoveImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
+- (void)concurrentRemoveImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
-    for (id<SDWebImageCache> cache in enumerator) {
+    for (id<SDImageCache> cache in enumerator) {
         [cache removeImageForKey:key cacheType:cacheType completion:^{
             if (operation.isCancelled) {
                 // Cancelled
@@ -396,10 +396,10 @@
     }
 }
 
-- (void)concurrentContainsImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDImageCacheContainsCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
+- (void)concurrentContainsImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDImageCacheContainsCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
-    for (id<SDWebImageCache> cache in enumerator) {
+    for (id<SDImageCache> cache in enumerator) {
         [cache containsImageForKey:key cacheType:cacheType completion:^(SDImageCacheType containsCacheType) {
             if (operation.isCancelled) {
                 // Cancelled
@@ -429,10 +429,10 @@
     }
 }
 
-- (void)concurrentClearWithCacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
+- (void)concurrentClearWithCacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
-    for (id<SDWebImageCache> cache in enumerator) {
+    for (id<SDImageCache> cache in enumerator) {
         [cache clearWithCacheType:cacheType completion:^{
             if (operation.isCancelled) {
                 // Cancelled
@@ -456,10 +456,10 @@
 
 #pragma mark - Serial Operation
 
-- (void)serialQueryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
+- (void)serialQueryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
-    id<SDWebImageCache> cache = enumerator.nextObject;
+    id<SDImageCache> cache = enumerator.nextObject;
     if (!cache) {
         // Complete
         [operation done];
@@ -492,9 +492,9 @@
     }];
 }
 
-- (void)serialStoreImage:(UIImage *)image imageData:(NSData *)imageData forKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator {
+- (void)serialStoreImage:(UIImage *)image imageData:(NSData *)imageData forKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDImageCache>> *)enumerator {
     NSParameterAssert(enumerator);
-    id<SDWebImageCache> cache = enumerator.nextObject;
+    id<SDImageCache> cache = enumerator.nextObject;
     if (!cache) {
         // Complete
         if (completionBlock) {
@@ -509,9 +509,9 @@
     }];
 }
 
-- (void)serialRemoveImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator {
+- (void)serialRemoveImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDImageCache>> *)enumerator {
     NSParameterAssert(enumerator);
-    id<SDWebImageCache> cache = enumerator.nextObject;
+    id<SDImageCache> cache = enumerator.nextObject;
     if (!cache) {
         // Complete
         if (completionBlock) {
@@ -526,10 +526,10 @@
     }];
 }
 
-- (void)serialContainsImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDImageCacheContainsCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
+- (void)serialContainsImageForKey:(NSString *)key cacheType:(SDImageCacheType)cacheType completion:(SDImageCacheContainsCompletionBlock)completionBlock enumerator:(NSEnumerator<id<SDImageCache>> *)enumerator operation:(SDImageCachesManagerOperation *)operation {
     NSParameterAssert(enumerator);
     NSParameterAssert(operation);
-    id<SDWebImageCache> cache = enumerator.nextObject;
+    id<SDImageCache> cache = enumerator.nextObject;
     if (!cache) {
         // Complete
         [operation done];
@@ -562,9 +562,9 @@
     }];
 }
 
-- (void)serialClearWithCacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDWebImageCache>> *)enumerator {
+- (void)serialClearWithCacheType:(SDImageCacheType)cacheType completion:(SDWebImageNoParamsBlock)completionBlock enumerator:(NSEnumerator<id<SDImageCache>> *)enumerator {
     NSParameterAssert(enumerator);
-    id<SDWebImageCache> cache = enumerator.nextObject;
+    id<SDImageCache> cache = enumerator.nextObject;
     if (!cache) {
         // Complete
         if (completionBlock) {

--- a/SDWebImage/SDImageCachesManager.m
+++ b/SDWebImage/SDImageCachesManager.m
@@ -116,7 +116,7 @@
     self.caches = [mutableCaches copy];
 }
 
-#pragma mark - SDWebImageCache
+#pragma mark - SDImageCache
 
 - (id<SDWebImageOperation>)queryImageForKey:(NSString *)key options:(SDWebImageOptions)options context:(SDWebImageContext *)context completion:(SDImageCacheQueryCompletionBlock)completionBlock {
     if (!key) {

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -8,7 +8,7 @@
 
 #import "SDWebImageCompat.h"
 #import "SDWebImageOperation.h"
-#import "SDWebImageCache.h"
+#import "SDImageCacheDefine.h"
 #import "SDWebImageDownloader.h"
 #import "SDWebImageTransformer.h"
 #import "SDWebImageCacheKeyFilter.h"
@@ -99,7 +99,7 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
 /**
  * The image cache used by manager to query image cache.
  */
-@property (strong, nonatomic, readonly, nonnull) id<SDWebImageCache> imageCache;
+@property (strong, nonatomic, readonly, nonnull) id<SDImageCache> imageCache;
 
 /**
  * The image downloader used by manager to download image.
@@ -158,7 +158,7 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
  The default image cache when the manager which is created with no arguments. Such as shared manager or init.
  Defaults to nil. Means using `SDImageCache.sharedImageCache`
  */
-@property (nonatomic, class, nullable) id<SDWebImageCache> defaultImageCache;
+@property (nonatomic, class, nullable) id<SDImageCache> defaultImageCache;
 
 /**
  The default image downloader for manager which is created with no arguments. Such as shared manager or init.
@@ -175,7 +175,7 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
  * Allows to specify instance of cache and image downloader used with image manager.
  * @return new instance of `SDWebImageManager` with specified cache and downloader.
  */
-- (nonnull instancetype)initWithCache:(nonnull id<SDWebImageCache>)cache downloader:(nonnull SDWebImageDownloader *)downloader NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithCache:(nonnull id<SDImageCache>)cache downloader:(nonnull SDWebImageDownloader *)downloader NS_DESIGNATED_INITIALIZER;
 
 /**
  * Downloads the image at the given URL if not present in cache or return the cached version otherwise.

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -13,7 +13,7 @@
 #import "SDAnimatedImage.h"
 #import "SDWebImageError.h"
 
-static id<SDWebImageCache> _defaultImageCache;
+static id<SDImageCache> _defaultImageCache;
 static SDWebImageDownloader *_defaultImageDownloader;
 
 @interface SDWebImageCombinedOperation ()
@@ -36,12 +36,12 @@ static SDWebImageDownloader *_defaultImageDownloader;
 
 @implementation SDWebImageManager
 
-+ (id<SDWebImageCache>)defaultImageCache {
++ (id<SDImageCache>)defaultImageCache {
     return _defaultImageCache;
 }
 
-+ (void)setDefaultImageCache:(id<SDWebImageCache>)defaultImageCache {
-    if (defaultImageCache && ![defaultImageCache conformsToProtocol:@protocol(SDWebImageCache)]) {
++ (void)setDefaultImageCache:(id<SDImageCache>)defaultImageCache {
+    if (defaultImageCache && ![defaultImageCache conformsToProtocol:@protocol(SDImageCache)]) {
         return;
     }
     _defaultImageCache = defaultImageCache;
@@ -68,7 +68,7 @@ static SDWebImageDownloader *_defaultImageDownloader;
 }
 
 - (nonnull instancetype)init {
-    id<SDWebImageCache> cache = [[self class] defaultImageCache];
+    id<SDImageCache> cache = [[self class] defaultImageCache];
     if (!cache) {
         cache = [SDImageCache sharedImageCache];
     }
@@ -79,7 +79,7 @@ static SDWebImageDownloader *_defaultImageDownloader;
     return [self initWithCache:cache downloader:downloader];
 }
 
-- (nonnull instancetype)initWithCache:(nonnull id<SDWebImageCache>)cache downloader:(nonnull SDWebImageDownloader *)downloader {
+- (nonnull instancetype)initWithCache:(nonnull id<SDImageCache>)cache downloader:(nonnull SDWebImageDownloader *)downloader {
     if ((self = [super init])) {
         _imageCache = cache;
         _imageDownloader = downloader;

--- a/Tests/Tests/SDImageCacheTests.m
+++ b/Tests/Tests/SDImageCacheTests.m
@@ -9,7 +9,7 @@
 #import "SDTestCase.h"
 #import <SDWebImage/SDImageCache.h>
 #import <SDWebImage/SDWebImageCodersManager.h>
-#import <SDWebImage/SDWebImageCachesManager.h>
+#import <SDWebImage/SDImageCachesManager.h>
 #import "SDWebImageTestDecoder.h"
 #import "SDMockFileManager.h"
 #import "SDWebImageTestCache.h"
@@ -30,11 +30,11 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
 @implementation SDImageCacheTests
 
 + (void)setUp {
-    [[SDWebImageCachesManager sharedManager] addCache:[SDImageCache sharedImageCache]];
+    [[SDImageCachesManager sharedManager] addCache:[SDImageCache sharedImageCache]];
 }
 
 + (void)tearDown {
-    [[SDWebImageCachesManager sharedManager] removeCache:[SDImageCache sharedImageCache]];
+    [[SDImageCachesManager sharedManager] removeCache:[SDImageCache sharedImageCache]];
 }
 
 - (void)test01SharedImageCache {
@@ -362,20 +362,20 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     expect([diskCache isKindOfClass:[SDWebImageTestDiskCache class]]).to.beTruthy();
 }
 
-#pragma mark - SDWebImageCache & SDWebImageCachesManager
-- (void)test50SDWebImageCacheQueryOp {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"SDWebImageCache query op works"];
+#pragma mark - SDImageCache & SDImageCachesManager
+- (void)test50SDImageCacheQueryOp {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"SDImageCache query op works"];
     [[SDImageCache sharedImageCache] storeImage:[self testJPEGImage] forKey:kTestImageKeyJPEG toDisk:NO completion:nil];
-    [[SDWebImageCachesManager sharedManager] queryImageForKey:kTestImageKeyJPEG options:0 context:nil completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
+    [[SDImageCachesManager sharedManager] queryImageForKey:kTestImageKeyJPEG options:0 context:nil completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         expect(image).notTo.beNil();
         [expectation fulfill];
     }];
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)test51SDWebImageCacheStoreOp {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"SDWebImageCache store op works"];
-    [[SDWebImageCachesManager sharedManager] storeImage:[self testJPEGImage] imageData:nil forKey:kTestImageKeyJPEG cacheType:SDImageCacheTypeAll completion:^{
+- (void)test51SDImageCacheStoreOp {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"SDImageCache store op works"];
+    [[SDImageCachesManager sharedManager] storeImage:[self testJPEGImage] imageData:nil forKey:kTestImageKeyJPEG cacheType:SDImageCacheTypeAll completion:^{
         UIImage *image = [[SDImageCache sharedImageCache] imageFromMemoryCacheForKey:kTestImageKeyJPEG];
         expect(image).notTo.beNil();
         [[SDImageCache sharedImageCache] diskImageExistsWithKey:kTestImageKeyJPEG completion:^(BOOL isInCache) {
@@ -386,9 +386,9 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)test52SDWebImageCacheRemoveOp {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"SDWebImageCache remove op works"];
-    [[SDWebImageCachesManager sharedManager] removeImageForKey:kTestImageKeyJPEG cacheType:SDImageCacheTypeDisk completion:^{
+- (void)test52SDImageCacheRemoveOp {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"SDImageCache remove op works"];
+    [[SDImageCachesManager sharedManager] removeImageForKey:kTestImageKeyJPEG cacheType:SDImageCacheTypeDisk completion:^{
         UIImage *memoryImage = [[SDImageCache sharedImageCache] imageFromMemoryCacheForKey:kTestImageKeyJPEG];
         expect(memoryImage).notTo.beNil();
         [[SDImageCache sharedImageCache] diskImageExistsWithKey:kTestImageKeyJPEG completion:^(BOOL isInCache) {
@@ -399,18 +399,18 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)test53SDWebImageCacheContainsOp {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"SDWebImageCache contains op works"];
-    [[SDWebImageCachesManager sharedManager] containsImageForKey:kTestImageKeyJPEG cacheType:SDImageCacheTypeAll completion:^(SDImageCacheType containsCacheType) {
+- (void)test53SDImageCacheContainsOp {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"SDImageCache contains op works"];
+    [[SDImageCachesManager sharedManager] containsImageForKey:kTestImageKeyJPEG cacheType:SDImageCacheTypeAll completion:^(SDImageCacheType containsCacheType) {
         expect(containsCacheType).equal(SDImageCacheTypeMemory);
         [expectation fulfill];
     }];
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)test54SDWebImageCacheClearOp {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"SDWebImageCache clear op works"];
-    [[SDWebImageCachesManager sharedManager] clearWithCacheType:SDImageCacheTypeAll completion:^{
+- (void)test54SDImageCacheClearOp {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"SDImageCache clear op works"];
+    [[SDImageCachesManager sharedManager] clearWithCacheType:SDImageCacheTypeAll completion:^{
         UIImage *memoryImage = [[SDImageCache sharedImageCache] imageFromMemoryCacheForKey:kTestImageKeyJPEG];
         expect(memoryImage).to.beNil();
         [[SDImageCache sharedImageCache] diskImageExistsWithKey:kTestImageKeyJPEG completion:^(BOOL isInCache) {
@@ -421,8 +421,8 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)test55SDWebImageCachesManagerOperationPolicySimple {
-    SDWebImageCachesManager *cachesManager = [[SDWebImageCachesManager alloc] init];
+- (void)test55SDImageCachesManagerOperationPolicySimple {
+    SDImageCachesManager *cachesManager = [[SDImageCachesManager alloc] init];
     SDImageCache *cache1 = [[SDImageCache alloc] initWithNamespace:@"cache1"];
     SDImageCache *cache2 = [[SDImageCache alloc] initWithNamespace:@"cache2"];
     [cachesManager addCache:cache1];
@@ -432,11 +432,11 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [[NSFileManager defaultManager] removeItemAtPath:cache2.diskCachePath error:nil];
     
     // LowestOnly
-    cachesManager.queryOperationPolicy = SDWebImageCachesManagerOperationPolicyLowestOnly;
-    cachesManager.storeOperationPolicy = SDWebImageCachesManagerOperationPolicyLowestOnly;
-    cachesManager.removeOperationPolicy = SDWebImageCachesManagerOperationPolicyLowestOnly;
-    cachesManager.containsOperationPolicy = SDWebImageCachesManagerOperationPolicyLowestOnly;
-    cachesManager.clearOperationPolicy = SDWebImageCachesManagerOperationPolicyLowestOnly;
+    cachesManager.queryOperationPolicy = SDImageCachesManagerOperationPolicyLowestOnly;
+    cachesManager.storeOperationPolicy = SDImageCachesManagerOperationPolicyLowestOnly;
+    cachesManager.removeOperationPolicy = SDImageCachesManagerOperationPolicyLowestOnly;
+    cachesManager.containsOperationPolicy = SDImageCachesManagerOperationPolicyLowestOnly;
+    cachesManager.clearOperationPolicy = SDImageCachesManagerOperationPolicyLowestOnly;
     [cachesManager queryImageForKey:kTestImageKeyJPEG options:0 context:nil completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         expect(image).to.beNil();
     }];
@@ -451,11 +451,11 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [cachesManager clearWithCacheType:SDImageCacheTypeMemory completion:nil];
     
     // HighestOnly
-    cachesManager.queryOperationPolicy = SDWebImageCachesManagerOperationPolicyHighestOnly;
-    cachesManager.storeOperationPolicy = SDWebImageCachesManagerOperationPolicyHighestOnly;
-    cachesManager.removeOperationPolicy = SDWebImageCachesManagerOperationPolicyHighestOnly;
-    cachesManager.containsOperationPolicy = SDWebImageCachesManagerOperationPolicyHighestOnly;
-    cachesManager.clearOperationPolicy = SDWebImageCachesManagerOperationPolicyHighestOnly;
+    cachesManager.queryOperationPolicy = SDImageCachesManagerOperationPolicyHighestOnly;
+    cachesManager.storeOperationPolicy = SDImageCachesManagerOperationPolicyHighestOnly;
+    cachesManager.removeOperationPolicy = SDImageCachesManagerOperationPolicyHighestOnly;
+    cachesManager.containsOperationPolicy = SDImageCachesManagerOperationPolicyHighestOnly;
+    cachesManager.clearOperationPolicy = SDImageCachesManagerOperationPolicyHighestOnly;
     [cachesManager queryImageForKey:kTestImageKeyPNG options:0 context:nil completion:^(UIImage * _Nullable image, NSData * _Nullable data, SDImageCacheType cacheType) {
         expect(image).to.beNil();
     }];
@@ -470,9 +470,9 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [cachesManager clearWithCacheType:SDImageCacheTypeMemory completion:nil];
 }
 
-- (void)test56SDWebImageCachesManagerOperationPolicyConcurrent {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"SDWebImageCachesManager operation cocurrent policy works"];
-    SDWebImageCachesManager *cachesManager = [[SDWebImageCachesManager alloc] init];
+- (void)test56SDImageCachesManagerOperationPolicyConcurrent {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"SDImageCachesManager operation cocurrent policy works"];
+    SDImageCachesManager *cachesManager = [[SDImageCachesManager alloc] init];
     SDImageCache *cache1 = [[SDImageCache alloc] initWithNamespace:@"cache1"];
     SDImageCache *cache2 = [[SDImageCache alloc] initWithNamespace:@"cache2"];
     [cachesManager addCache:cache1];
@@ -485,11 +485,11 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     
     // Cocurrent
     // Check all concurrent op
-    cachesManager.queryOperationPolicy = SDWebImageCachesManagerOperationPolicyConcurrent;
-    cachesManager.storeOperationPolicy = SDWebImageCachesManagerOperationPolicyConcurrent;
-    cachesManager.removeOperationPolicy = SDWebImageCachesManagerOperationPolicyConcurrent;
-    cachesManager.containsOperationPolicy = SDWebImageCachesManagerOperationPolicyConcurrent;
-    cachesManager.clearOperationPolicy = SDWebImageCachesManagerOperationPolicyConcurrent;
+    cachesManager.queryOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
+    cachesManager.storeOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
+    cachesManager.removeOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
+    cachesManager.containsOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
+    cachesManager.clearOperationPolicy = SDImageCachesManagerOperationPolicyConcurrent;
     [cachesManager queryImageForKey:kConcurrentTestImageKey options:0 context:nil completion:nil];
     [cachesManager storeImage:[self testJPEGImage] imageData:nil forKey:kConcurrentTestImageKey cacheType:SDImageCacheTypeMemory completion:nil];
     [cachesManager removeImageForKey:kConcurrentTestImageKey cacheType:SDImageCacheTypeMemory completion:nil];
@@ -511,9 +511,9 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     [self waitForExpectationsWithCommonTimeout];
 }
 
-- (void)test57SDWebImageCachesManagerOperationPolicySerial {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"SDWebImageCachesManager operation serial policy works"];
-    SDWebImageCachesManager *cachesManager = [[SDWebImageCachesManager alloc] init];
+- (void)test57SDImageCachesManagerOperationPolicySerial {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"SDImageCachesManager operation serial policy works"];
+    SDImageCachesManager *cachesManager = [[SDImageCachesManager alloc] init];
     SDImageCache *cache1 = [[SDImageCache alloc] initWithNamespace:@"cache1"];
     SDImageCache *cache2 = [[SDImageCache alloc] initWithNamespace:@"cache2"];
     [cachesManager addCache:cache1];
@@ -526,11 +526,11 @@ static NSString *kTestImageKeyPNG = @"TestImageKey.png";
     
     // Serial
     // Check all serial op
-    cachesManager.queryOperationPolicy = SDWebImageCachesManagerOperationPolicySerial;
-    cachesManager.storeOperationPolicy = SDWebImageCachesManagerOperationPolicySerial;
-    cachesManager.removeOperationPolicy = SDWebImageCachesManagerOperationPolicySerial;
-    cachesManager.containsOperationPolicy = SDWebImageCachesManagerOperationPolicySerial;
-    cachesManager.clearOperationPolicy = SDWebImageCachesManagerOperationPolicySerial;
+    cachesManager.queryOperationPolicy = SDImageCachesManagerOperationPolicySerial;
+    cachesManager.storeOperationPolicy = SDImageCachesManagerOperationPolicySerial;
+    cachesManager.removeOperationPolicy = SDImageCachesManagerOperationPolicySerial;
+    cachesManager.containsOperationPolicy = SDImageCachesManagerOperationPolicySerial;
+    cachesManager.clearOperationPolicy = SDImageCachesManagerOperationPolicySerial;
     [cachesManager queryImageForKey:kSerialTestImageKey options:0 context:nil completion:nil];
     [cachesManager storeImage:[self testJPEGImage] imageData:nil forKey:kSerialTestImageKey cacheType:SDImageCacheTypeMemory completion:nil];
     [cachesManager removeImageForKey:kSerialTestImageKey cacheType:SDImageCacheTypeMemory completion:nil];

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -28,8 +28,8 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/SDImageCache.h>
 #import <SDWebImage/SDMemoryCache.h>
 #import <SDWebImage/SDDiskCache.h>
-#import <SDWebImage/SDWebImageCache.h>
-#import <SDWebImage/SDWebImageCachesManager.h>
+#import <SDWebImage/SDImageCacheDefine.h>
+#import <SDWebImage/SDImageCachesManager.h>
 #import <SDWebImage/UIView+WebCache.h>
 #import <SDWebImage/UIImageView+WebCache.h>
 #import <SDWebImage/UIImageView+HighlightedWebCache.h>


### PR DESCRIPTION
Without all `Web` prefix

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Renaming all `SDWebImageCache` -> `SDImageCache`. `SDWebImageCachesManager` -> `SDImageCachesManager`

This may be my fault. Because previously I treat this `SDWebImageCache` protocol, as a `bridge` methods collection just for `SDWebImageManager` but not common usage. And currently it's actually only be used for `manager` instance though our hole framework. So I add the prefix `Web` there.

But it seems that cache is not related to Web network request. Maybe we can just remove all `Web` prefix, let user to choose to use the protocol for anything other than `WebManager`.

