### PR TITLE
Remove the duplicated process to force decode (draw on bitmap context) in Image/IO's progressive decoding.

### DIFF
--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -150,25 +150,6 @@
         // Create the image
         CGImageRef partialImageRef = CGImageSourceCreateImageAtIndex(_imageSource, 0, NULL);
         
-#if SD_UIKIT || SD_WATCH
-        // Workaround for iOS anamorphic image
-        if (partialImageRef) {
-            const size_t partialHeight = CGImageGetHeight(partialImageRef);
-            CGColorSpaceRef colorSpace = [SDWebImageCoderHelper colorSpaceGetDeviceRGB];
-            CGContextRef bmContext = CGBitmapContextCreate(NULL, _width, _height, 8, 0, colorSpace, kCGBitmapByteOrder32Host | kCGImageAlphaPremultipliedFirst);
-            if (bmContext) {
-                CGContextDrawImage(bmContext, (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = _width, .size.height = partialHeight}, partialImageRef);
-                CGImageRelease(partialImageRef);
-                partialImageRef = CGBitmapContextCreateImage(bmContext);
-                CGContextRelease(bmContext);
-            }
-            else {
-                CGImageRelease(partialImageRef);
-                partialImageRef = nil;
-            }
-        }
-#endif
-        
         if (partialImageRef) {
             CGFloat scale = _scale;
             if ([options valueForKey:SDWebImageCoderDecodeScaleFactor]) {


### PR DESCRIPTION
This is the bug in early version of Image/IO framework, but now it's already been fixed and duplicated process impact performance

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #1481

### Pull Request Description

### Reason
There seems a hack code to fix the issue about that `Workaround for iOS anamorphic image`. Which draw the image during progressive image decoding from `CGImageSourceCreateImageAtIndex`, into a bitmap context to `stretch` the full height. The original code is from [here](https://cocoaintheshell.whine.fr/2011/05/progressive-images-download-imageio/)

However, this fix seems only useful for the early version of iOS firmware and Image/IO framework. During my test, Image/IO works well for iOS 8 and above. The returned image always and already contains transparent space to fill the unfinished height of progressive decoding. (The pixel data is not enough to produce full height images). So there are no need to draw it again, which cause more CPU usage. The test result can be found there in #1481

I'd suggest to firstly merge in 5.x. This fix may not merge this into 4.x because it still supports iOS 7 and it's need another test later.