### PR TITLE
Replace @synchronized with dispatch_semaphore_t in SDWebImageManager

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -347,20 +347,34 @@
 @end
 
 
+@interface SDWebImageCombinedOperation ()
+
+@property (strong, nonatomic, nonnull) dispatch_semaphore_t cancelLock; // a lock to make the `cancel` method thread-safe
+
+@end
+
 @implementation SDWebImageCombinedOperation
 
-- (void)cancel {
-    @synchronized(self) {
-        self.cancelled = YES;
-        if (self.cacheOperation) {
-            [self.cacheOperation cancel];
-            self.cacheOperation = nil;
-        }
-        if (self.downloadToken) {
-            [self.manager.imageDownloader cancel:self.downloadToken];
-        }
-        [self.manager safelyRemoveOperationFromRunning:self];
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _cancelLock = dispatch_semaphore_create(1);
     }
+    return self;
+}
+
+- (void)cancel {
+    LOCK(self.cancelLock);
+    self.cancelled = YES;
+    if (self.cacheOperation) {
+        [self.cacheOperation cancel];
+        self.cacheOperation = nil;
+    }
+    if (self.downloadToken) {
+        [self.manager.imageDownloader cancel:self.downloadToken];
+    }
+    [self.manager safelyRemoveOperationFromRunning:self];
+    UNLOCK(self.cancelLock);
 }
 
 @end

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -9,7 +9,6 @@
 #import "SDWebImageManager.h"
 #import "NSImage+WebCache.h"
 #import <objc/message.h>
-#import <pthread/pthread.h>
 
 #define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
 #define UNLOCK(lock) dispatch_semaphore_signal(lock);

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -314,10 +314,11 @@
 }
 
 - (void)safelyRemoveOperationFromRunning:(nullable SDWebImageCombinedOperation*)operation {
-    LOCK(self.runningOperationsLock);
-    if (operation) {
-        [self.runningOperations removeObject:operation];
+    if (!operation) {
+        return;
     }
+    LOCK(self.runningOperationsLock);
+    [self.runningOperations removeObject:operation];
     UNLOCK(self.runningOperationsLock);
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request reffers to the following issues: https://github.com/rs/SDWebImage/issues/2267

### Pull Request Description
Replace `@synchronized` with `pthread_mutex_t` & `dispatch_semaphore_t` in `SDWebImageManager` to improve lock performance.

Two locks are updated:

1. For `failedURLs`, `dispatch_semaphore_t` is used, just likes the case in `SDWebImageDownloader`.

2. For `runningOperations`, `pthread_mutex_t` is used instead, since it requires recursiveness, which is not support by `dispatch_semaphore_t` .