### PR TITLE
Remove the duplicated process to force decode (draw on bitmap context) in Image/IO's progressive decoding.

### DIFF
--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -152,25 +152,6 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         // Create the image
         CGImageRef partialImageRef = CGImageSourceCreateImageAtIndex(_imageSource, 0, NULL);
         
-#if SD_UIKIT || SD_WATCH
-        // Workaround for iOS anamorphic image
-        if (partialImageRef) {
-            const size_t partialHeight = CGImageGetHeight(partialImageRef);
-            CGColorSpaceRef colorSpace = SDCGColorSpaceGetDeviceRGB();
-            CGContextRef bmContext = CGBitmapContextCreate(NULL, _width, _height, 8, 0, colorSpace, kCGBitmapByteOrderDefault | kCGImageAlphaPremultipliedFirst);
-            if (bmContext) {
-                CGContextDrawImage(bmContext, (CGRect){.origin.x = 0.0f, .origin.y = 0.0f, .size.width = _width, .size.height = partialHeight}, partialImageRef);
-                CGImageRelease(partialImageRef);
-                partialImageRef = CGBitmapContextCreateImage(bmContext);
-                CGContextRelease(bmContext);
-            }
-            else {
-                CGImageRelease(partialImageRef);
-                partialImageRef = nil;
-            }
-        }
-#endif
-        
         if (partialImageRef) {
 #if SD_UIKIT || SD_WATCH
             image = [[UIImage alloc] initWithCGImage:partialImageRef scale:1 orientation:_orientation];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2303 #2309 

### Pull Request Description

This PR is cherry-picked from #2303 which is merged in 5.x. This fix the extra draw during progressive decoding for JPEG/PNG images by Image/IO coder.

Tested with iOS 7 Real device, that fix is also works. So we should merge this into 4.x branch as well.
