### PR TITLE
Add one convenient method to pass context arg without completed block for all View Category

### DIFF
--- a/SDWebImage/MapKit/MKAnnotationView+WebCache.h
+++ b/SDWebImage/MapKit/MKAnnotationView+WebCache.h
@@ -54,6 +54,22 @@
                    options:(SDWebImageOptions)options NS_REFINED_FOR_SWIFT;
 
 /**
+ * Set the imageView `image` with an `url`, placeholder, custom options and context.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url         The url for the image.
+ * @param placeholder The image to be set initially, until the image request finishes.
+ * @param options     The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param context     A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ */
+
+- (void)sd_setImageWithURL:(nullable NSURL *)url
+          placeholderImage:(nullable UIImage *)placeholder
+                   options:(SDWebImageOptions)options
+                   context:(nullable SDWebImageContext *)context;
+
+/**
  * Set the imageView `image` with an `url`.
  *
  * The download is asynchronous and cached.
@@ -127,7 +143,7 @@
                  completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the imageView `image` with an `url`, placeholder and custom options.
+ * Set the imageView `image` with an `url`, placeholder, custom options and context.
  *
  * The download is asynchronous and cached.
  *

--- a/SDWebImage/MapKit/MKAnnotationView+WebCache.m
+++ b/SDWebImage/MapKit/MKAnnotationView+WebCache.m
@@ -25,7 +25,11 @@
 }
 
 - (void)sd_setImageWithURL:(nullable NSURL *)url placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options {
-    [self sd_setImageWithURL:url placeholderImage:placeholder options:options completed:nil];
+    [self sd_setImageWithURL:url placeholderImage:placeholder options:options progress:nil completed:nil];
+}
+
+- (void)sd_setImageWithURL:(nullable NSURL *)url placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context {
+    [self sd_setImageWithURL:url placeholderImage:placeholder options:options context:context progress:nil completed:nil];
 }
 
 - (void)sd_setImageWithURL:(nullable NSURL *)url completed:(nullable SDExternalCompletionBlock)completedBlock {

--- a/SDWebImage/NSButton+WebCache.h
+++ b/SDWebImage/NSButton+WebCache.h
@@ -56,6 +56,21 @@
                    options:(SDWebImageOptions)options NS_REFINED_FOR_SWIFT;
 
 /**
+ * Set the button `image` with an `url`, placeholder and custom options.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url         The url for the image.
+ * @param placeholder The image to be set initially, until the image request finishes.
+ * @param options     The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param context     A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ */
+- (void)sd_setImageWithURL:(nullable NSURL *)url
+          placeholderImage:(nullable UIImage *)placeholder
+                   options:(SDWebImageOptions)options
+                   context:(nullable SDWebImageContext *)context;
+
+/**
  * Set the button `image` with an `url`.
  *
  * The download is asynchronous and cached.
@@ -194,6 +209,21 @@
                             options:(SDWebImageOptions)options NS_REFINED_FOR_SWIFT;
 
 /**
+ * Set the button `alternateImage` with an `url`, placeholder, custom options and context.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url         The url for the alternateImage.
+ * @param placeholder The alternateImage to be set initially, until the alternateImage request finishes.
+ * @param options     The options to use when downloading the alternateImage. @see SDWebImageOptions for the possible values.
+ * @param context     A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ */
+- (void)sd_setAlternateImageWithURL:(nullable NSURL *)url
+                   placeholderImage:(nullable UIImage *)placeholder
+                            options:(SDWebImageOptions)options
+                            context:(nullable SDWebImageContext *)context;
+
+/**
  * Set the button `alternateImage` with an `url`.
  *
  * The download is asynchronous and cached.
@@ -267,7 +297,7 @@
                           completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the button `alternateImage` with an `url`, placeholder and custom options.
+ * Set the button `alternateImage` with an `url`, placeholder, custom options and context.
  *
  * The download is asynchronous and cached.
  *

--- a/SDWebImage/NSButton+WebCache.m
+++ b/SDWebImage/NSButton+WebCache.m
@@ -32,6 +32,10 @@ static NSString * const SDAlternateImageOperationKey = @"NSButtonAlternateImageO
     [self sd_setImageWithURL:url placeholderImage:placeholder options:options progress:nil completed:nil];
 }
 
+- (void)sd_setImageWithURL:(nullable NSURL *)url placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context {
+    [self sd_setImageWithURL:url placeholderImage:placeholder options:options context:context progress:nil completed:nil];
+}
+
 - (void)sd_setImageWithURL:(nullable NSURL *)url completed:(nullable SDExternalCompletionBlock)completedBlock {
     [self sd_setImageWithURL:url placeholderImage:nil options:0 progress:nil completed:completedBlock];
 }
@@ -80,6 +84,10 @@ static NSString * const SDAlternateImageOperationKey = @"NSButtonAlternateImageO
 
 - (void)sd_setAlternateImageWithURL:(nullable NSURL *)url placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options {
     [self sd_setAlternateImageWithURL:url placeholderImage:placeholder options:options progress:nil completed:nil];
+}
+
+- (void)sd_setAlternateImageWithURL:(nullable NSURL *)url placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context {
+    [self sd_setAlternateImageWithURL:url placeholderImage:placeholder options:options context:context progress:nil completed:nil];
 }
 
 - (void)sd_setAlternateImageWithURL:(nullable NSURL *)url completed:(nullable SDExternalCompletionBlock)completedBlock {

--- a/SDWebImage/SDAnimatedImageView+WebCache.h
+++ b/SDWebImage/SDAnimatedImageView+WebCache.h
@@ -49,6 +49,21 @@
                    options:(SDWebImageOptions)options NS_REFINED_FOR_SWIFT;
 
 /**
+ * Set the imageView `image` with an `url`, placeholder, custom options and context.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url         The url for the image.
+ * @param placeholder The image to be set initially, until the image request finishes.
+ * @param options     The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param context     A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ */
+- (void)sd_setImageWithURL:(nullable NSURL *)url
+          placeholderImage:(nullable UIImage *)placeholder
+                   options:(SDWebImageOptions)options
+                   context:(nullable SDWebImageContext *)context;
+
+/**
  * Set the imageView `image` with an `url`.
  *
  * The download is asynchronous and cached.
@@ -122,7 +137,7 @@
                  completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the imageView `image` with an `url`, placeholder and custom options.
+ * Set the imageView `image` with an `url`, placeholder, custom options and context.
  *
  * The download is asynchronous and cached.
  *

--- a/SDWebImage/SDAnimatedImageView+WebCache.m
+++ b/SDWebImage/SDAnimatedImageView+WebCache.m
@@ -27,6 +27,10 @@
     [self sd_setImageWithURL:url placeholderImage:placeholder options:options progress:nil completed:nil];
 }
 
+- (void)sd_setImageWithURL:(nullable NSURL *)url placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context {
+    [self sd_setImageWithURL:url placeholderImage:placeholder options:options context:context progress:nil completed:nil];
+}
+
 - (void)sd_setImageWithURL:(nullable NSURL *)url completed:(nullable SDExternalCompletionBlock)completedBlock {
     [self sd_setImageWithURL:url placeholderImage:nil options:0 progress:nil completed:completedBlock];
 }

--- a/SDWebImage/UIButton+WebCache.h
+++ b/SDWebImage/UIButton+WebCache.h
@@ -32,7 +32,7 @@
 - (nullable NSURL *)sd_imageURLForState:(UIControlState)state;
 
 /**
- * Set the imageView `image` with an `url`.
+ * Set the button `image` with an `url`.
  *
  * The download is asynchronous and cached.
  *
@@ -43,7 +43,7 @@
                   forState:(UIControlState)state NS_REFINED_FOR_SWIFT;
 
 /**
- * Set the imageView `image` with an `url` and a placeholder.
+ * Set the button `image` with an `url` and a placeholder.
  *
  * The download is asynchronous and cached.
  *
@@ -57,7 +57,7 @@
           placeholderImage:(nullable UIImage *)placeholder NS_REFINED_FOR_SWIFT;
 
 /**
- * Set the imageView `image` with an `url`, placeholder and custom options.
+ * Set the button `image` with an `url`, placeholder and custom options.
  *
  * The download is asynchronous and cached.
  *
@@ -72,7 +72,24 @@
                    options:(SDWebImageOptions)options NS_REFINED_FOR_SWIFT;
 
 /**
- * Set the imageView `image` with an `url`.
+ * Set the button `image` with an `url`, placeholder, custom options and context.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url         The url for the image.
+ * @param state       The state that uses the specified title. The values are described in UIControlState.
+ * @param placeholder The image to be set initially, until the image request finishes.
+ * @param options     The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param context     A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ */
+- (void)sd_setImageWithURL:(nullable NSURL *)url
+                  forState:(UIControlState)state
+          placeholderImage:(nullable UIImage *)placeholder
+                   options:(SDWebImageOptions)options
+                   context:(nullable SDWebImageContext *)context;
+
+/**
+ * Set the button `image` with an `url`.
  *
  * The download is asynchronous and cached.
  *
@@ -89,7 +106,7 @@
                  completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the imageView `image` with an `url`, placeholder.
+ * Set the button `image` with an `url`, placeholder.
  *
  * The download is asynchronous and cached.
  *
@@ -108,7 +125,7 @@
                  completed:(nullable SDExternalCompletionBlock)completedBlock NS_REFINED_FOR_SWIFT;
 
 /**
- * Set the imageView `image` with an `url`, placeholder and custom options.
+ * Set the button `image` with an `url`, placeholder and custom options.
  *
  * The download is asynchronous and cached.
  *
@@ -129,7 +146,7 @@
                  completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the imageView `image` with an `url`, placeholder and custom options.
+ * Set the button `image` with an `url`, placeholder and custom options.
  *
  * The download is asynchronous and cached.
  *
@@ -153,7 +170,7 @@
                  completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the imageView `image` with an `url`, placeholder and custom options.
+ * Set the button `image` with an `url`, placeholder, custom options and context.
  *
  * The download is asynchronous and cached.
  *
@@ -193,7 +210,7 @@
 - (nullable NSURL *)sd_backgroundImageURLForState:(UIControlState)state;
 
 /**
- * Set the backgroundImageView `image` with an `url`.
+ * Set the button `backgroundImage` with an `url`.
  *
  * The download is asynchronous and cached.
  *
@@ -204,7 +221,7 @@
                             forState:(UIControlState)state NS_REFINED_FOR_SWIFT;
 
 /**
- * Set the backgroundImageView `image` with an `url` and a placeholder.
+ * Set the button `backgroundImage` with an `url` and a placeholder.
  *
  * The download is asynchronous and cached.
  *
@@ -218,7 +235,7 @@
                     placeholderImage:(nullable UIImage *)placeholder NS_REFINED_FOR_SWIFT;
 
 /**
- * Set the backgroundImageView `image` with an `url`, placeholder and custom options.
+ * Set the button `backgroundImage` with an `url`, placeholder and custom options.
  *
  * The download is asynchronous and cached.
  *
@@ -233,7 +250,24 @@
                              options:(SDWebImageOptions)options NS_REFINED_FOR_SWIFT;
 
 /**
- * Set the backgroundImageView `image` with an `url`.
+ * Set the button `backgroundImage` with an `url`, placeholder, custom options and context.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url         The url for the image.
+ * @param state       The state that uses the specified title. The values are described in UIControlState.
+ * @param placeholder The image to be set initially, until the image request finishes.
+ * @param options     The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param context     A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ */
+- (void)sd_setBackgroundImageWithURL:(nullable NSURL *)url
+                            forState:(UIControlState)state
+                    placeholderImage:(nullable UIImage *)placeholder
+                             options:(SDWebImageOptions)options
+                             context:(nullable SDWebImageContext *)context;
+
+/**
+ * Set the button `backgroundImage` with an `url`.
  *
  * The download is asynchronous and cached.
  *
@@ -250,7 +284,7 @@
                            completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the backgroundImageView `image` with an `url`, placeholder.
+ * Set the button `backgroundImage` with an `url`, placeholder.
  *
  * The download is asynchronous and cached.
  *
@@ -269,7 +303,7 @@
                            completed:(nullable SDExternalCompletionBlock)completedBlock NS_REFINED_FOR_SWIFT;
 
 /**
- * Set the backgroundImageView `image` with an `url`, placeholder and custom options.
+ * Set the button `backgroundImage` with an `url`, placeholder and custom options.
  *
  * The download is asynchronous and cached.
  *
@@ -289,7 +323,7 @@
                            completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the backgroundImageView `image` with an `url`, placeholder and custom options.
+ * Set the button `backgroundImage` with an `url`, placeholder and custom options.
  *
  * The download is asynchronous and cached.
  *
@@ -312,7 +346,7 @@
                            completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the backgroundImageView `image` with an `url`, placeholder and custom options.
+ * Set the button `backgroundImage` with an `url`, placeholder, custom options and context.
  *
  * The download is asynchronous and cached.
  *

--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -61,7 +61,11 @@ static inline NSString * backgroundImageOperationKeyForState(UIControlState stat
 }
 
 - (void)sd_setImageWithURL:(nullable NSURL *)url forState:(UIControlState)state placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options {
-    [self sd_setImageWithURL:url forState:state placeholderImage:placeholder options:options completed:nil];
+    [self sd_setImageWithURL:url forState:state placeholderImage:placeholder options:options progress:nil completed:nil];
+}
+
+- (void)sd_setImageWithURL:(nullable NSURL *)url forState:(UIControlState)state placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context {
+    [self sd_setImageWithURL:url forState:state placeholderImage:placeholder options:options context:context progress:nil completed:nil];
 }
 
 - (void)sd_setImageWithURL:(nullable NSURL *)url forState:(UIControlState)state completed:(nullable SDExternalCompletionBlock)completedBlock {
@@ -141,7 +145,11 @@ static inline NSString * backgroundImageOperationKeyForState(UIControlState stat
 }
 
 - (void)sd_setBackgroundImageWithURL:(nullable NSURL *)url forState:(UIControlState)state placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options {
-    [self sd_setBackgroundImageWithURL:url forState:state placeholderImage:placeholder options:options completed:nil];
+    [self sd_setBackgroundImageWithURL:url forState:state placeholderImage:placeholder options:options progress:nil completed:nil];
+}
+
+- (void)sd_setBackgroundImageWithURL:(nullable NSURL *)url forState:(UIControlState)state placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context {
+    [self sd_setBackgroundImageWithURL:url forState:state placeholderImage:placeholder options:options context:context progress:nil completed:nil];
 }
 
 - (void)sd_setBackgroundImageWithURL:(nullable NSURL *)url forState:(UIControlState)state completed:(nullable SDExternalCompletionBlock)completedBlock {

--- a/SDWebImage/UIImageView+HighlightedWebCache.h
+++ b/SDWebImage/UIImageView+HighlightedWebCache.h
@@ -38,6 +38,19 @@
                               options:(SDWebImageOptions)options NS_REFINED_FOR_SWIFT;
 
 /**
+ * Set the imageView `highlightedImage` with an `url`, custom options and context.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url     The url for the image.
+ * @param options The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param context     A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ */
+- (void)sd_setHighlightedImageWithURL:(nullable NSURL *)url
+                              options:(SDWebImageOptions)options
+                              context:(nullable SDWebImageContext *)context;
+
+/**
  * Set the imageView `highlightedImage` with an `url`.
  *
  * The download is asynchronous and cached.
@@ -86,6 +99,28 @@
  */
 - (void)sd_setHighlightedImageWithURL:(nullable NSURL *)url
                               options:(SDWebImageOptions)options
+                             progress:(nullable SDImageLoaderProgressBlock)progressBlock
+                            completed:(nullable SDExternalCompletionBlock)completedBlock;
+
+/**
+ * Set the imageView `highlightedImage` with an `url`, custom options and context.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url            The url for the image.
+ * @param options        The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param context     A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ * @param progressBlock  A block called while image is downloading
+ *                       @note the progress block is executed on a background queue
+ * @param completedBlock A block called when operation has been completed. This block has no return value
+ *                       and takes the requested UIImage as first parameter. In case of error the image parameter
+ *                       is nil and the second parameter may contain an NSError. The third parameter is a Boolean
+ *                       indicating if the image was retrieved from the local cache or from the network.
+ *                       The fourth parameter is the original image url.
+ */
+- (void)sd_setHighlightedImageWithURL:(nullable NSURL *)url
+                              options:(SDWebImageOptions)options
+                              context:(nullable SDWebImageContext *)context
                              progress:(nullable SDImageLoaderProgressBlock)progressBlock
                             completed:(nullable SDExternalCompletionBlock)completedBlock;
 

--- a/SDWebImage/UIImageView+HighlightedWebCache.m
+++ b/SDWebImage/UIImageView+HighlightedWebCache.m
@@ -25,6 +25,10 @@ static NSString * const SDHighlightedImageOperationKey = @"UIImageViewImageOpera
     [self sd_setHighlightedImageWithURL:url options:options progress:nil completed:nil];
 }
 
+- (void)sd_setHighlightedImageWithURL:(nullable NSURL *)url options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context {
+    [self sd_setHighlightedImageWithURL:url options:options context:context progress:nil completed:nil];
+}
+
 - (void)sd_setHighlightedImageWithURL:(nullable NSURL *)url completed:(nullable SDExternalCompletionBlock)completedBlock {
     [self sd_setHighlightedImageWithURL:url options:0 progress:nil completed:completedBlock];
 }
@@ -33,7 +37,7 @@ static NSString * const SDHighlightedImageOperationKey = @"UIImageViewImageOpera
     [self sd_setHighlightedImageWithURL:url options:options progress:nil completed:completedBlock];
 }
 
-- (void)sd_setHighlightedImageWithURL:(NSURL *)url options:(SDWebImageOptions)options progress:(SDImageLoaderProgressBlock)progressBlock completed:(SDExternalCompletionBlock)completedBlock {
+- (void)sd_setHighlightedImageWithURL:(NSURL *)url options:(SDWebImageOptions)options progress:(nullable SDImageLoaderProgressBlock)progressBlock completed:(nullable SDExternalCompletionBlock)completedBlock {
     [self sd_setHighlightedImageWithURL:url options:options context:nil progress:progressBlock completed:completedBlock];
 }
 

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -79,6 +79,21 @@
                    options:(SDWebImageOptions)options NS_REFINED_FOR_SWIFT;
 
 /**
+ * Set the imageView `image` with an `url`, placeholder, custom options and context.
+ *
+ * The download is asynchronous and cached.
+ *
+ * @param url         The url for the image.
+ * @param placeholder The image to be set initially, until the image request finishes.
+ * @param options     The options to use when downloading the image. @see SDWebImageOptions for the possible values.
+ * @param context     A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
+ */
+- (void)sd_setImageWithURL:(nullable NSURL *)url
+          placeholderImage:(nullable UIImage *)placeholder
+                   options:(SDWebImageOptions)options
+                   context:(nullable SDWebImageContext *)context;
+
+/**
  * Set the imageView `image` with an `url`.
  *
  * The download is asynchronous and cached.
@@ -152,7 +167,7 @@
                  completed:(nullable SDExternalCompletionBlock)completedBlock;
 
 /**
- * Set the imageView `image` with an `url`, placeholder and custom options.
+ * Set the imageView `image` with an `url`, placeholder, custom options and context.
  *
  * The download is asynchronous and cached.
  *

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -25,6 +25,10 @@
     [self sd_setImageWithURL:url placeholderImage:placeholder options:options progress:nil completed:nil];
 }
 
+- (void)sd_setImageWithURL:(nullable NSURL *)url placeholderImage:(nullable UIImage *)placeholder options:(SDWebImageOptions)options context:(nullable SDWebImageContext *)context {
+    [self sd_setImageWithURL:url placeholderImage:placeholder options:options context:context progress:nil completed:nil];
+}
+
 - (void)sd_setImageWithURL:(nullable NSURL *)url completed:(nullable SDExternalCompletionBlock)completedBlock {
     [self sd_setImageWithURL:url placeholderImage:nil options:0 progress:nil completed:completedBlock];
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This just a little improvement for all View Category about the `context` arg. This fix the issue during #2189 development and no extra API-break was introduced.

In 5.x, we introduce a `SDWebImageContextOption` arg, to pass any object or value that a `enum` can not hold (poor of Objective-C enum). Previouslly I just add one arg into the final method, however, we can add one more convenient method, which take `url`, `placeholderImage`, `options`, `context` these 4 arg and so that our user can type less word to use the context feature :)
