### PR TITLE
Fix that the downloader operation may not call the completion block in race condition

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -275,7 +275,8 @@
     
     LOCK(self.operationsLock);
     SDWebImageDownloaderOperation *operation = [self.URLOperations objectForKey:url];
-    if (!operation) {
+    // There is a case that the operation may be marked as finished, but not been removed from `self.URLOperations`.
+    if (!operation || operation.isFinished) {
         operation = createCallback();
         __weak typeof(self) wself = self;
         operation.completionBlock = ^{


### PR DESCRIPTION
Which the operation we get is finished but not been removed from the operation array.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2344 

### Pull Request Description

See #2344. There may be a race condition cause the `SDWebImageDownloadOperation` been marked as finished and no longer running, but in `SDWebImageDownloader` we get this finished operation and add the progressBlock & completioinBlock to it. So final the progressBlock & completionBlock is not been called at all.

