### PR TITLE
Add `UIViewAnimationOptionAllowUserInteraction` as default options for convenient image transition

### DIFF
--- a/SDWebImage/SDWebImageTransition.h
+++ b/SDWebImage/SDWebImageTransition.h
@@ -62,7 +62,7 @@ typedef void (^SDWebImageTransitionCompletionBlock)(BOOL finished);
 @end
 
 // Convenience way to create transition. Remember to specify the duration if needed.
-// for UIKit, these transition just use the correspond `animationOptions`
+// for UIKit, these transition just use the correspond `animationOptions`. By default we enable `UIViewAnimationOptionAllowUserInteraction` to allow user interaction during transition.
 // for AppKit, these transition use Core Animation in `animations`. So your view must be layer-backed. Set `wantsLayer = YES` before you apply it.
 
 @interface SDWebImageTransition (Conveniences)

--- a/SDWebImage/SDWebImageTransition.m
+++ b/SDWebImage/SDWebImageTransition.m
@@ -31,7 +31,7 @@
 + (SDWebImageTransition *)fadeTransition {
     SDWebImageTransition *transition = [SDWebImageTransition new];
 #if SD_UIKIT
-    transition.animationOptions = UIViewAnimationOptionTransitionCrossDissolve;
+    transition.animationOptions = UIViewAnimationOptionTransitionCrossDissolve | UIViewAnimationOptionAllowUserInteraction;
 #else
     transition.animations = ^(__kindof NSView * _Nonnull view, NSImage * _Nullable image) {
         CATransition *trans = [CATransition animation];
@@ -45,7 +45,7 @@
 + (SDWebImageTransition *)flipFromLeftTransition {
     SDWebImageTransition *transition = [SDWebImageTransition new];
 #if SD_UIKIT
-    transition.animationOptions = UIViewAnimationOptionTransitionFlipFromLeft;
+    transition.animationOptions = UIViewAnimationOptionTransitionFlipFromLeft | UIViewAnimationOptionAllowUserInteraction;
 #else
     transition.animations = ^(__kindof NSView * _Nonnull view, NSImage * _Nullable image) {
         CATransition *trans = [CATransition animation];
@@ -60,7 +60,7 @@
 + (SDWebImageTransition *)flipFromRightTransition {
     SDWebImageTransition *transition = [SDWebImageTransition new];
 #if SD_UIKIT
-    transition.animationOptions = UIViewAnimationOptionTransitionFlipFromRight;
+    transition.animationOptions = UIViewAnimationOptionTransitionFlipFromRight | UIViewAnimationOptionAllowUserInteraction;
 #else
     transition.animations = ^(__kindof NSView * _Nonnull view, NSImage * _Nullable image) {
         CATransition *trans = [CATransition animation];
@@ -75,7 +75,7 @@
 + (SDWebImageTransition *)flipFromTopTransition {
     SDWebImageTransition *transition = [SDWebImageTransition new];
 #if SD_UIKIT
-    transition.animationOptions = UIViewAnimationOptionTransitionFlipFromTop;
+    transition.animationOptions = UIViewAnimationOptionTransitionFlipFromTop | UIViewAnimationOptionAllowUserInteraction;
 #else
     transition.animations = ^(__kindof NSView * _Nonnull view, NSImage * _Nullable image) {
         CATransition *trans = [CATransition animation];
@@ -90,7 +90,7 @@
 + (SDWebImageTransition *)flipFromBottomTransition {
     SDWebImageTransition *transition = [SDWebImageTransition new];
 #if SD_UIKIT
-    transition.animationOptions = UIViewAnimationOptionTransitionFlipFromBottom;
+    transition.animationOptions = UIViewAnimationOptionTransitionFlipFromBottom | UIViewAnimationOptionAllowUserInteraction;
 #else
     transition.animations = ^(__kindof NSView * _Nonnull view, NSImage * _Nullable image) {
         CATransition *trans = [CATransition animation];
@@ -105,7 +105,7 @@
 + (SDWebImageTransition *)curlUpTransition {
     SDWebImageTransition *transition = [SDWebImageTransition new];
 #if SD_UIKIT
-    transition.animationOptions = UIViewAnimationOptionTransitionCurlUp;
+    transition.animationOptions = UIViewAnimationOptionTransitionCurlUp | UIViewAnimationOptionAllowUserInteraction;
 #else
     transition.animations = ^(__kindof NSView * _Nonnull view, NSImage * _Nullable image) {
         CATransition *trans = [CATransition animation];
@@ -120,7 +120,7 @@
 + (SDWebImageTransition *)curlDownTransition {
     SDWebImageTransition *transition = [SDWebImageTransition new];
 #if SD_UIKIT
-    transition.animationOptions = UIViewAnimationOptionTransitionCurlDown;
+    transition.animationOptions = UIViewAnimationOptionTransitionCurlDown | UIViewAnimationOptionAllowUserInteraction;
 #else
     transition.animations = ^(__kindof NSView * _Nonnull view, NSImage * _Nullable image) {
         CATransition *trans = [CATransition animation];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2310 

### Pull Request Description

We introduce [image transition](https://github.com/rs/SDWebImage/wiki/Advanced-Usage#image-transition-430) feature from 4.3. Now some user suggest that we should allow user interaction during image transition animation. See #2310

For example, if we don't allow user interaction, during cell scrolling and you touch the cell to enter new page, this touch will be ignoed. Though you can manually set `UIViewAnimationOptionAllowUserInteraction`, but since it's a **convenient method** and most of people using image transition for tableView cell. I agree to set this options as default one.

So we just add all convenient image transition with the `UIViewAnimationOptionAllowUserInteraction` options. Simple changes :)