### PR TITLE
Fix that UIImage+Transform on macOS to use BGRA8888 instead of ARGB8888, as Apple's doc

### DIFF
--- a/SDWebImage/UIImage+Transform.m
+++ b/SDWebImage/UIImage+Transform.m
@@ -14,14 +14,14 @@
 #endif
 
 #if SD_MAC
-static CGContextRef SDCGContextCreateARGBBitmapContext(CGSize size, BOOL opaque, CGFloat scale) {
+static CGContextRef SDCGContextCreateBitmapContext(CGSize size, BOOL opaque, CGFloat scale) {
     size_t width = ceil(size.width * scale);
     size_t height = ceil(size.height * scale);
     if (width < 1 || height < 1) return NULL;
     
-    //pre-multiplied ARGB, 8-bits per component
+    //pre-multiplied BGRA, 8-bits per component, as Apple's doc
     CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();
-    CGImageAlphaInfo alphaInfo = (opaque ? kCGImageAlphaNoneSkipFirst : kCGImageAlphaPremultipliedFirst);
+    CGImageAlphaInfo alphaInfo = kCGBitmapByteOrder32Host | (opaque ? kCGImageAlphaNoneSkipFirst : kCGImageAlphaPremultipliedFirst);
     CGContextRef context = CGBitmapContextCreate(NULL, width, height, 8, 0, space, kCGBitmapByteOrderDefault | alphaInfo);
     CGColorSpaceRelease(space);
     if (!context) {
@@ -41,7 +41,7 @@ static void SDGraphicsBeginImageContextWithOptions(CGSize size, BOOL opaque, CGF
 #if SD_UIKIT || SD_WATCH
     UIGraphicsBeginImageContextWithOptions(size, opaque, scale);
 #else
-    CGContextRef context = SDCGContextCreateARGBBitmapContext(size, opaque, scale);
+    CGContextRef context = SDCGContextCreateBitmapContext(size, opaque, scale);
     if (!context) {
         return;
     }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This just a little enhancement to use BGRA8888 instead of ARGB8888 on macOS's compatibility method `SDGraphicsBeginImageContextWithOptions`.

Apple Docs:

> If the opaque parameter is YES, the alpha channel is ignored and the bitmap is treated as fully opaque (kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Host). Otherwise, each pixel uses a premultipled ARGB format (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host).

