### PR TITLE
Add optimalFrameCacheSize for FLAnimatedImage.

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -39,6 +39,29 @@
 @interface FLAnimatedImageView (WebCache)
 
 /**
+ * Optimal Frame Cache Size of FLAnimatedImage
+ * This value will help you set frameCacheSizeOptimal property of FLAnimatedImage after image load.
+ * default is 0.
+ * If this value is 0, frameCacheSizeOptimal property of FLAnimatedImage will set automatically.
+ */
+@property (nonatomic) NSUInteger sd_optimalFrameCacheSize;
+
+/**
+ * Set Default Optimal Frame Cache Size of FLAnimatedImage
+ * If sd_optimalFrameCacheSize is 0, FLAnimatedImage will use sd_defaultOptimalFrameCacheSize
+ * default is 0
+ *
+ * @param cacheSize     Default optimal frame cache size of FLAnimatedImage
+ */
++ (void)setSd_defaultOptimalFrameCacheSize:(NSUInteger)cacheSize;
+
+/**
+ *  Get Default Optimal Frame Cache Size of FLAnimatedImage
+ *  default is 0
+ */
++ (NSUInteger)sd_defaultOptimalFrameCacheSize;
+
+/**
  * Load the image at the given url (either from cache or download) and load it in this imageView. It works with both static and dynamic images
  * The download is asynchronous and cached.
  *

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -27,7 +27,32 @@
 
 @end
 
+static NSUInteger kDefaultOptimalFrameCacheSize = 0;
+static char optimalFrameCacheSizeKey;
+
 @implementation FLAnimatedImageView (WebCache)
+
+
++ (void)setSd_defaultOptimalFrameCacheSize:(NSUInteger)cacheSize
+{
+    defaultOptimalFrameCacheSize = cacheSize;
+}
++ (NSUInteger)sd_defaultOptimalFrameCacheSize
+{
+    return defaultOptimalFrameCacheSize;
+}
+
+
+- (void)setSd_optimalFrameCacheSize:(NSUInteger)cacheSize
+{
+    objc_setAssociatedObject(self, &optimalFrameCacheSizeKey, @(cacheSize), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (NSUInteger)sd_optimalFrameCacheSize
+{
+    return [objc_getAssociatedObject(self, &optimalFrameCacheSizeKey) floatValue];
+}
+
 
 - (void)sd_setImageWithURL:(nullable NSURL *)url {
     [self sd_setImageWithURL:url placeholderImage:nil options:0 progress:nil completed:nil];
@@ -83,7 +108,9 @@
                                weakSelf.animatedImage = nil;
                                // Secondly create FLAnimatedImage in global queue because it's time consuming, then set it back
                                dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-                                   FLAnimatedImage *animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
+                                   NSUInteger cacheSize = self.sd_optimalFrameCacheSize > 0 ? self.sd_optimalFrameCacheSize : kDefaultOptimalFrameCacheSize;
+                                   
+                                   FLAnimatedImage *animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:cacheSize predrawingEnabled:YES];
                                    dispatch_async(dispatch_get_main_queue(), ^{
                                        image.sd_FLAnimatedImage = animatedImage;
                                        weakSelf.animatedImage = animatedImage;


### PR DESCRIPTION
Add optimalFrameCacheSize for FLAnimatedImage. It makes users to set optimal frame cache size of FLAnimatedImage after image load.

AS-IS : optimal frame cache size of FLAnimatedImage set automatically after image load.

### New Pull Request Checklist

* [ ] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [ ] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [ ] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

...

