### PR TITLE
Fix that watchOS UIImage+WebCache does not mark as available and cause crash

### DIFF
--- a/SDWebImage/UIImage+WebCache.m
+++ b/SDWebImage/UIImage+WebCache.m
@@ -10,7 +10,7 @@
 #import "NSImage+Compatibility.h"
 #import "objc/runtime.h"
 
-#if SD_UIKIT
+#if SD_UIKIT || SD_WATCH
 
 @implementation UIImage (WebCache)
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This PR fix the 5.x development bug that `UIImage+WebCache` category header files mark this available for iOS/tvOS/watchOS/macOS. But the implementation files does not cover watchOS. So there will be a runtime exception when using. Still stupid bug...:)

