### PR TITLE
Refactor the UIImage+MultiFormat and GIF/WebP category

### DIFF
--- a/SDWebImage/UIImage+GIF.h
+++ b/SDWebImage/UIImage+GIF.h
@@ -9,24 +9,16 @@
 
 #import "SDWebImageCompat.h"
 
+// This category is just use as a convenience method. For more detail control, use methods in `UIImage+MultiFormat.h` or directlly use `SDImageCoder`
 @interface UIImage (GIF)
 
 /**
  Creates an animated UIImage from an NSData.
- For Static GIF, will create an UIImage with `images` array set to nil. For Animated GIF, will create an UIImage with valid `images` array.
+ This will create animated image if the data is Animated GIF. And will create a static image is the data is Static GIF.
 
  @param data The GIF data
  @return The created image
  */
-+ (nullable UIImage *)sd_animatedGIFWithData:(nullable NSData *)data;
-
-/**
- Creates an animated UIImage from an NSData.
- 
- @param data The GIF data
- @param firstFrameOnly Even if the image data is Animated GIF format, decode the first frame only
- @return The created image
- */
-+ (nullable UIImage *)sd_animatedGIFWithData:(nullable NSData *)data firstFrameOnly:(BOOL)firstFrameOnly;
++ (nullable UIImage *)sd_imageWithGIFData:(nullable NSData *)data;
 
 @end

--- a/SDWebImage/UIImage+GIF.m
+++ b/SDWebImage/UIImage+GIF.m
@@ -12,16 +12,11 @@
 
 @implementation UIImage (GIF)
 
-+ (nullable UIImage *)sd_animatedGIFWithData:(nullable NSData *)data {
-    return [self sd_animatedGIFWithData:data firstFrameOnly:NO];
-}
-
-+ (nullable UIImage *)sd_animatedGIFWithData:(nullable NSData *)data firstFrameOnly:(BOOL)firstFrameOnly {
++ (nullable UIImage *)sd_imageWithGIFData:(nullable NSData *)data {
     if (!data) {
         return nil;
     }
-    SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(firstFrameOnly)};
-    return [[SDImageGIFCoder sharedCoder] decodedImageWithData:data options:options];
+    return [[SDImageGIFCoder sharedCoder] decodedImageWithData:data options:0];
 }
 
 @end

--- a/SDWebImage/UIImage+MultiFormat.h
+++ b/SDWebImage/UIImage+MultiFormat.h
@@ -28,6 +28,16 @@
  */
 + (nullable UIImage *)sd_imageWithData:(nullable NSData *)data scale:(CGFloat)scale;
 
+/**
+ Create and decode a image with the specify image data and scale, allow specify animate/static control
+ 
+ @param data The image data
+ @param scale The image scale factor. Should be greater than or equal to 1.0.
+ @param firstFrameOnly Even if the image data is animated image format, decode the first frame only as static image.
+ @return The created image
+ */
++ (nullable UIImage *)sd_imageWithData:(nullable NSData *)data scale:(CGFloat)scale firstFrameOnly:(BOOL)firstFrameOnly;
+
 #pragma mark - Encode
 /**
  Encode the current image to the data, the image format is unspecified
@@ -52,5 +62,15 @@
  @return The encoded data. If can't encode, return nil
  */
 - (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat compressionQuality:(double)compressionQuality;
+
+/**
+ Encode the current image to data with the specify image format and compression quality, allow specify animate/static control
+ 
+ @param imageFormat The specify image format
+ @param compressionQuality The quality of the resulting image data. Value between 0.0-1.0. Some coders may not support compression quality.
+ @param firstFrameOnly Even if the image is animated image, encode the first frame only as static image.
+ @return The encoded data. If can't encode, return nil
+ */
+- (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat compressionQuality:(double)compressionQuality firstFrameOnly:(BOOL)firstFrameOnly;
 
 @end

--- a/SDWebImage/UIImage+MultiFormat.m
+++ b/SDWebImage/UIImage+MultiFormat.m
@@ -16,13 +16,17 @@
 }
 
 + (nullable UIImage *)sd_imageWithData:(nullable NSData *)data scale:(CGFloat)scale {
+    return [self sd_imageWithData:data scale:scale firstFrameOnly:NO];
+}
+
++ (nullable UIImage *)sd_imageWithData:(nullable NSData *)data scale:(CGFloat)scale firstFrameOnly:(BOOL)firstFrameOnly {
     if (!data) {
         return nil;
     }
     if (scale < 1) {
         scale = 1;
     }
-    SDImageCoderOptions *options = @{SDImageCoderDecodeScaleFactor : @(scale)};
+    SDImageCoderOptions *options = @{SDImageCoderDecodeScaleFactor : @(scale), SDImageCoderDecodeFirstFrameOnly : @(firstFrameOnly)};
     return [[SDImageCodersManager sharedManager] decodedImageWithData:data options:options];
 }
 
@@ -35,7 +39,11 @@
 }
 
 - (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat compressionQuality:(double)compressionQuality {
-    SDImageCoderOptions *options = @{SDImageCoderEncodeCompressionQuality : @(compressionQuality)};
+    return [self sd_imageDataAsFormat:imageFormat compressionQuality:compressionQuality firstFrameOnly:NO];
+}
+
+- (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat compressionQuality:(double)compressionQuality firstFrameOnly:(BOOL)firstFrameOnly {
+    SDImageCoderOptions *options = @{SDImageCoderEncodeCompressionQuality : @(compressionQuality), SDImageCoderEncodeFirstFrameOnly : @(firstFrameOnly)};
     return [[SDImageCodersManager sharedManager] encodedDataWithImage:self format:imageFormat options:options];
 }
 

--- a/SDWebImage/WebP/UIImage+WebP.h
+++ b/SDWebImage/WebP/UIImage+WebP.h
@@ -10,25 +10,17 @@
 
 #import "SDWebImageCompat.h"
 
+// This category is just use as a convenience method. For more detail control, use methods in `UIImage+MultiFormat.h` or directlly use `SDImageCoder`
 @interface UIImage (WebP)
 
 /**
  Create a image from the WebP data.
- This may create animated image if the data is Animated WebP.
+ This will create animated image if the data is Animated WebP. And will create a static image is the data is Static WebP.
 
  @param data The WebP data
  @return The created image
  */
 + (nullable UIImage *)sd_imageWithWebPData:(nullable NSData *)data;
-
-/**
- Create a image from the WebP data.
- 
- @param data The WebP data
- @param firstFrameOnly Even if the image data is Animated WebP format, decode the first frame only
- @return The created image
- */
-+ (nullable UIImage *)sd_imageWithWebPData:(nullable NSData *)data firstFrameOnly:(BOOL)firstFrameOnly;
 
 @end
 

--- a/SDWebImage/WebP/UIImage+WebP.m
+++ b/SDWebImage/WebP/UIImage+WebP.m
@@ -14,15 +14,10 @@
 @implementation UIImage (WebP)
 
 + (nullable UIImage *)sd_imageWithWebPData:(nullable NSData *)data {
-    return [self sd_imageWithWebPData:data firstFrameOnly:NO];
-}
-
-+ (nullable UIImage *)sd_imageWithWebPData:(nullable NSData *)data firstFrameOnly:(BOOL)firstFrameOnly {
     if (!data) {
         return nil;
     }
-    SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(firstFrameOnly)};
-    return [[SDImageWebPCoder sharedCoder] decodedImageWithData:data options:options];
+    return [[SDImageWebPCoder sharedCoder] decodedImageWithData:data options:0];
 }
 
 @end

--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -43,11 +43,11 @@
 
 - (void)test03UIImageGIFCategory {
     // Test invalid image data
-    UIImage *image = [UIImage sd_animatedGIFWithData:nil];
+    UIImage *image = [UIImage sd_imageWithGIFData:nil];
     expect(image).to.beNil();
     // Test valid image data
     NSData *data = [NSData dataWithContentsOfFile:[self testGIFPath]];
-    image = [UIImage sd_animatedGIFWithData:data];
+    image = [UIImage sd_imageWithGIFData:data];
     expect(image).notTo.beNil();
 }
 


### PR DESCRIPTION
Simplify the usage and remove the extra method which is not used so common.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

### Reason
This PR is a refactory for our convenience category `UIImage+MultiFormat`.
Since SDWebImage 4.2, we introduce custom image coder feature and move all the core decoding/encoding code into `SDImageCoder`. So actually these method is just a simple wrapper.

We can now put it further and sync the coder option with more easier-use API for convenience.

The `UIImage+WebP` and `UIImage+GIF` category, however, it's just a special image format type, which is not really good to use. So just keep it as simple and no extra control. If user need detailed control about decoding/encoding, check `UIImage+MultiFormat` or use `SDImageCoder` directly

### Design

```swift
extension UIImage {
    // MARK: Decoding
    open class func sd_image(with data: Data?) -> UIImage?
    open class func sd_image(with data: Data?, scale: CGFloat) -> UIImage?
    open class func sd_image(with data: Data?, scale: CGFloat, firstFrameOnly: Bool) -> UIImage?

    // MARK: Encoding
    open func sd_imageData() -> Data?
    open func sd_imageData(as imageFormat: SDImageFormat) -> Data?
    open func sd_imageData(as imageFormat: SDImageFormat, compressionQuality: Double) -> Data?
    open func sd_imageData(as imageFormat: SDImageFormat, compressionQuality: Double, firstFrameOnly: Bool) -> Data?
}
```