### PR TITLE
Renaming SDWebImageFrame & SDWebImageCoderHelper

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -458,18 +458,18 @@
 		328BB6D62082581100760D6C /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 328BB6C02082581100760D6C /* SDMemoryCache.m */; };
 		328BB6D72082581100760D6C /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 328BB6C02082581100760D6C /* SDMemoryCache.m */; };
 		328BB6D82082581100760D6C /* SDMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 328BB6C02082581100760D6C /* SDMemoryCache.m */; };
-		3290FA041FA478AF0047D20C /* SDWebImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDWebImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3290FA051FA478AF0047D20C /* SDWebImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDWebImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3290FA061FA478AF0047D20C /* SDWebImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDWebImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3290FA071FA478AF0047D20C /* SDWebImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDWebImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3290FA081FA478AF0047D20C /* SDWebImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDWebImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3290FA091FA478AF0047D20C /* SDWebImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDWebImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3290FA0A1FA478AF0047D20C /* SDWebImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDWebImageFrame.m */; };
-		3290FA0B1FA478AF0047D20C /* SDWebImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDWebImageFrame.m */; };
-		3290FA0C1FA478AF0047D20C /* SDWebImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDWebImageFrame.m */; };
-		3290FA0D1FA478AF0047D20C /* SDWebImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDWebImageFrame.m */; };
-		3290FA0E1FA478AF0047D20C /* SDWebImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDWebImageFrame.m */; };
-		3290FA0F1FA478AF0047D20C /* SDWebImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDWebImageFrame.m */; };
+		3290FA041FA478AF0047D20C /* SDImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3290FA051FA478AF0047D20C /* SDImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3290FA061FA478AF0047D20C /* SDImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3290FA071FA478AF0047D20C /* SDImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3290FA081FA478AF0047D20C /* SDImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3290FA091FA478AF0047D20C /* SDImageFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3290FA021FA478AF0047D20C /* SDImageFrame.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3290FA0A1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
+		3290FA0B1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
+		3290FA0C1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
+		3290FA0D1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
+		3290FA0E1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
+		3290FA0F1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
 		329A18591FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		329A185A1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		329A185B1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -506,18 +506,18 @@
 		32C0FDEA2013426C001B8F2D /* SDWebImageIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C0FDE02013426C001B8F2D /* SDWebImageIndicator.m */; };
 		32C0FDEB2013426C001B8F2D /* SDWebImageIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C0FDE02013426C001B8F2D /* SDWebImageIndicator.m */; };
 		32C0FDEC2013426C001B8F2D /* SDWebImageIndicator.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C0FDE02013426C001B8F2D /* SDWebImageIndicator.m */; };
-		32CF1C071FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32CF1C081FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32CF1C091FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32CF1C0A1FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32CF1C0B1FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32CF1C0C1FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		32CF1C0D1FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
-		32CF1C0E1FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
-		32CF1C0F1FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
-		32CF1C101FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
-		32CF1C111FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
-		32CF1C121FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */; };
+		32CF1C071FA496B000004BD1 /* SDImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32CF1C081FA496B000004BD1 /* SDImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32CF1C091FA496B000004BD1 /* SDImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32CF1C0A1FA496B000004BD1 /* SDImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32CF1C0B1FA496B000004BD1 /* SDImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32CF1C0C1FA496B000004BD1 /* SDImageCoderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 32CF1C051FA496B000004BD1 /* SDImageCoderHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32CF1C0D1FA496B000004BD1 /* SDImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDImageCoderHelper.m */; };
+		32CF1C0E1FA496B000004BD1 /* SDImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDImageCoderHelper.m */; };
+		32CF1C0F1FA496B000004BD1 /* SDImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDImageCoderHelper.m */; };
+		32CF1C101FA496B000004BD1 /* SDImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDImageCoderHelper.m */; };
+		32CF1C111FA496B000004BD1 /* SDImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDImageCoderHelper.m */; };
+		32CF1C121FA496B000004BD1 /* SDImageCoderHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 32CF1C061FA496B000004BD1 /* SDImageCoderHelper.m */; };
 		32D1221E2080B2EB003685A3 /* SDImageCacheDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D1221F2080B2EB003685A3 /* SDImageCacheDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32D122202080B2EB003685A3 /* SDImageCacheDefine.h in Headers */ = {isa = PBXBuildFile; fileRef = 32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1614,16 +1614,16 @@
 		328BB6BE2082581100760D6C /* SDDiskCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDDiskCache.m; sourceTree = "<group>"; };
 		328BB6BF2082581100760D6C /* SDMemoryCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDMemoryCache.h; sourceTree = "<group>"; };
 		328BB6C02082581100760D6C /* SDMemoryCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDMemoryCache.m; sourceTree = "<group>"; };
-		3290FA021FA478AF0047D20C /* SDWebImageFrame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageFrame.h; sourceTree = "<group>"; };
-		3290FA031FA478AF0047D20C /* SDWebImageFrame.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageFrame.m; sourceTree = "<group>"; };
+		3290FA021FA478AF0047D20C /* SDImageFrame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDImageFrame.h; sourceTree = "<group>"; };
+		3290FA031FA478AF0047D20C /* SDImageFrame.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDImageFrame.m; sourceTree = "<group>"; };
 		329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+WebCache.h"; path = "SDWebImage/UIImage+WebCache.h"; sourceTree = "<group>"; };
 		329A18581FFF5DFD008C9A2F /* UIImage+WebCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImage+WebCache.m"; path = "SDWebImage/UIImage+WebCache.m"; sourceTree = "<group>"; };
 		32B9B535206ED4230026769D /* SDWebImageDownloaderConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageDownloaderConfig.h; sourceTree = "<group>"; };
 		32B9B536206ED4230026769D /* SDWebImageDownloaderConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDownloaderConfig.m; sourceTree = "<group>"; };
 		32C0FDDF2013426C001B8F2D /* SDWebImageIndicator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageIndicator.h; sourceTree = "<group>"; };
 		32C0FDE02013426C001B8F2D /* SDWebImageIndicator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageIndicator.m; sourceTree = "<group>"; };
-		32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageCoderHelper.h; sourceTree = "<group>"; };
-		32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageCoderHelper.m; sourceTree = "<group>"; };
+		32CF1C051FA496B000004BD1 /* SDImageCoderHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDImageCoderHelper.h; sourceTree = "<group>"; };
+		32CF1C061FA496B000004BD1 /* SDImageCoderHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDImageCoderHelper.m; sourceTree = "<group>"; };
 		32D1221A2080B2EB003685A3 /* SDImageCacheDefine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDImageCacheDefine.h; sourceTree = "<group>"; };
 		32D1221B2080B2EB003685A3 /* SDImageCacheDefine.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDImageCacheDefine.m; sourceTree = "<group>"; };
 		32D1221C2080B2EB003685A3 /* SDImageCachesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDImageCachesManager.m; sourceTree = "<group>"; };
@@ -1879,10 +1879,10 @@
 				321E60A11F38E8F600405457 /* SDWebImageGIFCoder.m */,
 				327054D2206CD8B3006EA328 /* SDWebImageAPNGCoder.h */,
 				327054D3206CD8B3006EA328 /* SDWebImageAPNGCoder.m */,
-				3290FA021FA478AF0047D20C /* SDWebImageFrame.h */,
-				3290FA031FA478AF0047D20C /* SDWebImageFrame.m */,
-				32CF1C051FA496B000004BD1 /* SDWebImageCoderHelper.h */,
-				32CF1C061FA496B000004BD1 /* SDWebImageCoderHelper.m */,
+				3290FA021FA478AF0047D20C /* SDImageFrame.h */,
+				3290FA031FA478AF0047D20C /* SDImageFrame.m */,
+				32CF1C051FA496B000004BD1 /* SDImageCoderHelper.h */,
+				32CF1C061FA496B000004BD1 /* SDImageCoderHelper.m */,
 			);
 			name = Decoder;
 			sourceTree = "<group>";
@@ -2409,7 +2409,7 @@
 				327054D7206CD8B3006EA328 /* SDWebImageAPNGCoder.h in Headers */,
 				431739571CDFC8B70008FEB9 /* encode.h in Headers */,
 				323F8B711F38EF770092B609 /* delta_palettization_enc.h in Headers */,
-				3290FA071FA478AF0047D20C /* SDWebImageFrame.h in Headers */,
+				3290FA071FA478AF0047D20C /* SDImageFrame.h in Headers */,
 				324DF4B7200A14DC008A84CC /* SDWebImageDefine.h in Headers */,
 				807A122B1F89636300EC2A9B /* SDWebImageCodersManager.h in Headers */,
 				80377EC61F2F66D500F89830 /* webpi_dec.h in Headers */,
@@ -2453,7 +2453,7 @@
 				00733A641BC4880E00A5A117 /* SDWebImageOperation.h in Headers */,
 				32484766201775F600AF9E5A /* SDAnimatedImageView+WebCache.h in Headers */,
 				321E60A51F38E8F600405457 /* SDWebImageGIFCoder.h in Headers */,
-				32CF1C0A1FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */,
+				32CF1C0A1FA496B000004BD1 /* SDImageCoderHelper.h in Headers */,
 				80377C4D1F2F666300F89830 /* endian_inl_utils.h in Headers */,
 				431739581CDFC8B70008FEB9 /* format_constants.h in Headers */,
 				43CE75781CFE9427006C64D0 /* FLAnimatedImage.h in Headers */,
@@ -2490,7 +2490,7 @@
 			files = (
 				80377D521F2F66A700F89830 /* neon.h in Headers */,
 				80377D261F2F66A700F89830 /* common_sse2.h in Headers */,
-				3290FA051FA478AF0047D20C /* SDWebImageFrame.h in Headers */,
+				3290FA051FA478AF0047D20C /* SDImageFrame.h in Headers */,
 				80377C1D1F2F666300F89830 /* huffman_encode_utils.h in Headers */,
 				80377E9A1F2F66D400F89830 /* common_dec.h in Headers */,
 				32D1221F2080B2EB003685A3 /* SDImageCacheDefine.h in Headers */,
@@ -2511,7 +2511,7 @@
 				4314D1621D0E0E3B004B36C9 /* mux_types.h in Headers */,
 				4314D1631D0E0E3B004B36C9 /* demux.h in Headers */,
 				80377D421F2F66A700F89830 /* lossless_common.h in Headers */,
-				32CF1C081FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */,
+				32CF1C081FA496B000004BD1 /* SDImageCoderHelper.h in Headers */,
 				4314D16B1D0E0E3B004B36C9 /* encode.h in Headers */,
 				80377D501F2F66A700F89830 /* mips_macro.h in Headers */,
 				80377C291F2F666300F89830 /* thread_utils.h in Headers */,
@@ -2589,7 +2589,7 @@
 				80377C791F2F666400F89830 /* utils.h in Headers */,
 				328BB6A02081FED200760D6C /* SDWebImageCacheKeyFilter.h in Headers */,
 				323F8B721F38EF770092B609 /* delta_palettization_enc.h in Headers */,
-				32CF1C0B1FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */,
+				32CF1C0B1FA496B000004BD1 /* SDImageCoderHelper.h in Headers */,
 				431BB6D91D06D2C1006A3455 /* SDWebImageManager.h in Headers */,
 				80377C691F2F666400F89830 /* filters_utils.h in Headers */,
 				80377EC81F2F66D500F89830 /* alphai_dec.h in Headers */,
@@ -2617,7 +2617,7 @@
 				80377E201F2F66A800F89830 /* msa_macro.h in Headers */,
 				80377E031F2F66A800F89830 /* dsp.h in Headers */,
 				80377C661F2F666400F89830 /* color_cache_utils.h in Headers */,
-				3290FA081FA478AF0047D20C /* SDWebImageFrame.h in Headers */,
+				3290FA081FA478AF0047D20C /* SDImageFrame.h in Headers */,
 				321E60A61F38E8F600405457 /* SDWebImageGIFCoder.h in Headers */,
 				431BB6E71D06D2C1006A3455 /* SDWebImageCompat.h in Headers */,
 				80377E211F2F66A800F89830 /* neon.h in Headers */,
@@ -2709,7 +2709,7 @@
 				4397D2C41D0DDD8C00BB2784 /* SDImageCache.h in Headers */,
 				3248476E201775F600AF9E5A /* SDAnimatedImageView.h in Headers */,
 				4397D2C51D0DDD8C00BB2784 /* UIImageView+WebCache.h in Headers */,
-				3290FA091FA478AF0047D20C /* SDWebImageFrame.h in Headers */,
+				3290FA091FA478AF0047D20C /* SDImageFrame.h in Headers */,
 				4369C27C1D9807EC007E863A /* UIView+WebCache.h in Headers */,
 				80377EE21F2F66D500F89830 /* vp8i_dec.h in Headers */,
 				80377C8B1F2F666400F89830 /* quant_levels_utils.h in Headers */,
@@ -2731,7 +2731,7 @@
 				80377E761F2F66A800F89830 /* yuv.h in Headers */,
 				80377C7A1F2F666400F89830 /* bit_reader_inl_utils.h in Headers */,
 				80377E631F2F66A800F89830 /* lossless.h in Headers */,
-				32CF1C0C1FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */,
+				32CF1C0C1FA496B000004BD1 /* SDImageCoderHelper.h in Headers */,
 				43A918691D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
 				4397D2D81D0DDD8C00BB2784 /* UIButton+WebCache.h in Headers */,
 				32F7C0742030114C00873181 /* SDWebImageTransformer.h in Headers */,
@@ -2807,7 +2807,7 @@
 				431739511CDFC8B70008FEB9 /* format_constants.h in Headers */,
 				43A918661D8308FE00B3925F /* SDImageCacheConfig.h in Headers */,
 				323F8B701F38EF770092B609 /* delta_palettization_enc.h in Headers */,
-				3290FA061FA478AF0047D20C /* SDWebImageFrame.h in Headers */,
+				3290FA061FA478AF0047D20C /* SDImageFrame.h in Headers */,
 				324DF4B6200A14DC008A84CC /* SDWebImageDefine.h in Headers */,
 				807A122A1F89636300EC2A9B /* SDWebImageCodersManager.h in Headers */,
 				80377EB61F2F66D400F89830 /* webpi_dec.h in Headers */,
@@ -2851,7 +2851,7 @@
 				80377C331F2F666300F89830 /* endian_inl_utils.h in Headers */,
 				32484765201775F600AF9E5A /* SDAnimatedImageView+WebCache.h in Headers */,
 				321E60A41F38E8F600405457 /* SDWebImageGIFCoder.h in Headers */,
-				32CF1C091FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */,
+				32CF1C091FA496B000004BD1 /* SDImageCoderHelper.h in Headers */,
 				4A2CAE1B1AB4BB6800B6BC39 /* SDWebImageDownloader.h in Headers */,
 				431739501CDFC8B70008FEB9 /* encode.h in Headers */,
 				323F8B881F38EF770092B609 /* histogram_enc.h in Headers */,
@@ -2887,7 +2887,7 @@
 				431738C21CDFC2660008FEB9 /* mux_types.h in Headers */,
 				431738BE1CDFC2660008FEB9 /* demux.h in Headers */,
 				80377BFC1F2F665300F89830 /* bit_writer_utils.h in Headers */,
-				32CF1C071FA496B000004BD1 /* SDWebImageCoderHelper.h in Headers */,
+				32CF1C071FA496B000004BD1 /* SDImageCoderHelper.h in Headers */,
 				32F7C0842030719600873181 /* UIImage+Transform.h in Headers */,
 				431738BF1CDFC2660008FEB9 /* encode.h in Headers */,
 				53761316155AD0D5005750A4 /* SDImageCache.h in Headers */,
@@ -2904,7 +2904,7 @@
 				80377D0D1F2F66A100F89830 /* neon.h in Headers */,
 				431738C31CDFC2660008FEB9 /* types.h in Headers */,
 				80377D0C1F2F66A100F89830 /* msa_macro.h in Headers */,
-				3290FA041FA478AF0047D20C /* SDWebImageFrame.h in Headers */,
+				3290FA041FA478AF0047D20C /* SDImageFrame.h in Headers */,
 				80377D1D1F2F66A100F89830 /* yuv.h in Headers */,
 				43CE75D01CFE98E0006C64D0 /* FLAnimatedImageView+WebCache.h in Headers */,
 				807A12281F89636300EC2A9B /* SDWebImageCodersManager.h in Headers */,
@@ -3201,7 +3201,7 @@
 				80377DD31F2F66A700F89830 /* lossless_enc.c in Sources */,
 				32FDE88C20888726008D7530 /* UIImage+WebP.m in Sources */,
 				323F8BBD1F38EF770092B609 /* predictor_enc.c in Sources */,
-				3290FA0D1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
+				3290FA0D1FA478AF0047D20C /* SDImageFrame.m in Sources */,
 				80377DBD1F2F66A700F89830 /* dec.c in Sources */,
 				00733A561BC4880000A5A117 /* SDWebImageDownloaderOperation.m in Sources */,
 				80377DE71F2F66A700F89830 /* upsampling.c in Sources */,
@@ -3228,7 +3228,7 @@
 				80377DC31F2F66A700F89830 /* enc_neon.c in Sources */,
 				80377C501F2F666300F89830 /* huffman_encode_utils.c in Sources */,
 				80377DE51F2F66A700F89830 /* upsampling_neon.c in Sources */,
-				32CF1C101FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */,
+				32CF1C101FA496B000004BD1 /* SDImageCoderHelper.m in Sources */,
 				80377DAE1F2F66A700F89830 /* argb_sse2.c in Sources */,
 				323F8B7D1F38EF770092B609 /* frame_enc.c in Sources */,
 				328BB6D62082581100760D6C /* SDMemoryCache.m in Sources */,
@@ -3419,7 +3419,7 @@
 				80377D291F2F66A700F89830 /* cost_sse2.c in Sources */,
 				80377D601F2F66A700F89830 /* yuv_sse2.c in Sources */,
 				80377C281F2F666300F89830 /* thread_utils.c in Sources */,
-				3290FA0B1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
+				3290FA0B1FA478AF0047D20C /* SDImageFrame.m in Sources */,
 				80377C2A1F2F666300F89830 /* utils.c in Sources */,
 				323F8B4B1F38EF770092B609 /* backward_references_enc.c in Sources */,
 				807A122F1F89636300EC2A9B /* SDWebImageCodersManager.m in Sources */,
@@ -3500,7 +3500,7 @@
 				4314D14B1D0E0E3B004B36C9 /* SDWebImageCompat.m in Sources */,
 				328BB6B12081FEE500760D6C /* SDWebImageCacheSerializer.m in Sources */,
 				4314D14D1D0E0E3B004B36C9 /* UIImage+GIF.m in Sources */,
-				32CF1C0E1FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */,
+				32CF1C0E1FA496B000004BD1 /* SDImageCoderHelper.m in Sources */,
 				323F8B571F38EF770092B609 /* config_enc.c in Sources */,
 				80377D371F2F66A700F89830 /* enc_mips32.c in Sources */,
 				80377D431F2F66A700F89830 /* lossless_enc_mips_dsp_r2.c in Sources */,
@@ -3586,7 +3586,7 @@
 				80377E0F1F2F66A800F89830 /* filters_sse2.c in Sources */,
 				80377DED1F2F66A800F89830 /* alpha_processing_mips_dsp_r2.c in Sources */,
 				80377DF81F2F66A800F89830 /* cost_sse2.c in Sources */,
-				3290FA0E1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
+				3290FA0E1FA478AF0047D20C /* SDImageFrame.m in Sources */,
 				80377E2F1F2F66A800F89830 /* yuv_sse2.c in Sources */,
 				431BB6AA1D06D2C1006A3455 /* SDWebImageManager.m in Sources */,
 				323F8B4E1F38EF770092B609 /* backward_references_enc.c in Sources */,
@@ -3666,7 +3666,7 @@
 				80377C701F2F666400F89830 /* quant_levels_utils.c in Sources */,
 				328BB6B42081FEE500760D6C /* SDWebImageCacheSerializer.m in Sources */,
 				431BB6BD1D06D2C1006A3455 /* UIImage+GIF.m in Sources */,
-				32CF1C111FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */,
+				32CF1C111FA496B000004BD1 /* SDImageCoderHelper.m in Sources */,
 				323F8B5A1F38EF770092B609 /* config_enc.c in Sources */,
 				80377E061F2F66A800F89830 /* enc_mips32.c in Sources */,
 				80377E121F2F66A800F89830 /* lossless_enc_mips_dsp_r2.c in Sources */,
@@ -3731,9 +3731,9 @@
 				320CAE202086F50500CFFC80 /* SDWebImageError.m in Sources */,
 				80377E6E1F2F66A800F89830 /* upsampling_msa.c in Sources */,
 				323F8B911F38EF770092B609 /* iterator_enc.c in Sources */,
-				3290FA0F1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
+				3290FA0F1FA478AF0047D20C /* SDImageFrame.m in Sources */,
 				80377EE01F2F66D500F89830 /* vp8_dec.c in Sources */,
-				32CF1C121FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */,
+				32CF1C121FA496B000004BD1 /* SDImageCoderHelper.m in Sources */,
 				32B9B542206ED4230026769D /* SDWebImageDownloaderConfig.m in Sources */,
 				80377E521F2F66A800F89830 /* filters_msa.c in Sources */,
 				329A18641FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */,
@@ -3871,7 +3871,7 @@
 				80377D8E1F2F66A700F89830 /* lossless_enc.c in Sources */,
 				32FDE88B20888726008D7530 /* UIImage+WebP.m in Sources */,
 				323F8BBC1F38EF770092B609 /* predictor_enc.c in Sources */,
-				3290FA0C1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
+				3290FA0C1FA478AF0047D20C /* SDImageFrame.m in Sources */,
 				80377D781F2F66A700F89830 /* dec.c in Sources */,
 				80377DA21F2F66A700F89830 /* upsampling.c in Sources */,
 				80377C401F2F666300F89830 /* rescaler_utils.c in Sources */,
@@ -3897,7 +3897,7 @@
 				80377D7E1F2F66A700F89830 /* enc_neon.c in Sources */,
 				80377DA01F2F66A700F89830 /* upsampling_neon.c in Sources */,
 				80377D691F2F66A700F89830 /* argb_sse2.c in Sources */,
-				32CF1C0F1FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */,
+				32CF1C0F1FA496B000004BD1 /* SDImageCoderHelper.m in Sources */,
 				80377D6A1F2F66A700F89830 /* argb.c in Sources */,
 				323F8B7C1F38EF770092B609 /* frame_enc.c in Sources */,
 				328BB6D52082581100760D6C /* SDMemoryCache.m in Sources */,
@@ -4041,7 +4041,7 @@
 				80377D041F2F66A100F89830 /* lossless_enc.c in Sources */,
 				32FDE88920888726008D7530 /* UIImage+WebP.m in Sources */,
 				323F8BBA1F38EF770092B609 /* predictor_enc.c in Sources */,
-				3290FA0A1FA478AF0047D20C /* SDWebImageFrame.m in Sources */,
+				3290FA0A1FA478AF0047D20C /* SDImageFrame.m in Sources */,
 				80377CEE1F2F66A100F89830 /* dec.c in Sources */,
 				80377D181F2F66A100F89830 /* upsampling.c in Sources */,
 				80377C0C1F2F665300F89830 /* rescaler_utils.c in Sources */,
@@ -4068,7 +4068,7 @@
 				80377D161F2F66A100F89830 /* upsampling_neon.c in Sources */,
 				80377CDF1F2F66A100F89830 /* argb_sse2.c in Sources */,
 				80377CE01F2F66A100F89830 /* argb.c in Sources */,
-				32CF1C0D1FA496B000004BD1 /* SDWebImageCoderHelper.m in Sources */,
+				32CF1C0D1FA496B000004BD1 /* SDImageCoderHelper.m in Sources */,
 				323F8B7A1F38EF770092B609 /* frame_enc.c in Sources */,
 				80377E8B1F2F66D000F89830 /* frame_dec.c in Sources */,
 				328BB6D32082581100760D6C /* SDMemoryCache.m in Sources */,

--- a/SDWebImage/NSImage+Compatibility.m
+++ b/SDWebImage/NSImage+Compatibility.m
@@ -10,7 +10,7 @@
 
 #if SD_MAC
 
-#import "SDWebImageCoderHelper.h"
+#import "SDImageCoderHelper.h"
 
 @implementation NSImage (Compatibility)
 
@@ -45,7 +45,7 @@
     if (orientation != kCGImagePropertyOrientationUp) {
         // AppKit design is different from UIKit. Where CGImage based image rep does not respect to any orientation. Only data based image rep which contains the EXIF metadata can automatically detect orientation.
         // This should be nonnull, until the memory is exhausted cause `CGBitmapContextCreate` failed.
-        CGImageRef rotatedCGImage = [SDWebImageCoderHelper CGImageCreateDecoded:cgImage orientation:orientation];
+        CGImageRef rotatedCGImage = [SDImageCoderHelper CGImageCreateDecoded:cgImage orientation:orientation];
         imageRep = [[NSBitmapImageRep alloc] initWithCGImage:cgImage];
         CGImageRelease(rotatedCGImage);
     } else {

--- a/SDWebImage/SDAnimatedImage.m
+++ b/SDWebImage/SDAnimatedImage.m
@@ -11,7 +11,7 @@
 #import "UIImage+WebCache.h"
 #import "SDWebImageCoder.h"
 #import "SDWebImageCodersManager.h"
-#import "SDWebImageFrame.h"
+#import "SDImageFrame.h"
 
 #define LOCK(...) dispatch_semaphore_wait(self->_lock, DISPATCH_TIME_FOREVER); \
 __VA_ARGS__; \
@@ -199,7 +199,7 @@ static NSArray *SDBundlePreferredScales() {
 
 @property (nonatomic, strong) id<SDWebImageAnimatedCoder> coder;
 @property (nonatomic, assign, readwrite) SDImageFormat animatedImageFormat;
-@property (atomic, copy) NSArray<SDWebImageFrame *> *loadedAnimatedImageFrames; // Mark as atomic to keep thread-safe
+@property (atomic, copy) NSArray<SDImageFrame *> *loadedAnimatedImageFrames; // Mark as atomic to keep thread-safe
 @property (nonatomic, assign, getter=isAllFramesLoaded) BOOL allFramesLoaded;
 
 @end
@@ -328,11 +328,11 @@ static NSArray *SDBundlePreferredScales() {
 #pragma mark - Preload
 - (void)preloadAllFrames {
     if (!self.isAllFramesLoaded) {
-        NSMutableArray<SDWebImageFrame *> *frames = [NSMutableArray arrayWithCapacity:self.animatedImageFrameCount];
+        NSMutableArray<SDImageFrame *> *frames = [NSMutableArray arrayWithCapacity:self.animatedImageFrameCount];
         for (size_t i = 0; i < self.animatedImageFrameCount; i++) {
             UIImage *image = [self animatedImageFrameAtIndex:i];
             NSTimeInterval duration = [self animatedImageDurationAtIndex:i];
-            SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:image duration:duration]; // through the image should be nonnull, used as nullable for `animatedImageFrameAtIndex:`
+            SDImageFrame *frame = [SDImageFrame frameWithImage:image duration:duration]; // through the image should be nonnull, used as nullable for `animatedImageFrameAtIndex:`
             [frames addObject:frame];
         }
         self.loadedAnimatedImageFrames = frames;
@@ -406,7 +406,7 @@ static NSArray *SDBundlePreferredScales() {
         return nil;
     }
     if (self.isAllFramesLoaded) {
-        SDWebImageFrame *frame = [self.loadedAnimatedImageFrames objectAtIndex:index];
+        SDImageFrame *frame = [self.loadedAnimatedImageFrames objectAtIndex:index];
         return frame.image;
     }
     return [self.coder animatedImageFrameAtIndex:index];
@@ -417,7 +417,7 @@ static NSArray *SDBundlePreferredScales() {
         return 0;
     }
     if (self.isAllFramesLoaded) {
-        SDWebImageFrame *frame = [self.loadedAnimatedImageFrames objectAtIndex:index];
+        SDImageFrame *frame = [self.loadedAnimatedImageFrames objectAtIndex:index];
         return frame.duration;
     }
     return [self.coder animatedImageDurationAtIndex:index];

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -13,7 +13,7 @@
 #import "UIImage+WebCache.h"
 #import "SDWebImageCodersManager.h"
 #import "SDWebImageTransformer.h"
-#import "SDWebImageCoderHelper.h"
+#import "SDImageCoderHelper.h"
 #import "SDAnimatedImage.h"
 
 @interface SDImageCache ()
@@ -177,7 +177,7 @@
                 if (!data && image) {
                     // If we do not have any data to detect image format, check whether it contains alpha channel to use PNG or JPEG format
                     SDImageFormat format;
-                    if ([SDWebImageCoderHelper CGImageContainsAlpha:image.CGImage]) {
+                    if ([SDImageCoderHelper CGImageContainsAlpha:image.CGImage]) {
                         format = SDImageFormatPNG;
                     } else {
                         format = SDImageFormatJPEG;

--- a/SDWebImage/SDImageCacheDefine.m
+++ b/SDWebImage/SDImageCacheDefine.m
@@ -8,7 +8,7 @@
 
 #import "SDImageCacheDefine.h"
 #import "SDWebImageCodersManager.h"
-#import "SDWebImageCoderHelper.h"
+#import "SDImageCoderHelper.h"
 #import "SDAnimatedImage.h"
 #import "UIImage+WebCache.h"
 
@@ -47,9 +47,9 @@ UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSS
         if (shouldDecode) {
             BOOL shouldScaleDown = options & SDWebImageScaleDownLargeImages;
             if (shouldScaleDown) {
-                image = [SDWebImageCoderHelper decodedAndScaledDownImageWithImage:image limitBytes:0];
+                image = [SDImageCoderHelper decodedAndScaledDownImageWithImage:image limitBytes:0];
             } else {
-                image = [SDWebImageCoderHelper decodedImageWithImage:image];
+                image = [SDImageCoderHelper decodedImageWithImage:image];
             }
         }
     }

--- a/SDWebImage/SDImageCoderHelper.h
+++ b/SDWebImage/SDImageCoderHelper.h
@@ -8,9 +8,9 @@
 
 #import <ImageIO/ImageIO.h>
 #import "SDWebImageCompat.h"
-#import "SDWebImageFrame.h"
+#import "SDImageFrame.h"
 
-@interface SDWebImageCoderHelper : NSObject
+@interface SDImageCoderHelper : NSObject
 
 /**
  Return an animated image with frames array.
@@ -20,7 +20,7 @@
  @param frames The frames array. If no frames or frames is empty, return nil
  @return A animated image for rendering on UIImageView(UIKit) or NSImageView(AppKit)
  */
-+ (UIImage * _Nullable)animatedImageWithFrames:(NSArray<SDWebImageFrame *> * _Nullable)frames;
++ (UIImage * _Nullable)animatedImageWithFrames:(NSArray<SDImageFrame *> * _Nullable)frames;
 
 /**
  Return frames array from an animated image.
@@ -30,7 +30,7 @@
  @param animatedImage A animated image. If it's not animated, return nil
  @return The frames array
  */
-+ (NSArray<SDWebImageFrame *> * _Nullable)framesFromAnimatedImage:(UIImage * _Nullable)animatedImage NS_SWIFT_NAME(frames(from:));
++ (NSArray<SDImageFrame *> * _Nullable)framesFromAnimatedImage:(UIImage * _Nullable)animatedImage NS_SWIFT_NAME(frames(from:));
 
 /**
  Return the shared device-dependent RGB color space. This follows The Get Rule.

--- a/SDWebImage/SDImageCoderHelper.m
+++ b/SDWebImage/SDImageCoderHelper.m
@@ -6,8 +6,8 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageCoderHelper.h"
-#import "SDWebImageFrame.h"
+#import "SDImageCoderHelper.h"
+#import "SDImageFrame.h"
 #import "NSImage+Compatibility.h"
 #import "NSData+ImageContentType.h"
 #import "SDAnimatedImageRep.h"
@@ -41,9 +41,9 @@ static const CGFloat kTileTotalPixels = kSourceImageTileSizeMB * kPixelsPerMB;
 static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to overlap the seems where tiles meet.
 #endif
 
-@implementation SDWebImageCoderHelper
+@implementation SDImageCoderHelper
 
-+ (UIImage *)animatedImageWithFrames:(NSArray<SDWebImageFrame *> *)frames {
++ (UIImage *)animatedImageWithFrames:(NSArray<SDImageFrame *> *)frames {
     NSUInteger frameCount = frames.count;
     if (frameCount == 0) {
         return nil;
@@ -59,7 +59,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     NSUInteger const gcd = gcdArray(frameCount, durations);
     __block NSUInteger totalDuration = 0;
     NSMutableArray<UIImage *> *animatedImages = [NSMutableArray arrayWithCapacity:frameCount];
-    [frames enumerateObjectsUsingBlock:^(SDWebImageFrame * _Nonnull frame, NSUInteger idx, BOOL * _Nonnull stop) {
+    [frames enumerateObjectsUsingBlock:^(SDImageFrame * _Nonnull frame, NSUInteger idx, BOOL * _Nonnull stop) {
         UIImage *image = frame.image;
         NSUInteger duration = frame.duration * 1000;
         totalDuration += duration;
@@ -89,7 +89,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     
     for (size_t i = 0; i < frameCount; i++) {
         @autoreleasepool {
-            SDWebImageFrame *frame = frames[i];
+            SDImageFrame *frame = frames[i];
             float frameDuration = frame.duration;
             CGImageRef frameImageRef = frame.image.CGImage;
             NSDictionary *frameProperties = @{(__bridge_transfer NSString *)kCGImagePropertyGIFDictionary : @{(__bridge_transfer NSString *)kCGImagePropertyGIFDelayTime : @(frameDuration)}};
@@ -117,12 +117,12 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     return animatedImage;
 }
 
-+ (NSArray<SDWebImageFrame *> *)framesFromAnimatedImage:(UIImage *)animatedImage {
++ (NSArray<SDImageFrame *> *)framesFromAnimatedImage:(UIImage *)animatedImage {
     if (!animatedImage) {
         return nil;
     }
     
-    NSMutableArray<SDWebImageFrame *> *frames = [NSMutableArray array];
+    NSMutableArray<SDImageFrame *> *frames = [NSMutableArray array];
     NSUInteger frameCount = 0;
     
 #if SD_UIKIT || SD_WATCH
@@ -148,7 +148,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         if ([image isEqual:previousImage]) {
             repeatCount++;
         } else {
-            SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:previousImage duration:avgDuration * repeatCount];
+            SDImageFrame *frame = [SDImageFrame frameWithImage:previousImage duration:avgDuration * repeatCount];
             [frames addObject:frame];
             repeatCount = 1;
             index++;
@@ -156,7 +156,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         previousImage = image;
         // last one
         if (idx == frameCount - 1) {
-            SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:previousImage duration:avgDuration * repeatCount];
+            SDImageFrame *frame = [SDImageFrame frameWithImage:previousImage duration:avgDuration * repeatCount];
             [frames addObject:frame];
         }
     }];
@@ -184,7 +184,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
             [bitmapImageRep setProperty:NSImageCurrentFrame withValue:@(i)];
             float frameDuration = [[bitmapImageRep valueForProperty:NSImageCurrentFrameDuration] floatValue];
             NSImage *frameImage = [[NSImage alloc] initWithCGImage:bitmapImageRep.CGImage scale:scale orientation:kCGImagePropertyOrientationUp];
-            SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:frameImage duration:frameDuration];
+            SDImageFrame *frame = [SDImageFrame frameWithImage:frameImage duration:frameDuration];
             [frames addObject:frame];
         }
     }

--- a/SDWebImage/SDImageFrame.h
+++ b/SDWebImage/SDImageFrame.h
@@ -9,9 +9,9 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
 
-@interface SDWebImageFrame : NSObject
+@interface SDImageFrame : NSObject
 
-// This class is used for creating animated images via `animatedImageWithFrames` in `SDWebImageCoderHelper`. Attention if you need to specify animated images loop count, use `sd_imageLoopCount` property in `UIImage+WebCache.h`.
+// This class is used for creating animated images via `animatedImageWithFrames` in `SDImageCoderHelper`. Attention if you need to specify animated images loop count, use `sd_imageLoopCount` property in `UIImage+WebCache.h`.
 
 /**
  The image of current frame. You should not set an animated image.

--- a/SDWebImage/SDImageFrame.m
+++ b/SDWebImage/SDImageFrame.m
@@ -6,19 +6,19 @@
  * file that was distributed with this source code.
  */
 
-#import "SDWebImageFrame.h"
+#import "SDImageFrame.h"
 
-@interface SDWebImageFrame ()
+@interface SDImageFrame ()
 
 @property (nonatomic, strong, readwrite, nonnull) UIImage *image;
 @property (nonatomic, readwrite, assign) NSTimeInterval duration;
 
 @end
 
-@implementation SDWebImageFrame
+@implementation SDImageFrame
 
 + (instancetype)frameWithImage:(UIImage *)image duration:(NSTimeInterval)duration {
-    SDWebImageFrame *frame = [[SDWebImageFrame alloc] init];
+    SDImageFrame *frame = [[SDImageFrame alloc] init];
     frame.image = image;
     frame.duration = duration;
     

--- a/SDWebImage/SDWebImageAPNGCoder.m
+++ b/SDWebImage/SDWebImageAPNGCoder.m
@@ -11,7 +11,7 @@
 #import "NSData+ImageContentType.h"
 #import "UIImage+WebCache.h"
 #import "NSImage+Compatibility.h"
-#import "SDWebImageCoderHelper.h"
+#import "SDImageCoderHelper.h"
 #import "SDAnimatedImageRep.h"
 
 // iOS 8 Image/IO framework binary does not contains these APNG contants, so we define them. Thanks Apple :)
@@ -108,7 +108,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
     if (decodeFirstFrame || count <= 1) {
         animatedImage = [[UIImage alloc] initWithData:data scale:scale];
     } else {
-        NSMutableArray<SDWebImageFrame *> *frames = [NSMutableArray array];
+        NSMutableArray<SDImageFrame *> *frames = [NSMutableArray array];
         
         for (size_t i = 0; i < count; i++) {
             CGImageRef imageRef = CGImageSourceCreateImageAtIndex(source, i, NULL);
@@ -120,13 +120,13 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
             UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
             CGImageRelease(imageRef);
             
-            SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:image duration:duration];
+            SDImageFrame *frame = [SDImageFrame frameWithImage:image duration:duration];
             [frames addObject:frame];
         }
         
         NSUInteger loopCount = [self sd_imageLoopCountWithSource:source];
         
-        animatedImage = [SDWebImageCoderHelper animatedImageWithFrames:frames];
+        animatedImage = [SDImageCoderHelper animatedImageWithFrames:frames];
         animatedImage.sd_imageLoopCount = loopCount;
     }
     
@@ -189,7 +189,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
     
     NSMutableData *imageData = [NSMutableData data];
     CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatPNG];
-    NSArray<SDWebImageFrame *> *frames = [SDWebImageCoderHelper framesFromAnimatedImage:image];
+    NSArray<SDImageFrame *> *frames = [SDImageCoderHelper framesFromAnimatedImage:image];
     
     // Create an image destination. APNG does not support EXIF image orientation
     CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, frames.count, NULL);
@@ -216,7 +216,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         CGImageDestinationSetProperties(imageDestination, (__bridge CFDictionaryRef)properties);
         
         for (size_t i = 0; i < frames.count; i++) {
-            SDWebImageFrame *frame = frames[i];
+            SDImageFrame *frame = frames[i];
             float frameDuration = frame.duration;
             CGImageRef frameImageRef = frame.image.CGImage;
             NSDictionary *frameProperties = @{(__bridge_transfer NSString *)kCGImagePropertyPNGDictionary : @{(__bridge_transfer NSString *)kCGImagePropertyAPNGDelayTime : @(frameDuration)}};
@@ -402,7 +402,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         return nil;
     }
     // Image/IO create CGImage does not decompressed, so we do this because this is called background queue, this can avoid main queue block when rendering(especially when one more imageViews use the same image instance)
-    CGImageRef newImageRef = [SDWebImageCoderHelper CGImageCreateDecoded:imageRef];
+    CGImageRef newImageRef = [SDImageCoderHelper CGImageCreateDecoded:imageRef];
     if (!newImageRef) {
         newImageRef = imageRef;
     } else {

--- a/SDWebImage/SDWebImageCoder.h
+++ b/SDWebImage/SDWebImageCoder.h
@@ -59,7 +59,7 @@ FOUNDATION_EXPORT SDWebImageCoderOption _Nonnull const SDWebImageCoderEncodeComp
 
 /**
  Decode the image data to image.
- @note This protocol may supports decode animated image frames. You can use `+[SDWebImageCoderHelper animatedImageWithFrames:]` to produce an animated image with frames.
+ @note This protocol may supports decode animated image frames. You can use `+[SDImageCoderHelper animatedImageWithFrames:]` to produce an animated image with frames.
 
  @param data The image data to be decoded
  @param options A dictionary containing any decoding options. Pass @{SDWebImageCoderDecodeFirstFrameOnly: @(YES)} to decode the first frame only.
@@ -80,7 +80,7 @@ FOUNDATION_EXPORT SDWebImageCoderOption _Nonnull const SDWebImageCoderEncodeComp
 
 /**
  Encode the image to image data.
- @note This protocol may supports encode animated image frames. You can use `+[SDWebImageCoderHelper framesFromAnimatedImage:]` to assemble an animated image with frames.
+ @note This protocol may supports encode animated image frames. You can use `+[SDImageCoderHelper framesFromAnimatedImage:]` to assemble an animated image with frames.
 
  @param image The image to be encoded
  @param format The image format to encode, you should note `SDImageFormatUndefined` format is also  possible

--- a/SDWebImage/SDWebImageGIFCoder.m
+++ b/SDWebImage/SDWebImageGIFCoder.m
@@ -11,7 +11,7 @@
 #import "UIImage+WebCache.h"
 #import <ImageIO/ImageIO.h>
 #import "NSData+ImageContentType.h"
-#import "SDWebImageCoderHelper.h"
+#import "SDImageCoderHelper.h"
 #import "SDAnimatedImageRep.h"
 
 @interface SDGIFCoderFrame : NSObject
@@ -101,7 +101,7 @@
     if (decodeFirstFrame || count <= 1) {
         animatedImage = [[UIImage alloc] initWithData:data scale:scale];
     } else {
-        NSMutableArray<SDWebImageFrame *> *frames = [NSMutableArray array];
+        NSMutableArray<SDImageFrame *> *frames = [NSMutableArray array];
         
         for (size_t i = 0; i < count; i++) {
             CGImageRef imageRef = CGImageSourceCreateImageAtIndex(source, i, NULL);
@@ -113,13 +113,13 @@
             UIImage *image = [[UIImage alloc] initWithCGImage:imageRef scale:scale orientation:UIImageOrientationUp];
             CGImageRelease(imageRef);
             
-            SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:image duration:duration];
+            SDImageFrame *frame = [SDImageFrame frameWithImage:image duration:duration];
             [frames addObject:frame];
         }
         
         NSUInteger loopCount = [self sd_imageLoopCountWithSource:source];
         
-        animatedImage = [SDWebImageCoderHelper animatedImageWithFrames:frames];
+        animatedImage = [SDImageCoderHelper animatedImageWithFrames:frames];
         animatedImage.sd_imageLoopCount = loopCount;
     }
     
@@ -271,7 +271,7 @@
     
     NSMutableData *imageData = [NSMutableData data];
     CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatGIF];
-    NSArray<SDWebImageFrame *> *frames = [SDWebImageCoderHelper framesFromAnimatedImage:image];
+    NSArray<SDImageFrame *> *frames = [SDImageCoderHelper framesFromAnimatedImage:image];
     
     // Create an image destination. GIF does not support EXIF image orientation
     CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, frames.count, NULL);
@@ -298,7 +298,7 @@
         CGImageDestinationSetProperties(imageDestination, (__bridge CFDictionaryRef)properties);
         
         for (size_t i = 0; i < frames.count; i++) {
-            SDWebImageFrame *frame = frames[i];
+            SDImageFrame *frame = frames[i];
             float frameDuration = frame.duration;
             CGImageRef frameImageRef = frame.image.CGImage;
             NSDictionary *frameProperties = @{(__bridge_transfer NSString *)kCGImagePropertyGIFDictionary : @{(__bridge_transfer NSString *)kCGImagePropertyGIFDelayTime : @(frameDuration)}};
@@ -397,7 +397,7 @@
         return nil;
     }
     // Image/IO create CGImage does not decode, so we do this because this is called background queue, this can avoid main queue block when rendering(especially when one more imageViews use the same image instance)
-    CGImageRef newImageRef = [SDWebImageCoderHelper CGImageCreateDecoded:imageRef];
+    CGImageRef newImageRef = [SDImageCoderHelper CGImageCreateDecoded:imageRef];
     if (!newImageRef) {
         newImageRef = imageRef;
     } else {

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -7,7 +7,7 @@
  */
 
 #import "SDWebImageImageIOCoder.h"
-#import "SDWebImageCoderHelper.h"
+#import "SDImageCoderHelper.h"
 #import "NSImage+Compatibility.h"
 #import <ImageIO/ImageIO.h>
 #import "NSData+ImageContentType.h"
@@ -159,7 +159,7 @@
                 }
             }
 #if SD_UIKIT || SD_WATCH
-            UIImageOrientation imageOrientation = [SDWebImageCoderHelper imageOrientationFromEXIFOrientation:_orientation];
+            UIImageOrientation imageOrientation = [SDImageCoderHelper imageOrientationFromEXIFOrientation:_orientation];
             image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:imageOrientation];
 #else
             image = [[UIImage alloc] initWithCGImage:partialImageRef scale:scale orientation:_orientation];
@@ -191,7 +191,7 @@
     }
     
     if (format == SDImageFormatUndefined) {
-        BOOL hasAlpha = [SDWebImageCoderHelper CGImageContainsAlpha:image.CGImage];
+        BOOL hasAlpha = [SDImageCoderHelper CGImageContainsAlpha:image.CGImage];
         if (hasAlpha) {
             format = SDImageFormatPNG;
         } else {
@@ -211,7 +211,7 @@
     
     NSMutableDictionary *properties = [NSMutableDictionary dictionary];
 #if SD_UIKIT || SD_WATCH
-    CGImagePropertyOrientation exifOrientation = [SDWebImageCoderHelper exifOrientationFromImageOrientation:image.imageOrientation];
+    CGImagePropertyOrientation exifOrientation = [SDImageCoderHelper exifOrientationFromImageOrientation:image.imageOrientation];
 #else
     CGImagePropertyOrientation exifOrientation = kCGImagePropertyOrientationUp;
 #endif

--- a/SDWebImage/SDWebImageLoader.m
+++ b/SDWebImage/SDWebImageLoader.m
@@ -9,7 +9,7 @@
 #import "SDWebImageLoader.h"
 #import "SDWebImageCacheKeyFilter.h"
 #import "SDWebImageCodersManager.h"
-#import "SDWebImageCoderHelper.h"
+#import "SDImageCoderHelper.h"
 #import "SDAnimatedImage.h"
 #import "UIImage+WebCache.h"
 #import "objc/runtime.h"
@@ -62,9 +62,9 @@ UIImage * _Nullable SDWebImageLoaderDecodeImageData(NSData * _Nonnull imageData,
         if (shouldDecode) {
             BOOL shouldScaleDown = options & SDWebImageScaleDownLargeImages;
             if (shouldScaleDown) {
-                image = [SDWebImageCoderHelper decodedAndScaledDownImageWithImage:image limitBytes:0];
+                image = [SDImageCoderHelper decodedAndScaledDownImageWithImage:image limitBytes:0];
             } else {
-                image = [SDWebImageCoderHelper decodedImageWithImage:image];
+                image = [SDImageCoderHelper decodedImageWithImage:image];
             }
         }
     }
@@ -131,7 +131,7 @@ UIImage * _Nullable SDWebImageLoaderDecodeProgressiveImageData(NSData * _Nonnull
             shouldDecode = NO;
         }
         if (shouldDecode) {
-            image = [SDWebImageCoderHelper decodedImageWithImage:image];
+            image = [SDImageCoderHelper decodedImageWithImage:image];
         }
         // mark the image as progressive (completionBlock one are not mark as progressive)
         image.sd_isIncremental = YES;

--- a/SDWebImage/UIImage+ForceDecode.m
+++ b/SDWebImage/UIImage+ForceDecode.m
@@ -7,7 +7,7 @@
  */
 
 #import "UIImage+ForceDecode.h"
-#import "SDWebImageCoderHelper.h"
+#import "SDImageCoderHelper.h"
 #import "objc/runtime.h"
 
 @implementation UIImage (ForceDecode)
@@ -25,7 +25,7 @@
     if (!image) {
         return nil;
     }
-    return [SDWebImageCoderHelper decodedImageWithImage:image];
+    return [SDImageCoderHelper decodedImageWithImage:image];
 }
 
 + (UIImage *)sd_decodedAndScaledDownImageWithImage:(UIImage *)image {
@@ -36,7 +36,7 @@
     if (!image) {
         return nil;
     }
-    return [SDWebImageCoderHelper decodedAndScaledDownImageWithImage:image limitBytes:bytes];
+    return [SDImageCoderHelper decodedAndScaledDownImageWithImage:image limitBytes:bytes];
 }
 
 @end

--- a/SDWebImage/WebP/SDWebImageWebPCoder.m
+++ b/SDWebImage/WebP/SDWebImageWebPCoder.m
@@ -9,7 +9,7 @@
 #ifdef SD_WEBP
 
 #import "SDWebImageWebPCoder.h"
-#import "SDWebImageCoderHelper.h"
+#import "SDImageCoderHelper.h"
 #import "NSImage+Compatibility.h"
 #import "UIImage+WebCache.h"
 #import "UIImage+ForceDecode.h"
@@ -168,13 +168,13 @@ dispatch_semaphore_signal(self->_lock);
     BOOL hasAlpha = flags & ALPHA_FLAG;
     CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Host;
     bitmapInfo |= hasAlpha ? kCGImageAlphaPremultipliedFirst : kCGImageAlphaNoneSkipFirst;
-    CGContextRef canvas = CGBitmapContextCreate(NULL, canvasWidth, canvasHeight, 8, 0, [SDWebImageCoderHelper colorSpaceGetDeviceRGB], bitmapInfo);
+    CGContextRef canvas = CGBitmapContextCreate(NULL, canvasWidth, canvasHeight, 8, 0, [SDImageCoderHelper colorSpaceGetDeviceRGB], bitmapInfo);
     if (!canvas) {
         WebPDemuxDelete(demuxer);
         return nil;
     }
     
-    NSMutableArray<SDWebImageFrame *> *frames = [NSMutableArray array];
+    NSMutableArray<SDImageFrame *> *frames = [NSMutableArray array];
     
     do {
         @autoreleasepool {
@@ -190,7 +190,7 @@ dispatch_semaphore_signal(self->_lock);
             CGImageRelease(imageRef);
             
             NSTimeInterval duration = [self sd_frameDurationWithIterator:iter];
-            SDWebImageFrame *frame = [SDWebImageFrame frameWithImage:image duration:duration];
+            SDImageFrame *frame = [SDImageFrame frameWithImage:image duration:duration];
             [frames addObject:frame];
         }
         
@@ -200,7 +200,7 @@ dispatch_semaphore_signal(self->_lock);
     WebPDemuxDelete(demuxer);
     CGContextRelease(canvas);
     
-    UIImage *animatedImage = [SDWebImageCoderHelper animatedImageWithFrames:frames];
+    UIImage *animatedImage = [SDImageCoderHelper animatedImageWithFrames:frames];
     animatedImage.sd_imageLoopCount = loopCount;
     
     return animatedImage;
@@ -251,7 +251,7 @@ dispatch_semaphore_signal(self->_lock);
         size_t rgbaSize = last_y * stride;
         CGDataProviderRef provider =
         CGDataProviderCreateWithData(NULL, rgba, rgbaSize, NULL);
-        CGColorSpaceRef colorSpaceRef = [SDWebImageCoderHelper colorSpaceGetDeviceRGB];
+        CGColorSpaceRef colorSpaceRef = [SDImageCoderHelper colorSpaceGetDeviceRGB];
         
         CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Host | kCGImageAlphaPremultipliedFirst;
         size_t components = 4;
@@ -270,7 +270,7 @@ dispatch_semaphore_signal(self->_lock);
             return nil;
         }
         
-        CGContextRef canvas = CGBitmapContextCreate(NULL, width, height, 8, 0, [SDWebImageCoderHelper colorSpaceGetDeviceRGB], bitmapInfo);
+        CGContextRef canvas = CGBitmapContextCreate(NULL, width, height, 8, 0, [SDImageCoderHelper colorSpaceGetDeviceRGB], bitmapInfo);
         if (!canvas) {
             CGImageRelease(imageRef);
             return nil;
@@ -393,7 +393,7 @@ dispatch_semaphore_signal(self->_lock);
     size_t bitsPerComponent = 8;
     size_t bitsPerPixel = 32;
     size_t bytesPerRow = config.output.u.RGBA.stride;
-    CGColorSpaceRef colorSpaceRef = [SDWebImageCoderHelper colorSpaceGetDeviceRGB];
+    CGColorSpaceRef colorSpaceRef = [SDImageCoderHelper colorSpaceGetDeviceRGB];
     CGColorRenderingIntent renderingIntent = kCGRenderingIntentDefault;
     CGImageRef imageRef = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorSpaceRef, bitmapInfo, provider, NULL, NO, renderingIntent);
     
@@ -428,7 +428,7 @@ dispatch_semaphore_signal(self->_lock);
     if ([options valueForKey:SDWebImageCoderEncodeCompressionQuality]) {
         compressionQuality = [[options valueForKey:SDWebImageCoderEncodeCompressionQuality] doubleValue];
     }
-    NSArray<SDWebImageFrame *> *frames = [SDWebImageCoderHelper framesFromAnimatedImage:image];
+    NSArray<SDImageFrame *> *frames = [SDImageCoderHelper framesFromAnimatedImage:image];
     
     BOOL encodeFirstFrame = [options[SDWebImageCoderEncodeFirstFrameOnly] boolValue];
     if (encodeFirstFrame || frames.count == 0) {
@@ -441,7 +441,7 @@ dispatch_semaphore_signal(self->_lock);
             return nil;
         }
         for (size_t i = 0; i < frames.count; i++) {
-            SDWebImageFrame *currentFrame = frames[i];
+            SDImageFrame *currentFrame = frames[i];
             NSData *webpData = [self sd_encodedWebpDataWithImage:currentFrame.image quality:compressionQuality];
             int duration = currentFrame.duration * 1000;
             WebPMuxFrameInfo frame = { .bitstream.bytes = webpData.bytes,
@@ -662,7 +662,7 @@ static void FreeImageData(void *info, const void *data, size_t size) {
     if (!_canvas) {
         CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Host;
         bitmapInfo |= _hasAlpha ? kCGImageAlphaPremultipliedFirst : kCGImageAlphaNoneSkipFirst;
-        CGContextRef canvas = CGBitmapContextCreate(NULL, _canvasWidth, _canvasHeight, 8, 0, [SDWebImageCoderHelper colorSpaceGetDeviceRGB], bitmapInfo);
+        CGContextRef canvas = CGBitmapContextCreate(NULL, _canvasWidth, _canvasHeight, 8, 0, [SDImageCoderHelper colorSpaceGetDeviceRGB], bitmapInfo);
         if (!canvas) {
             return nil;
         }

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -57,8 +57,8 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/SDWebImageAPNGCoder.h>
 #import <SDWebImage/SDWebImageGIFCoder.h>
 #import <SDWebImage/SDWebImageImageIOCoder.h>
-#import <SDWebImage/SDWebImageFrame.h>
-#import <SDWebImage/SDWebImageCoderHelper.h>
+#import <SDWebImage/SDImageFrame.h>
+#import <SDWebImage/SDImageCoderHelper.h>
 #import <SDWebImage/UIImage+GIF.h>
 #import <SDWebImage/UIImage+ForceDecode.h>
 #import <SDWebImage/NSData+ImageContentType.h>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2291 

### Pull Request Description

Renaming `SDWebImageFrame` to `SDImageFrame`.
Renaming `SDWebImageCoderHelper` to `SDImageCoderHelper`.

These class should obey the naming rule. 
> No Web-Cache manager related, and no `NSURL` related class should named without `Web` prefix. Class which represent something about framework itself should prefix hole `SDWebImage` even if not image related.

