### PR TITLE
Refactor manager logic - Also suppoort ignore cache query

### DIFF
--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -145,31 +145,36 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageOptions) {
     SDWebImageQueryDiskSync = 1 << 14,
     
     /**
-     * By default, when the cache missed, the image is download from the network. This flag can prevent network to load from cache only.
+     * By default, when the cache missed, the image is load from the loader. This flag can prevent this to load from cache only.
      */
     SDWebImageFromCacheOnly = 1 << 15,
     
     /**
+     * By default, we query the cache before the image is load from the loader. This flag can prevent this to load from loader only.
+     */
+    SDWebImageFromLoaderOnly = 1 << 16,
+    
+    /**
      * By default, when you use `SDWebImageTransition` to do some view transition after the image load finished, this transition is only applied for image download from the network. This mask can force to apply view transition for memory and disk cache as well.
      */
-    SDWebImageForceTransition = 1 << 16,
+    SDWebImageForceTransition = 1 << 17,
     
     /**
      * By default, we will decode the image in the background during cache query and download from the network. This can help to improve performance because when rendering image on the screen, it need to be firstly decoded. But this happen on the main queue by Core Animation.
      * However, this process may increase the memory usage as well. If you are experiencing a issue due to excessive memory consumption, This flag can prevent decode the image.
      */
-    SDWebImageAvoidDecodeImage = 1 << 17,
+    SDWebImageAvoidDecodeImage = 1 << 18,
     
     /**
      * By default, we decode the animated image. This flag can force decode the first frame only and produece the static image.
      */
-    SDWebImageDecodeFirstFrameOnly = 1 << 18,
+    SDWebImageDecodeFirstFrameOnly = 1 << 19,
     
     /**
      * By default, for `SDAnimatedImage`, we decode the animated image frame during rendering to reduce memory usage. However, you can specify to preload all frames into memory to reduce CPU usage when the animated image is shared by lots of imageViews.
      * This will actually trigger `preloadAllAnimatedImageFrames` in the background queue(Disk Cache & Download only).
      */
-    SDWebImagePreloadAllFrames = 1 << 19
+    SDWebImagePreloadAllFrames = 1 << 20
 };
 
 

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -33,7 +33,8 @@ typedef NS_OPTIONS(NSUInteger, SDWebImageDownloaderOptions) {
 
     /**
      * Call completion block with nil image/imageData if the image was read from NSURLCache
-     * (to be combined with `SDWebImageDownloaderUseNSURLCache`).
+     * And the error code is `SDWebImageErrorCacheNotModified`
+     * This flag should be combined with `SDWebImageDownloaderUseNSURLCache`.
      */
     SDWebImageDownloaderIgnoreCachedResponse = 1 << 3,
     

--- a/SDWebImage/SDWebImageError.h
+++ b/SDWebImage/SDWebImageError.h
@@ -11,8 +11,12 @@
 
 FOUNDATION_EXPORT NSErrorDomain const _Nonnull SDWebImageErrorDomain;
 
+FOUNDATION_EXPORT NSErrorUserInfoKey const _Nonnull SDWebImageErrorDownloadStatusCodeKey;
+
 typedef NS_ERROR_ENUM(SDWebImageErrorDomain, SDWebImageError) {
     SDWebImageErrorInvalidURL = 1000, // The URL is invalid, such as nil URL or corrupted URL
     SDWebImageErrorBadImageData = 1001, // The image data can not be decoded to image, or the image data is empty
+    SDWebImageErrorCacheNotModified = 1002, // The remote location specify that the cached image is not modified, such as the HTTP response 304 code. It's useful for `SDWebImageRefreshCached`
     SDWebImageErrorInvalidDownloadOperation = 2000, // The image download operation is invalid, such as nil operation or unexpected error occur when operation initialized
+    SDWebImageErrorInvalidDownloadStatusCode = 2001, // The image downloda response a invalid status code. You can check the status code in error's userInfo under `SDWebImageErrorDownloadStatusCodeKey`
 };

--- a/SDWebImage/SDWebImageError.m
+++ b/SDWebImage/SDWebImageError.m
@@ -10,3 +10,4 @@
 #import "SDWebImageError.h"
 
 NSErrorDomain const _Nonnull SDWebImageErrorDomain = @"SDWebImageErrorDomain";
+NSErrorUserInfoKey const _Nonnull SDWebImageErrorDownloadStatusCodeKey = @"SDWebImageErrorDownloadStatusCodeKey";


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

### Reason

Our manager's implementation of that entry method `loadImageWithURL:options:context:progress:completed` seems contains too much logic. Especailly after we introduce the `Custom Cache` & `Custom Loader` protocol.

But recentlly I'm doing something about Photos framework loader. Photos framework 's best practice is to load the image without cache because they are all in the local disk files.

We alrady have a `SDWebImageFromCacheOnly` to only load image from cache. However, there are no equivalent options like `SDWebImageFromLoaderOnly`. If you don't want any cache query, you have no ways to do it from our current API for this.

However, if I want to implement this feauture (Since this will not break API). I will find it really really hard to implement this because we put all the logic into that cache query completion block......I try it but it's frastrating. So I think it's a time for refactory.

### Design

The refactor is more about implementation related. No public API  need to change. The basic design is to seperate the `loadImageWithURL:` huge process into some independent part. I can simply change it into 3 parts. `Context arg process`, `Cache query process`, `Download query process`.

### Implementation

```objective-c
- (SDWebImageContext *)processedContextWithContext:(SDWebImageContext *)context;

- (void)callCacheProcessForOperation:(nonnull SDWebImageCombinedOperation *)operation
                                 url:(nullable NSURL *)url
                             options:(SDWebImageOptions)options
                             context:(nullable SDWebImageContext *)context
                            progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                           completed:(nullable SDInternalCompletionBlock)completedBlock;

- (void)callDownloadProcessForOperation:(nonnull SDWebImageCombinedOperation *)operation
                                    url:(nullable NSURL *)url
                                options:(SDWebImageOptions)options
                                context:(SDWebImageContext *)context
                            cachedImage:(nullable UIImage *)cachedImage
                             cachedData:(nullable NSData *)cachedData
                              cacheType:(SDImageCacheType)cacheType
                               progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                              completed:(nullable SDInternalCompletionBlock)completedBlock;
```