### PR TITLE
Fix the progressive decoding bug on macOS. Including image orientation & SDAnimatedimageView

### DIFF
--- a/SDWebImage/NSImage+Compatibility.m
+++ b/SDWebImage/NSImage+Compatibility.m
@@ -46,7 +46,7 @@
         // AppKit design is different from UIKit. Where CGImage based image rep does not respect to any orientation. Only data based image rep which contains the EXIF metadata can automatically detect orientation.
         // This should be nonnull, until the memory is exhausted cause `CGBitmapContextCreate` failed.
         CGImageRef rotatedCGImage = [SDImageCoderHelper CGImageCreateDecoded:cgImage orientation:orientation];
-        imageRep = [[NSBitmapImageRep alloc] initWithCGImage:cgImage];
+        imageRep = [[NSBitmapImageRep alloc] initWithCGImage:rotatedCGImage];
         CGImageRelease(rotatedCGImage);
     } else {
         imageRep = [[NSBitmapImageRep alloc] initWithCGImage:cgImage];

--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -322,6 +322,9 @@ dispatch_semaphore_signal(self->_lock);
         }
         
         [self.layer setNeedsDisplay];
+#if SD_MAC
+        [self.layer displayIfNeeded]; // macOS's imageViewLayer is not equal to self.layer. But `[super setImage:]` will impliedly mark it needsDisplay. We call `[self.layer displayIfNeeded]` to immediately refresh the imageViewLayer to avoid flashing
+#endif
     }
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This PR fix the image orientation during progressive decoding & SDAnimatedImage on the macOS :)
This will not add to milestone because it's just a bugfix during new feature development for 5.x
