### PR TITLE
Fix that WebP (including Animated WebP) decoding issue on iOS 12.

### DIFF
--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -73,9 +73,12 @@
     int canvasWidth = WebPDemuxGetI(demuxer, WEBP_FF_CANVAS_WIDTH);
     int canvasHeight = WebPDemuxGetI(demuxer, WEBP_FF_CANVAS_HEIGHT);
     CGBitmapInfo bitmapInfo;
+    // `CGBitmapContextCreate` does not support RGB888 on iOS. Where `CGImageCreate` supports.
     if (!(flags & ALPHA_FLAG)) {
+        // RGBX8888
         bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaNoneSkipLast;
     } else {
+        // RGBA8888
         bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast;
     }
     CGContextRef canvas = CGBitmapContextCreate(NULL, canvasWidth, canvasHeight, 8, 0, SDCGColorSpaceGetDeviceRGB(), bitmapInfo);
@@ -298,7 +301,15 @@
     CGDataProviderRef provider =
     CGDataProviderCreateWithData(NULL, config.output.u.RGBA.rgba, config.output.u.RGBA.size, FreeImageData);
     CGColorSpaceRef colorSpaceRef = SDCGColorSpaceGetDeviceRGB();
-    CGBitmapInfo bitmapInfo = config.input.has_alpha ? kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast : kCGBitmapByteOrder32Big | kCGImageAlphaNoneSkipLast;
+    CGBitmapInfo bitmapInfo;
+    // `CGBitmapContextCreate` does not support RGB888 on iOS. Where `CGImageCreate` supports.
+    if (!config.input.has_alpha) {
+        // RGB888
+        bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaNone;
+    } else {
+        // RGBA8888
+        bitmapInfo = kCGBitmapByteOrder32Big | kCGImageAlphaPremultipliedLast;
+    }
     size_t components = config.input.has_alpha ? 4 : 3;
     CGColorRenderingIntent renderingIntent = kCGRenderingIntentDefault;
     CGImageRef imageRef = CGImageCreate(width, height, 8, components * 8, components * width, colorSpaceRef, bitmapInfo, provider, NULL, NO, renderingIntent);


### PR DESCRIPTION
Using the correct bitmapInfo to avoid `CGImageCreate` failed when the WebP image contains no alpha channel

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2347 

### Pull Request Description

Fix the WebP (including Animated WebP) decoding issue for non-alpha channel image. This is because that the wrong arg using in `CGImageCreate` method to create bitmap image. It's not been founded because the previous iOS realease seems not cause any issue. Only happend on iOS 12.

However, that `CGBitmapContextCreate` does not support RGB888 on iOS (only on macOS). So we'd better using RGBX8888 as usual to create a non-alpha channel bitmap context.

PS: For non-alpha image, using 3-channel `RGB888` can save 1/4 memory usage than using a 4-channel `RGBX8888`, so we'd better using that unless the API does not support.