### PR TITLE
Add optimalFrameCacheSize && predrawingEnabled options for FLAnimatedImage

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -39,6 +39,20 @@
 @interface FLAnimatedImageView (WebCache)
 
 /**
+ * Optimal frame cache size of FLAnimatedImage during initializer. (1.0.11 version later)
+ * This value will help you set `optimalFrameCacheSize` arg of FLAnimatedImage initializer after image load.
+ * Defaults to 0.
+ */
+@property (nonatomic, assign) NSUInteger sd_optimalFrameCacheSize;
+
+/**
+ * Predrawing control of FLAnimatedImage during initializer. (1.0.11 version later)
+ * This value will help you set `predrawingEnabled` arg of FLAnimatedImage initializer after image load.
+ * Defaults to YES.
+ */
+@property (nonatomic, assign) BOOL sd_predrawingEnabled;
+
+/**
  * Load the image at the given url (either from cache or download) and load it in this imageView. It works with both static and dynamic images
  * The download is asynchronous and cached.
  *

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -29,6 +29,33 @@
 
 @implementation FLAnimatedImageView (WebCache)
 
+// These property based options will moved to `SDWebImageContext` in 5.x, to allow per-image-request level options instead of per-imageView-level options
+- (NSUInteger)sd_optimalFrameCacheSize {
+    NSUInteger optimalFrameCacheSize = 0;
+    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_optimalFrameCacheSize));
+    if ([value isKindOfClass:[NSNumber class]]) {
+        optimalFrameCacheSize = value.unsignedShortValue;
+    }
+    return optimalFrameCacheSize;
+}
+
+- (void)setSd_optimalFrameCacheSize:(NSUInteger)sd_optimalFrameCacheSize {
+    objc_setAssociatedObject(self, @selector(sd_optimalFrameCacheSize), @(sd_optimalFrameCacheSize), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (BOOL)sd_predrawingEnabled {
+    BOOL predrawingEnabled = YES;
+    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_predrawingEnabled));
+    if ([value isKindOfClass:[NSNumber class]]) {
+        predrawingEnabled = value.boolValue;
+    }
+    return predrawingEnabled;
+}
+
+- (void)setSd_predrawingEnabled:(BOOL)sd_predrawingEnabled {
+    objc_setAssociatedObject(self, @selector(sd_predrawingEnabled), @(sd_predrawingEnabled), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 - (void)sd_setImageWithURL:(nullable NSURL *)url {
     [self sd_setImageWithURL:url placeholderImage:nil options:0 progress:nil completed:nil];
 }
@@ -83,7 +110,13 @@
                                weakSelf.animatedImage = nil;
                                // Secondly create FLAnimatedImage in global queue because it's time consuming, then set it back
                                dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-                                   FLAnimatedImage *animatedImage = [FLAnimatedImage animatedImageWithGIFData:imageData];
+                                   FLAnimatedImage *animatedImage;
+                                   // Compatibility in 4.x for lower version FLAnimatedImage.
+                                   if ([FLAnimatedImage respondsToSelector:@selector(initWithAnimatedGIFData:optimalFrameCacheSize:predrawingEnabled:)]) {
+                                       animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:self.sd_optimalFrameCacheSize predrawingEnabled:self.sd_predrawingEnabled];
+                                   } else {
+                                       animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData];
+                                   }
                                    dispatch_async(dispatch_get_main_queue(), ^{
                                        image.sd_FLAnimatedImage = animatedImage;
                                        weakSelf.animatedImage = animatedImage;


### PR DESCRIPTION
It makes users to set optimal frame cache size of FLAnimatedImage after image load.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2308 

### Pull Request Description

Thir PR is original from #2308. Seems some user need the extra options to feed `FLAnimatedImage`'s initializer.

This solution is kept compatibility in 4.x. In 5.x, this will using `SDWebImageContext` solution instead of imageView level config. And `FLAnimatedImage` plugin code will move to another repo called [SDWebImageFLPlugin](https://github.com/dreampiggy/SDWebImageFLPlugin).