### PR TITLE
Remove the extra calculation of image orientation for ImageIO coder

### DIFF
--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -98,20 +98,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     
     UIImage *image = [[UIImage alloc] initWithData:data];
     
-#if SD_MAC
     return image;
-#else
-    if (!image) {
-        return nil;
-    }
-    
-    UIImageOrientation orientation = [[self class] sd_imageOrientationFromImageData:data];
-    if (orientation != UIImageOrientationUp) {
-        image = [[UIImage alloc] initWithCGImage:image.CGImage scale:image.scale orientation:orientation];
-    }
-    
-    return image;
-#endif
 }
 
 - (UIImage *)incrementallyDecodedImageWithData:(NSData *)data finished:(BOOL)finished {
@@ -515,31 +502,6 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     });
     return canEncode;
 }
-
-#if SD_UIKIT || SD_WATCH
-#pragma mark EXIF orientation tag converter
-+ (UIImageOrientation)sd_imageOrientationFromImageData:(nonnull NSData *)imageData {
-    UIImageOrientation result = UIImageOrientationUp;
-    CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
-    if (imageSource) {
-        CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, NULL);
-        if (properties) {
-            CFTypeRef val;
-            NSInteger exifOrientation;
-            val = CFDictionaryGetValue(properties, kCGImagePropertyOrientation);
-            if (val) {
-                CFNumberGetValue(val, kCFNumberNSIntegerType, &exifOrientation);
-                result = [SDWebImageCoderHelper imageOrientationFromEXIFOrientation:exifOrientation];
-            } // else - if it's not set it remains at up
-            CFRelease((CFTypeRef) properties);
-        } else {
-            //NSLog(@"NO PROPERTIES, FAIL");
-        }
-        CFRelease(imageSource);
-    }
-    return result;
-}
-#endif
 
 #if SD_UIKIT || SD_WATCH
 + (BOOL)shouldScaleDownImage:(nonnull UIImage *)image {

--- a/Tests/Tests/SDWebImageDecoderTests.m
+++ b/Tests/Tests/SDWebImageDecoderTests.m
@@ -82,20 +82,6 @@
     expect(decodedImage.size.height).to.equal(image.size.height);
 }
 
-- (void)test08ImageOrientationFromImageDataWithInvalidData {
-    // sync download image
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-    SEL selector = @selector(sd_imageOrientationFromImageData:);
-#pragma clang diagnostic pop
-    
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    UIImageOrientation orientation = (UIImageOrientation)[[SDWebImageImageIOCoder class] performSelector:selector withObject:nil];
-#pragma clang diagnostic pop
-    expect(orientation).to.equal(UIImageOrientationUp);
-}
-
 - (void)test09ThatStaticWebPCoderWorks {
     NSURL *staticWebPURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"TestImageStatic" withExtension:@"webp"];
     [self verifyCoder:[SDWebImageWebPCoder sharedCoder]


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2271  

### Pull Request Description

This PR is cherry-picked from #2271, which already merged in 5.x branch. This fix the extra decoding cost to check EXIF orientation.
Tested with iOS 7 device as well, now `+[UIImage imageWithData:]` can parse the EXIF orientation to image orientation, no need to manually check and using `+[UIImage imageWithCGImage:scale:orientation:]`

