### PR TITLE
Renaming UIImage+WebCache to the correct naming UIImage+Metadata, make clear of the category usage

### DIFF
--- a/SDWebImage.xcodeproj/project.pbxproj
+++ b/SDWebImage.xcodeproj/project.pbxproj
@@ -470,18 +470,18 @@
 		3290FA0D1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
 		3290FA0E1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
 		3290FA0F1FA478AF0047D20C /* SDImageFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 3290FA031FA478AF0047D20C /* SDImageFrame.m */; };
-		329A18591FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		329A185A1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		329A185B1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		329A185C1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		329A185D1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		329A185E1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		329A185F1FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+WebCache.m */; };
-		329A18601FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+WebCache.m */; };
-		329A18611FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+WebCache.m */; };
-		329A18621FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+WebCache.m */; };
-		329A18631FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+WebCache.m */; };
-		329A18641FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+WebCache.m */; };
+		329A18591FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+Metadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		329A185A1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+Metadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		329A185B1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+Metadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		329A185C1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+Metadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		329A185D1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+Metadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		329A185E1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 329A18571FFF5DFD008C9A2F /* UIImage+Metadata.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		329A185F1FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+Metadata.m */; };
+		329A18601FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+Metadata.m */; };
+		329A18611FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+Metadata.m */; };
+		329A18621FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+Metadata.m */; };
+		329A18631FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+Metadata.m */; };
+		329A18641FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 329A18581FFF5DFD008C9A2F /* UIImage+Metadata.m */; };
 		32B9B537206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 32B9B535206ED4230026769D /* SDWebImageDownloaderConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32B9B538206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 32B9B535206ED4230026769D /* SDWebImageDownloaderConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32B9B539206ED4230026769D /* SDWebImageDownloaderConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 32B9B535206ED4230026769D /* SDWebImageDownloaderConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1616,8 +1616,8 @@
 		328BB6C02082581100760D6C /* SDMemoryCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDMemoryCache.m; sourceTree = "<group>"; };
 		3290FA021FA478AF0047D20C /* SDImageFrame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDImageFrame.h; sourceTree = "<group>"; };
 		3290FA031FA478AF0047D20C /* SDImageFrame.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDImageFrame.m; sourceTree = "<group>"; };
-		329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+WebCache.h"; path = "SDWebImage/UIImage+WebCache.h"; sourceTree = "<group>"; };
-		329A18581FFF5DFD008C9A2F /* UIImage+WebCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIImage+WebCache.m"; path = "SDWebImage/UIImage+WebCache.m"; sourceTree = "<group>"; };
+		329A18571FFF5DFD008C9A2F /* UIImage+Metadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+Metadata.h"; sourceTree = "<group>"; };
+		329A18581FFF5DFD008C9A2F /* UIImage+Metadata.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Metadata.m"; sourceTree = "<group>"; };
 		32B9B535206ED4230026769D /* SDWebImageDownloaderConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageDownloaderConfig.h; sourceTree = "<group>"; };
 		32B9B536206ED4230026769D /* SDWebImageDownloaderConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SDWebImageDownloaderConfig.m; sourceTree = "<group>"; };
 		32C0FDDF2013426C001B8F2D /* SDWebImageIndicator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDWebImageIndicator.h; sourceTree = "<group>"; };
@@ -2005,8 +2005,6 @@
 		4369C2851D9811BB007E863A /* WebCache Categories */ = {
 			isa = PBXGroup;
 			children = (
-				329A18571FFF5DFD008C9A2F /* UIImage+WebCache.h */,
-				329A18581FFF5DFD008C9A2F /* UIImage+WebCache.m */,
 				321DB35F2011D4D60015D2CB /* NSButton+WebCache.h */,
 				321DB3602011D4D60015D2CB /* NSButton+WebCache.m */,
 				53922D93148C56230056699D /* UIButton+WebCache.h */,
@@ -2141,6 +2139,8 @@
 				5D5B9141188EE8DD006D06BD /* NSData+ImageContentType.m */,
 				A18A6CC5172DC28500419892 /* UIImage+GIF.h */,
 				A18A6CC6172DC28500419892 /* UIImage+GIF.m */,
+				329A18571FFF5DFD008C9A2F /* UIImage+Metadata.h */,
+				329A18581FFF5DFD008C9A2F /* UIImage+Metadata.m */,
 				53EDFB8817623F7C00698166 /* UIImage+MultiFormat.h */,
 				53EDFB8917623F7C00698166 /* UIImage+MultiFormat.m */,
 				321E60BC1F38E91700405457 /* UIImage+ForceDecode.h */,
@@ -2400,7 +2400,7 @@
 				80377C4A1F2F666300F89830 /* bit_writer_utils.h in Headers */,
 				321B37902083290E00C0EA77 /* SDImageLoadersManager.h in Headers */,
 				323F8BE71F38EF770092B609 /* vp8li_enc.h in Headers */,
-				329A185C1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */,
+				329A185C1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */,
 				4369C27A1D9807EC007E863A /* UIView+WebCache.h in Headers */,
 				32F21B5420788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.h in Headers */,
 				80377DCC1F2F66A700F89830 /* lossless_common.h in Headers */,
@@ -2516,7 +2516,7 @@
 				80377D501F2F66A700F89830 /* mips_macro.h in Headers */,
 				80377C291F2F666300F89830 /* thread_utils.h in Headers */,
 				4314D16D1D0E0E3B004B36C9 /* SDImageCache.h in Headers */,
-				329A185A1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */,
+				329A185A1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */,
 				4314D16F1D0E0E3B004B36C9 /* NSData+ImageContentType.h in Headers */,
 				80377C121F2F666300F89830 /* bit_reader_inl_utils.h in Headers */,
 				4314D1701D0E0E3B004B36C9 /* mux.h in Headers */,
@@ -2599,7 +2599,7 @@
 				80377C601F2F666400F89830 /* bit_reader_inl_utils.h in Headers */,
 				32FDE89920888726008D7530 /* UIImage+WebP.h in Headers */,
 				321B37852083290E00C0EA77 /* SDImageLoader.h in Headers */,
-				329A185D1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */,
+				329A185D1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */,
 				431BB6DC1D06D2C1006A3455 /* UIButton+WebCache.h in Headers */,
 				431BB6E11D06D2C1006A3455 /* SDWebImage.h in Headers */,
 				80377E311F2F66A800F89830 /* yuv.h in Headers */,
@@ -2724,7 +2724,7 @@
 				80377E481F2F66A800F89830 /* dsp.h in Headers */,
 				323F8BE91F38EF770092B609 /* vp8li_enc.h in Headers */,
 				3248477A201775F600AF9E5A /* SDAnimatedImage.h in Headers */,
-				329A185E1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */,
+				329A185E1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */,
 				320224BB203979BA00E9F285 /* SDAnimatedImageRep.h in Headers */,
 				328BB6C62082581100760D6C /* SDDiskCache.h in Headers */,
 				32FDE89420888726008D7530 /* SDImageWebPCoder.h in Headers */,
@@ -2797,7 +2797,7 @@
 				321B378F2083290E00C0EA77 /* SDImageLoadersManager.h in Headers */,
 				431739541CDFC8B70008FEB9 /* types.h in Headers */,
 				323F8BE61F38EF770092B609 /* vp8li_enc.h in Headers */,
-				329A185B1FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */,
+				329A185B1FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */,
 				4369C2791D9807EC007E863A /* UIView+WebCache.h in Headers */,
 				32F21B5320788D8C0036B1D5 /* SDWebImageDownloaderRequestModifier.h in Headers */,
 				80377D871F2F66A700F89830 /* lossless_common.h in Headers */,
@@ -2915,7 +2915,7 @@
 				321E60941F38E8ED00405457 /* SDImageIOCoder.h in Headers */,
 				431738BD1CDFC2660008FEB9 /* decode.h in Headers */,
 				80377D0B1F2F66A100F89830 /* mips_macro.h in Headers */,
-				329A18591FFF5DFD008C9A2F /* UIImage+WebCache.h in Headers */,
+				329A18591FFF5DFD008C9A2F /* UIImage+Metadata.h in Headers */,
 				32D122302080B2EB003685A3 /* SDImageCachesManager.h in Headers */,
 				5376131A155AD0D5005750A4 /* SDWebImageDownloader.h in Headers */,
 				328BB6CD2082581100760D6C /* SDMemoryCache.h in Headers */,
@@ -3355,7 +3355,7 @@
 				00733A5E1BC4880000A5A117 /* UIImage+MultiFormat.m in Sources */,
 				80377DD01F2F66A700F89830 /* lossless_enc_neon.c in Sources */,
 				80377DE21F2F66A700F89830 /* rescaler.c in Sources */,
-				329A18621FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */,
+				329A18621FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */,
 				80377DAD1F2F66A700F89830 /* argb_mips_dsp_r2.c in Sources */,
 				328BB6B32081FEE500760D6C /* SDWebImageCacheSerializer.m in Sources */,
 				00733A601BC4880000A5A117 /* UIImageView+HighlightedWebCache.m in Sources */,
@@ -3380,7 +3380,7 @@
 				80377EA01F2F66D400F89830 /* vp8_dec.c in Sources */,
 				80377EA31F2F66D400F89830 /* vp8l_dec.c in Sources */,
 				80377E9D1F2F66D400F89830 /* io_dec.c in Sources */,
-				329A18601FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */,
+				329A18601FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */,
 				80377D541F2F66A700F89830 /* rescaler_mips32.c in Sources */,
 				80377D331F2F66A700F89830 /* dec.c in Sources */,
 				32EB6D92206D132E005CAEF6 /* SDAnimatedImageRep.m in Sources */,
@@ -3546,7 +3546,7 @@
 				80377ED01F2F66D500F89830 /* vp8_dec.c in Sources */,
 				80377ED31F2F66D500F89830 /* vp8l_dec.c in Sources */,
 				80377ECD1F2F66D500F89830 /* io_dec.c in Sources */,
-				329A18631FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */,
+				329A18631FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */,
 				80377E231F2F66A800F89830 /* rescaler_mips32.c in Sources */,
 				80377E021F2F66A800F89830 /* dec.c in Sources */,
 				32EB6D8F206D132E005CAEF6 /* SDAnimatedImageRep.m in Sources */,
@@ -3736,7 +3736,7 @@
 				32CF1C121FA496B000004BD1 /* SDImageCoderHelper.m in Sources */,
 				32B9B542206ED4230026769D /* SDWebImageDownloaderConfig.m in Sources */,
 				80377E521F2F66A800F89830 /* filters_msa.c in Sources */,
-				329A18641FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */,
+				329A18641FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */,
 				80377C821F2F666400F89830 /* filters_utils.c in Sources */,
 				324DF4BF200A14DC008A84CC /* SDWebImageDefine.m in Sources */,
 				4397D28C1D0DDD8C00BB2784 /* UIImageView+WebCache.m in Sources */,
@@ -4025,7 +4025,7 @@
 				43CE75801CFE9427006C64D0 /* FLAnimatedImageView.m in Sources */,
 				4369C2801D9807EC007E863A /* UIView+WebCache.m in Sources */,
 				80377D8B1F2F66A700F89830 /* lossless_enc_neon.c in Sources */,
-				329A18611FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */,
+				329A18611FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */,
 				80377D9D1F2F66A700F89830 /* rescaler.c in Sources */,
 				328BB6B22081FEE500760D6C /* SDWebImageCacheSerializer.m in Sources */,
 				80377D681F2F66A700F89830 /* argb_mips_dsp_r2.c in Sources */,
@@ -4195,7 +4195,7 @@
 				43CE757F1CFE9427006C64D0 /* FLAnimatedImageView.m in Sources */,
 				4369C27E1D9807EC007E863A /* UIView+WebCache.m in Sources */,
 				80377D011F2F66A100F89830 /* lossless_enc_neon.c in Sources */,
-				329A185F1FFF5DFD008C9A2F /* UIImage+WebCache.m in Sources */,
+				329A185F1FFF5DFD008C9A2F /* UIImage+Metadata.m in Sources */,
 				80377D131F2F66A100F89830 /* rescaler.c in Sources */,
 				328BB6B02081FEE500760D6C /* SDWebImageCacheSerializer.m in Sources */,
 				80377CDE1F2F66A100F89830 /* argb_mips_dsp_r2.c in Sources */,

--- a/SDWebImage/NSImage+Compatibility.h
+++ b/SDWebImage/NSImage+Compatibility.h
@@ -8,7 +8,7 @@
 
 #import "SDWebImageCompat.h"
 
-// This category is provided to easily write cross-platform(AppKit/UIKit) code. For common usage, see `UIImage+WebCache`.
+// This category is provided to easily write cross-platform(AppKit/UIKit) code. For common usage, see `UIImage+Metadata.h`.
 
 #if SD_MAC
 

--- a/SDWebImage/SDAnimatedImage.m
+++ b/SDWebImage/SDAnimatedImage.m
@@ -8,7 +8,6 @@
 
 #import "SDAnimatedImage.h"
 #import "NSImage+Compatibility.h"
-#import "UIImage+WebCache.h"
 #import "SDImageCoder.h"
 #import "SDImageCodersManager.h"
 #import "SDImageFrame.h"

--- a/SDWebImage/SDAnimatedImageView.h
+++ b/SDWebImage/SDAnimatedImageView.h
@@ -51,7 +51,7 @@
  */
 @property (nonatomic, assign) NSUInteger maxBufferSize;
 /**
- Whehter or not to enable incremental image load for animated image. This is for the animated image which `sd_isIncremental` is YES (See `UIImage+WebCache.h`). If enable, animated image rendering will stop at the last frame available currently, and continue when another `setImage:` trigger, where the new animated image's `animatedImageData` should be updated from the previous one. If the `sd_isIncremental` is NO. The incremental image load stop.
+ Whehter or not to enable incremental image load for animated image. This is for the animated image which `sd_isIncremental` is YES (See `UIImage+Metadata.h`). If enable, animated image rendering will stop at the last frame available currently, and continue when another `setImage:` trigger, where the new animated image's `animatedImageData` should be updated from the previous one. If the `sd_isIncremental` is NO. The incremental image load stop.
  @note If you are confused about this description, open Chrome browser to view some large GIF images with low network speed to see the animation behavior.
  @note The best practice to use incremental load is using `initWithAnimatedCoder:scale` in `SDAnimatedImage` with animated coder which conform to `SDProgressiveImageCoder` as well. Then call incremental update and incremental decode method to produce the image.
  Default is YES. Set to NO to only render the static poster for incremental animated image.

--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -10,7 +10,7 @@
 
 #if SD_UIKIT || SD_MAC
 
-#import "UIImage+WebCache.h"
+#import "UIImage+Metadata.h"
 #import "NSImage+Compatibility.h"
 #import <mach/mach.h>
 #import <objc/runtime.h>

--- a/SDWebImage/SDImageAPNGCoder.m
+++ b/SDWebImage/SDImageAPNGCoder.m
@@ -9,7 +9,7 @@
 #import "SDImageAPNGCoder.h"
 #import <ImageIO/ImageIO.h>
 #import "NSData+ImageContentType.h"
-#import "UIImage+WebCache.h"
+#import "UIImage+Metadata.h"
 #import "NSImage+Compatibility.h"
 #import "SDImageCoderHelper.h"
 #import "SDAnimatedImageRep.h"

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -10,7 +10,6 @@
 #import "SDMemoryCache.h"
 #import "SDDiskCache.h"
 #import "NSImage+Compatibility.h"
-#import "UIImage+WebCache.h"
 #import "SDImageCodersManager.h"
 #import "SDImageTransformer.h"
 #import "SDImageCoderHelper.h"

--- a/SDWebImage/SDImageCacheDefine.m
+++ b/SDWebImage/SDImageCacheDefine.m
@@ -10,7 +10,7 @@
 #import "SDImageCodersManager.h"
 #import "SDImageCoderHelper.h"
 #import "SDAnimatedImage.h"
-#import "UIImage+WebCache.h"
+#import "UIImage+Metadata.h"
 
 UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context) {
     UIImage *image;

--- a/SDWebImage/SDImageCoderHelper.m
+++ b/SDWebImage/SDImageCoderHelper.m
@@ -245,7 +245,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     if (width == 0 || height == 0) return NULL;
     BOOL hasAlpha = [self CGImageContainsAlpha:cgImage];
     // iOS prefer BGRA8888 (premultiplied) or BGRX8888 bitmapInfo for screen rendering, which is same as `UIGraphicsBeginImageContext()` or `- [CALayer drawInContext:]`
-    // Through you can use any supported bitmapInfo (see: https://developer.apple.com/library/content/documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/dq_context/dq_context.html#//apple_ref/doc/uid/TP30001066-CH203-BCIBHHBB ) and let Core Graphics reorder it when you call `CGContextDrawImage`
+    // Though you can use any supported bitmapInfo (see: https://developer.apple.com/library/content/documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/dq_context/dq_context.html#//apple_ref/doc/uid/TP30001066-CH203-BCIBHHBB ) and let Core Graphics reorder it when you call `CGContextDrawImage`
     // But since our build-in coders use this bitmapInfo, this can have a little performance benefit
     CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Host;
     bitmapInfo |= hasAlpha ? kCGImageAlphaPremultipliedFirst : kCGImageAlphaNoneSkipFirst;

--- a/SDWebImage/SDImageCodersManager.m
+++ b/SDWebImage/SDImageCodersManager.m
@@ -13,8 +13,6 @@
 #ifdef SD_WEBP
 #import "SDImageWebPCoder.h"
 #endif
-#import "NSImage+Compatibility.h"
-#import "UIImage+WebCache.h"
 
 #define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
 #define UNLOCK(lock) dispatch_semaphore_signal(lock);

--- a/SDWebImage/SDImageFrame.h
+++ b/SDWebImage/SDImageFrame.h
@@ -11,7 +11,7 @@
 
 @interface SDImageFrame : NSObject
 
-// This class is used for creating animated images via `animatedImageWithFrames` in `SDImageCoderHelper`. Attention if you need to specify animated images loop count, use `sd_imageLoopCount` property in `UIImage+WebCache.h`.
+// This class is used for creating animated images via `animatedImageWithFrames` in `SDImageCoderHelper`. Attention if you need to specify animated images loop count, use `sd_imageLoopCount` property in `UIImage+Metadata.h`.
 
 /**
  The image of current frame. You should not set an animated image.

--- a/SDWebImage/SDImageGIFCoder.m
+++ b/SDWebImage/SDImageGIFCoder.m
@@ -8,7 +8,7 @@
 
 #import "SDImageGIFCoder.h"
 #import "NSImage+Compatibility.h"
-#import "UIImage+WebCache.h"
+#import "UIImage+Metadata.h"
 #import <ImageIO/ImageIO.h>
 #import "NSData+ImageContentType.h"
 #import "SDImageCoderHelper.h"

--- a/SDWebImage/SDImageLoader.m
+++ b/SDWebImage/SDImageLoader.m
@@ -11,7 +11,7 @@
 #import "SDImageCodersManager.h"
 #import "SDImageCoderHelper.h"
 #import "SDAnimatedImage.h"
-#import "UIImage+WebCache.h"
+#import "UIImage+Metadata.h"
 #import "objc/runtime.h"
 
 static void * SDImageLoaderProgressiveCoderKey = &SDImageLoaderProgressiveCoderKey;

--- a/SDWebImage/SDWebImageDefine.h
+++ b/SDWebImage/SDWebImageDefine.h
@@ -27,7 +27,7 @@ FOUNDATION_EXPORT CGFloat SDImageScaleFactorForKey(NSString * _Nullable key);
 
 /**
  Scale the image with the scale factor for the specify key. If no need to scale, return the original image.
- This works for `UIImage`(UIKit) or `NSImage`(AppKit). And this function also preserve the associated value in `UIImage+WebCache`.
+ This works for `UIImage`(UIKit) or `NSImage`(AppKit). And this function also preserve the associated value in `UIImage+Metadata.h`.
  @note This is actually a convenience function, which firstlly call `SDImageScaleFactorForKey` and then call `SDScaledImageForScaleFactor`, kept for backward compatibility.
 
  @param key The image cache key
@@ -38,7 +38,7 @@ FOUNDATION_EXPORT UIImage * _Nullable SDScaledImageForKey(NSString * _Nullable k
 
 /**
  Scale the image with the scale factor. If no need to scale, return the original image.
- This works for `UIImage`(UIKit) or `NSImage`(AppKit). And this function also preserve the associated value in `UIImage+WebCache`.
+ This works for `UIImage`(UIKit) or `NSImage`(AppKit). And this function also preserve the associated value in `UIImage+Metadata.h`.
  
  @param scale The image scale factor
  @param image The image

--- a/SDWebImage/SDWebImageDefine.m
+++ b/SDWebImage/SDWebImageDefine.m
@@ -7,7 +7,7 @@
  */
 
 #import "SDWebImageDefine.h"
-#import "UIImage+WebCache.h"
+#import "UIImage+Metadata.h"
 #import "NSImage+Compatibility.h"
 
 #pragma mark - Image scale

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -9,7 +9,7 @@
 #import "SDWebImageManager.h"
 #import "SDImageCache.h"
 #import "SDWebImageDownloader.h"
-#import "UIImage+WebCache.h"
+#import "UIImage+Metadata.h"
 #import "SDWebImageError.h"
 
 #define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);

--- a/SDWebImage/UIImage+Metadata.h
+++ b/SDWebImage/UIImage+Metadata.h
@@ -8,7 +8,7 @@
 
 #import "SDWebImageCompat.h"
 
-@interface UIImage (WebCache)
+@interface UIImage (Metadata)
 
 /**
  * UIKit:

--- a/SDWebImage/UIImage+Metadata.m
+++ b/SDWebImage/UIImage+Metadata.m
@@ -6,13 +6,13 @@
  * file that was distributed with this source code.
  */
 
-#import "UIImage+WebCache.h"
+#import "UIImage+Metadata.h"
 #import "NSImage+Compatibility.h"
 #import "objc/runtime.h"
 
 #if SD_UIKIT || SD_WATCH
 
-@implementation UIImage (WebCache)
+@implementation UIImage (Metadata)
 
 - (NSUInteger)sd_imageLoopCount {
     NSUInteger imageLoopCount = 0;
@@ -47,7 +47,7 @@
 
 #if SD_MAC
 
-@implementation NSImage (WebCache)
+@implementation NSImage (Metadata)
 
 - (NSUInteger)sd_imageLoopCount {
     NSUInteger imageLoopCount = 0;

--- a/SDWebImage/WebP/SDImageWebPCoder.m
+++ b/SDWebImage/WebP/SDImageWebPCoder.m
@@ -11,7 +11,7 @@
 #import "SDImageWebPCoder.h"
 #import "SDImageCoderHelper.h"
 #import "NSImage+Compatibility.h"
-#import "UIImage+WebCache.h"
+#import "UIImage+Metadata.h"
 #import "UIImage+ForceDecode.h"
 #if __has_include(<webp/decode.h>) && __has_include(<webp/encode.h>) && __has_include(<webp/demux.h>) && __has_include(<webp/mux.h>)
 #import <webp/decode.h>

--- a/WebImage/SDWebImage.h
+++ b/WebImage/SDWebImage.h
@@ -41,7 +41,7 @@ FOUNDATION_EXPORT const unsigned char WebImageVersionString[];
 #import <SDWebImage/UIButton+WebCache.h>
 #import <SDWebImage/SDWebImagePrefetcher.h>
 #import <SDWebImage/UIView+WebCacheOperation.h>
-#import <SDWebImage/UIImage+WebCache.h>
+#import <SDWebImage/UIImage+Metadata.h>
 #import <SDWebImage/UIImage+MultiFormat.h>
 #import <SDWebImage/SDWebImageOperation.h>
 #import <SDWebImage/SDWebImageDownloader.h>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This PR, renaming the new category during 5.x development called `UIImage+WebCache`, to the correct naming called `UIImage+Metadata`.

WebCache are concept about image loading, but not for these image meta information related properties. So this should be renamed.

This PR does not cause any further API-breaking from 4.x to 5.x, beucase this category does not appear in 4.x.