### PR TITLE
Add the support for watchOS to use View Category method (sd_setImageWithURL:) on WKInterfaceImage

### DIFF
--- a/Examples/SDWebImage Watch Demo Extension/InterfaceController.m
+++ b/Examples/SDWebImage Watch Demo Extension/InterfaceController.m
@@ -7,7 +7,7 @@
  */
 
 #import "InterfaceController.h"
-#import <SDWebImage/SDWebImageManager.h>
+#import <SDWebImage/UIImageView+WebCache.h>
 
 
 @interface InterfaceController()
@@ -30,9 +30,8 @@
     [super willActivate];
     
     NSString *urlString = @"https://nr-platform.s3.amazonaws.com/uploads/platform/published_extension/branding_icon/275/AmazonS3.png";
-    [[SDWebImageManager sharedManager] loadImageWithURL:[NSURL URLWithString:urlString] options:0 progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
-        self.imageInterface.image = image;
-    }];
+    WKInterfaceImage *imageInterface = self.imageInterface;
+    [imageInterface sd_setImageWithURL:[NSURL URLWithString:urlString]];
 }
 
 - (void)didDeactivate {

--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -70,6 +70,12 @@
     #endif
     #if SD_WATCH
         #import <WatchKit/WatchKit.h>
+        #ifndef UIView
+            #define UIView WKInterfaceObject
+        #endif
+        #ifndef UIImageView
+            #define UIImageView WKInterfaceImage
+        #endif
     #endif
 #endif
 

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -7,9 +7,6 @@
  */
 
 #import "SDWebImageCompat.h"
-
-#if SD_UIKIT || SD_MAC
-
 #import "SDWebImageManager.h"
 
 /**
@@ -195,5 +192,3 @@
 #endif
 
 @end
-
-#endif

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -7,9 +7,6 @@
  */
 
 #import "UIImageView+WebCache.h"
-
-#if SD_UIKIT || SD_MAC
-
 #import "objc/runtime.h"
 #import "UIView+WebCacheOperation.h"
 #import "UIView+WebCache.h"
@@ -140,5 +137,3 @@ static char animationLoadOperationKey;
 #endif
 
 @end
-
-#endif

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -7,9 +7,6 @@
  */
 
 #import "SDWebImageCompat.h"
-
-#if SD_UIKIT || SD_MAC
-
 #import "SDWebImageManager.h"
 #import "SDWebImageTransition.h"
 
@@ -105,6 +102,8 @@ typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable ima
  */
 - (void)sd_cancelCurrentImageLoad;
 
+#if SD_UIKIT || SD_MAC
+
 #pragma mark - Image Transition
 
 /**
@@ -135,6 +134,6 @@ typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable ima
 
 #endif
 
-@end
-
 #endif
+
+@end

--- a/SDWebImage/UIView+WebCacheOperation.h
+++ b/SDWebImage/UIView+WebCacheOperation.h
@@ -7,10 +7,7 @@
  */
 
 #import "SDWebImageCompat.h"
-
-#if SD_UIKIT || SD_MAC
-
-#import "SDWebImageManager.h"
+#import "SDWebImageOperation.h"
 
 // These methods are used to support canceling for UIView image loading, it's designed to be used internal but not external.
 // All the stored operations are weak, so it will be dalloced after image loading finished. If you need to store operations, use your own class to keep a strong reference for them.
@@ -39,5 +36,3 @@
 - (void)sd_removeImageLoadOperationWithKey:(nullable NSString *)key;
 
 @end
-
-#endif

--- a/SDWebImage/UIView+WebCacheOperation.m
+++ b/SDWebImage/UIView+WebCacheOperation.m
@@ -7,9 +7,6 @@
  */
 
 #import "UIView+WebCacheOperation.h"
-
-#if SD_UIKIT || SD_MAC
-
 #import "objc/runtime.h"
 
 static char loadOperationKey;
@@ -71,5 +68,3 @@ typedef NSMapTable<NSString *, id<SDWebImageOperation>> SDOperationsDictionary;
 }
 
 @end
-
-#endif


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2331 #1070

### Pull Request Description

This PR is cherry-picked from the #2331. Which is already been merged in 5.x branch. However, since this feature is not a API-breaking change, and it's not hard to merge to 4.x as well. So I think we can adopt it to 4.x.

And, after some consideration, I suggest that the next version we can upgrade a minor version, to 4.4.0. Why do so, may because next version we contains 3 feature PR (#2308, #2281 and this one), we also change a little behavior from previous version (#2315), and many historical bugfix. Some changes may not so obvious, but may impact the user usage. So I guess a minor upgrade version should be more acceptable to follow sem-version.

