### PR TITLE
Add the ability to custom the cache namespace prefix

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -59,7 +59,11 @@
                        diskCacheDirectory:(nonnull NSString *)directory
                                    config:(nullable SDImageCacheConfig *)config {
     if ((self = [super init])) {
-        NSString *fullNamespace = [@"com.hackemist.SDImageCache." stringByAppendingString:ns];
+        NSString *namespacePrefix = config.namespacePrefix;
+        if (!namespacePrefix) {
+            namespacePrefix = @"";
+        }
+        NSString *fullNamespace = [namespacePrefix stringByAppendingString:ns];
         
         // Create IO serial queue
         _ioQueue = dispatch_queue_create("com.hackemist.SDImageCache", DISPATCH_QUEUE_SERIAL);

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -73,6 +73,12 @@
 @property (assign, nonatomic) NSUInteger maxMemoryCount;
 
 /**
+ * The namespace prefix of cache. It's used to prefix the namespace you provide to the caches's initializer. You 'd better name it with reverse domain name notation and keep the final dot.
+ * Defautls to `com.hackemist.SDImageCache.`, which will prefix your namespace such as `default` to final `com.hackemist.SDImageCache.default`. If you specify nil, it will be treated equals to an empty string.
+ */
+@property (copy, nonatomic, nullable) NSString *namespacePrefix;
+
+/**
  * The custom file manager for disk cache. Pass nil to let disk cache choose the proper file manager.
  * Defaults to nil.
  * @note This value does not support dynamic changes. Which means further modification on this value after cache initlized has no effect.

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -32,6 +32,7 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
         _diskCacheWritingOptions = NSDataWritingAtomic;
         _maxCacheAge = kDefaultCacheMaxCacheAge;
         _maxCacheSize = 0;
+        _namespacePrefix = @"com.hackemist.SDImageCache.";
         _memoryCacheClass = [SDMemoryCache class];
         _diskCacheClass = [SDDiskCache class];
     }
@@ -49,6 +50,7 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
     config.maxCacheSize = self.maxCacheSize;
     config.maxMemoryCost = self.maxMemoryCost;
     config.maxMemoryCount = self.maxMemoryCount;
+    config.namespacePrefix = [self.namespacePrefix copyWithZone:zone];
     config.fileManager = self.fileManager; // NSFileManager does not conform to NSCopying, just pass the reference
     config.memoryCacheClass = self.memoryCacheClass;
     config.diskCacheClass = self.diskCacheClass;


### PR DESCRIPTION
Which allow user to specify the correct namespace prefix by their own

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: https://github.com/rs/SDWebImage/commit/a6bdba724e0ab0a8445aa23164845a6f1db054f1

### Pull Request Description

### Reason

In the previous renaming, we change the default image cache's prefix of namespace from `com.hackemist.SDWebImageCache.` to `com.hackemist.SDImageCache.`. However, we does not notice this will also cause the previous version of SDWebImage user will lost their cache folder because the we always `prefix` the namespace from the cache initializer arg.

### Design
We'd better provide a config for this instead of hard-coded the string into the implementation files. It's easy to do this, just using the `defaultCacheConfig` and provide a new property contains the prefix string. We recommend to use the [
Reverse domain name notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) and keep the final dot (.) charactor. However, if you want, you can just using something like `MyProject_`, and your namespace will final become `MyProject_default` and treat this as the disk cache folder. It's not a enforcement.

### Implementation

```objective-c
/**
 * The namespace prefix of cache. It's used to prefix the namespace you provide to the caches's initializer. You 'd better name it with reverse domain name notation and keep the final dot.
 * Defautls to `com.hackemist.SDImageCache.`, which will prefix your namespace such as `default` to final `com.hackemist.SDImageCache.default`.
 */
@property (copy, nonatomic, nonnull) NSString *namespacePrefix;
```

