### PR TITLE
Renaming progressive load

### DIFF
--- a/Examples/SDWebImage Demo/DetailViewController.m
+++ b/Examples/SDWebImage Demo/DetailViewController.m
@@ -24,7 +24,7 @@
     }
     [self.imageView sd_setImageWithURL:self.imageURL
                       placeholderImage:nil
-                               options:SDWebImageProgressiveDownload];
+                               options:SDWebImageProgressiveLoad];
 }
 
 - (void)viewDidLoad

--- a/Examples/SDWebImage OSX Demo/ViewController.m
+++ b/Examples/SDWebImage OSX Demo/ViewController.m
@@ -29,7 +29,7 @@
     self.imageView3.animates = YES;
     self.imageView4.animates = YES;
     self.imageView1.sd_imageIndicator = SDWebImageProgressIndicator.defaultIndicator;
-    [self.imageView1 sd_setImageWithURL:[NSURL URLWithString:@"https://raw.githubusercontent.com/recurser/exif-orientation-examples/master/Landscape_2.jpg"] placeholderImage:nil options:SDWebImageProgressiveDownload];
+    [self.imageView1 sd_setImageWithURL:[NSURL URLWithString:@"https://raw.githubusercontent.com/recurser/exif-orientation-examples/master/Landscape_2.jpg"] placeholderImage:nil options:SDWebImageProgressiveLoad];
     [self.imageView2 sd_setImageWithURL:[NSURL URLWithString:@"https:raw.githubusercontent.com/onevcat/APNGKit/master/TestImages/APNG-cube.apng"]];
     [self.imageView3 sd_setImageWithURL:[NSURL URLWithString:@"https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"]];
     self.imageView4.wantsLayer = YES;

--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -70,7 +70,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
      * This flag enables progressive download, the image is displayed progressively during download as a browser would do.
      * By default, the image is only displayed once completely downloaded.
      */
-    SDWebImageProgressiveDownload = 1 << 3,
+    SDWebImageProgressiveLoad = 1 << 3,
     
     /**
      * Even if the image is cached, respect the HTTP response cache control, and refresh the image from remote location if needed.
@@ -128,7 +128,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     /**
      * By default, images are decoded respecting their original size. On iOS, this flag will scale down the
      * images to a size compatible with the constrained memory of devices.
-     * This flag take no effect if `SDWebImageAvoidDecodeImage` is set. And it will be ignored if `SDWebImageProgressiveDownload` is set.
+     * This flag take no effect if `SDWebImageAvoidDecodeImage` is set. And it will be ignored if `SDWebImageProgressiveLoad` is set.
      */
     SDWebImageScaleDownLargeImages = 1 << 12,
     

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -23,7 +23,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     /**
      * This flag enables progressive download, the image is displayed progressively during download as a browser would do.
      */
-    SDWebImageDownloaderProgressiveDownload = 1 << 1,
+    SDWebImageDownloaderProgressiveLoad = 1 << 1,
 
     /**
      * By default, request prevent the use of NSURLCache. With this flag, NSURLCache
@@ -64,7 +64,7 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
     /**
      * By default, images are decoded respecting their original size. On iOS, this flag will scale down the
      * images to a size compatible with the constrained memory of devices.
-     * This flag take no effect if `SDWebImageDownloaderAvoidDecodeImage` is set. And it will be ignored if `SDWebImageDownloaderProgressiveDownload` is set.
+     * This flag take no effect if `SDWebImageDownloaderAvoidDecodeImage` is set. And it will be ignored if `SDWebImageDownloaderProgressiveLoad` is set.
      */
     SDWebImageDownloaderScaleDownLargeImages = 1 << 8,
     
@@ -197,8 +197,8 @@ typedef SDWebImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
  * @param completedBlock A block called once the download is completed.
  *                       If the download succeeded, the image parameter is set, in case of error,
  *                       error parameter is set with the error. The last parameter is always YES
- *                       if SDWebImageDownloaderProgressiveDownload isn't use. With the
- *                       SDWebImageDownloaderProgressiveDownload option, this block is called
+ *                       if SDWebImageDownloaderProgressiveLoad isn't use. With the
+ *                       SDWebImageDownloaderProgressiveLoad option, this block is called
  *                       repeatedly with the partial image object and the finished argument set to NO
  *                       before to be called a last time with the full image and finished argument
  *                       set to YES. In case of error, the finished argument is always YES.

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -480,7 +480,7 @@ didReceiveResponse:(NSURLResponse *)response
     }
     SDWebImageDownloaderOptions downloaderOptions = 0;
     if (options & SDWebImageLowPriority) downloaderOptions |= SDWebImageDownloaderLowPriority;
-    if (options & SDWebImageProgressiveDownload) downloaderOptions |= SDWebImageDownloaderProgressiveDownload;
+    if (options & SDWebImageProgressiveLoad) downloaderOptions |= SDWebImageDownloaderProgressiveLoad;
     if (options & SDWebImageRefreshCached) downloaderOptions |= SDWebImageDownloaderUseNSURLCache;
     if (options & SDWebImageContinueInBackground) downloaderOptions |= SDWebImageDownloaderContinueInBackground;
     if (options & SDWebImageHandleCookies) downloaderOptions |= SDWebImageDownloaderHandleCookies;
@@ -490,7 +490,7 @@ didReceiveResponse:(NSURLResponse *)response
     
     if (cachedImage && options & SDWebImageRefreshCached) {
         // force progressive off if image already cached but forced refreshing
-        downloaderOptions &= ~SDWebImageDownloaderProgressiveDownload;
+        downloaderOptions &= ~SDWebImageDownloaderProgressiveLoad;
         // ignore image read from NSURLCache if image if cached but force refreshing
         downloaderOptions |= SDWebImageDownloaderIgnoreCachedResponse;
     }

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -335,7 +335,7 @@ didReceiveResponse:(NSURLResponse *)response
     }
     [self.imageData appendData:data];
 
-    if ((self.options & SDWebImageDownloaderProgressiveDownload) && self.expectedSize > 0) {
+    if ((self.options & SDWebImageDownloaderProgressiveLoad) && self.expectedSize > 0) {
         // Get the image data
         NSData *imageData = [self.imageData copy];
         // Get the total bytes downloaded

--- a/SDWebImage/SDWebImageLoader.h
+++ b/SDWebImage/SDWebImageLoader.h
@@ -38,7 +38,7 @@ FOUNDATION_EXPORT SDWebImageContextOption _Nonnull const SDWebImageContextLoader
 FOUNDATION_EXPORT UIImage * _Nullable SDWebImageLoaderDecodeImageData(NSData * _Nonnull imageData, NSURL * _Nonnull imageURL, SDWebImageOptions options, SDWebImageContext * _Nullable context);
 
 /**
- This is the built-in decoding process for image progressive download from network. It's used when `SDWebImageProgressiveDownload` option is set. (It's not required when your loader does not support progressive image loading)
+ This is the built-in decoding process for image progressive download from network. It's used when `SDWebImageProgressiveLoad` option is set. (It's not required when your loader does not support progressive image loading)
  @note If you want to implement your custom loader with `loadImageWithURL:options:context:progress:completed:` API, but also want to keep compatible with SDWebImage's behavior, you'd better use this to produce image.
 
  @param imageData The image data from the network so far. Should not be nil

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -19,23 +19,23 @@ typedef void(^SDExternalCompletionBlock)(UIImage * _Nullable image, NSError * _N
 
 typedef void(^SDInternalCompletionBlock)(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL);
 
-// A combined operation representing the cache and download operation. You can it to cancel the load process.
+// A combined operation representing the cache and loader operation. You can it to cancel the load process.
 @interface SDWebImageCombinedOperation : NSObject <SDWebImageOperation>
 
 /**
- Cancel the current operation, including cache and download process
+ Cancel the current operation, including cache and loader process
  */
 - (void)cancel;
 
 /**
- The cache operation used for image cache query
+ The cache operation from the image cache query
  */
 @property (strong, nonatomic, nullable, readonly) id<SDWebImageOperation> cacheOperation;
 
 /**
- The download operation if the image is download from the network
+ The loader operation from the image loader (such as download operation)
  */
-@property (strong, nonatomic, nullable, readonly) id<SDWebImageOperation> downloadOperation;
+@property (strong, nonatomic, nullable, readonly) id<SDWebImageOperation> loaderOperation;
 
 @end
 

--- a/SDWebImage/SDWebImageManager.h
+++ b/SDWebImage/SDWebImageManager.h
@@ -194,7 +194,7 @@ SDWebImageManager *manager = [SDWebImageManager sharedManager];
  *   The forth parameter is an `SDImageCacheType` enum indicating if the image was retrieved from the local cache
  *   or from the memory cache or from the network.
  *
- *   The fith parameter is set to NO when the SDWebImageProgressiveDownload option is used and the image is
+ *   The fith parameter is set to NO when the SDWebImageProgressiveLoad option is used and the image is
  *   downloading. This block is thus called repeatedly with a partial image. When image is fully downloaded, the
  *   block is called a last time with the full image and the last parameter set to YES.
  *

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -19,7 +19,7 @@ static id<SDWebImageLoader> _defaultImageLoader;
 @interface SDWebImageCombinedOperation ()
 
 @property (assign, nonatomic, getter = isCancelled) BOOL cancelled;
-@property (strong, nonatomic, readwrite, nullable) id<SDWebImageOperation> downloadOperation;
+@property (strong, nonatomic, readwrite, nullable) id<SDWebImageOperation> loaderOperation;
 @property (strong, nonatomic, readwrite, nullable) id<SDWebImageOperation> cacheOperation;
 @property (weak, nonatomic, nullable) SDWebImageManager *manager;
 
@@ -237,7 +237,7 @@ static id<SDWebImageLoader> _defaultImageLoader;
         
         // `SDWebImageCombinedOperation` -> `SDWebImageDownloadToken` -> `downloadOperationCancelToken`, which is a `SDCallbacksDictionary` and retain the completed block below, so we need weak-strong again to avoid retain cycle
         __weak typeof(operation) weakOperation = operation;
-        operation.downloadOperation = [self.imageLoader loadImageWithURL:url options:options context:context progress:progressBlock completed:^(UIImage *downloadedImage, NSData *downloadedData, NSError *error, BOOL finished) {
+        operation.loaderOperation = [self.imageLoader loadImageWithURL:url options:options context:context progress:progressBlock completed:^(UIImage *downloadedImage, NSData *downloadedData, NSError *error, BOOL finished) {
             __strong typeof(weakOperation) strongOperation = weakOperation;
             if (!strongOperation || strongOperation.isCancelled) {
                 // Do nothing if the operation was cancelled
@@ -404,9 +404,9 @@ static id<SDWebImageLoader> _defaultImageLoader;
             [self.cacheOperation cancel];
             self.cacheOperation = nil;
         }
-        if (self.downloadOperation) {
-            [self.downloadOperation cancel];
-            self.downloadOperation = nil;
+        if (self.loaderOperation) {
+            [self.loaderOperation cancel];
+            self.loaderOperation = nil;
         }
         [self.manager safelyRemoveOperationFromRunning:self];
     }

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -59,7 +59,7 @@ typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable ima
  *   The forth parameter is an `SDImageCacheType` enum indicating if the image was retrieved from the local cache
  *   or from the memory cache or from the network.
  *
- *   The fith parameter normally is always YES. However, if you provide SDWebImageAvoidAutoSetImage with SDWebImageProgressiveDownload options to enable progressive downloading and set the image yourself. This block is thus called repeatedly with a partial image. When image is fully downloaded, the
+ *   The fith parameter normally is always YES. However, if you provide SDWebImageAvoidAutoSetImage with SDWebImageProgressiveLoad options to enable progressive downloading and set the image yourself. This block is thus called repeatedly with a partial image. When image is fully downloaded, the
  *   block is called a last time with the full image and the last parameter set to YES.
  *
  *   The last parameter is the original image URL

--- a/Tests/Tests/SDAnimatedImageTest.m
+++ b/Tests/Tests/SDAnimatedImageTest.m
@@ -196,7 +196,7 @@ static const NSUInteger kTestGIFFrameCount = 5; // local TestImage.gif loop coun
     XCTestExpectation *expectation = [self expectationWithDescription:@"test SDAnimatedImageView view category"];
     SDAnimatedImageView *imageView = [SDAnimatedImageView new];
     NSURL *testURL = [NSURL URLWithString:kTestGIFURL];
-    [imageView sd_setImageWithURL:testURL placeholderImage:nil options:SDWebImageProgressiveDownload progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
+    [imageView sd_setImageWithURL:testURL placeholderImage:nil options:SDWebImageProgressiveLoad progress:^(NSInteger receivedSize, NSInteger expectedSize, NSURL * _Nullable targetURL) {
         dispatch_async(dispatch_get_main_queue(), ^{
             UIImage *image = imageView.image;
             // Progressive image may be nil when download data is not enough

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -136,7 +136,7 @@
 - (void)test09ThatProgressiveJPEGWorks {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Progressive JPEG download"];
     NSURL *imageURL = [NSURL URLWithString:kTestJpegURL];
-    [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL options:SDWebImageDownloaderProgressiveDownload progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
+    [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL options:SDWebImageDownloaderProgressiveLoad progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
         if (image && data && !error && finished) {
             [expectation fulfill];
         } else if (finished) {
@@ -251,7 +251,7 @@
 - (void)test16ThatProgressiveWebPWorks {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Progressive WebP download"];
     NSURL *imageURL = [NSURL URLWithString:@"http://www.ioncannon.net/wp-content/uploads/2011/06/test9.webp"];
-    [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL options:SDWebImageDownloaderProgressiveDownload progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
+    [[SDWebImageDownloader sharedDownloader] downloadImageWithURL:imageURL options:SDWebImageDownloaderProgressiveLoad progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
         if (image && data && !error && finished) {
             [expectation fulfill];
         } else if (finished) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: 

### Pull Request Description

I don't know whether this renaming is quite suitable. (Change options will break current API...Make user hard to migrate..I think users are our treasure)

But since now we have `SDWebImageLoader` protocol. And I'm build Photos framework extension using SDWebImage this feature. I accidentally run into this `ProgressiveDownload` options. I think we'd better renaming `SDWebImageProgressiveDownload` into `SDWebImageProgressiveLoad`. Which is more clear. And after change, that `SDWebImageDownloaderProgressiveDownload` downloader options will also express more clearly....

The [Photos framework extension](https://github.com/dreampiggy/SDWebImage-Photos) is almost done. Which currently point to 5.x branch of SD. That framework's naming can be considered to change. And I'll transfer that repo to [SDWebImage](https://github.com/SDWebImage) organization after that finished.  :)

(Currently I just writing code to finish the feature and fix for performance issue, this extension can be done even after 5.x release, since it does not break API).
