### PR TITLE
Follow App Store submit rule, upgrade the min Xcode version to Xcode 9.0. Using `@available` and `API_AVAILABLE` to check API availability

### DIFF
--- a/Examples/SDWebImage Demo/LaunchScreen.storyboard
+++ b/Examples/SDWebImage Demo/LaunchScreen.storyboard
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,9 +18,9 @@
                         <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This library provides an async image downloader with cache support. For convenie
 - tvOS 9.0 or later
 - watchOS 2.0 or later
 - macOS 10.10 or later
-- Xcode 7.3 or later
+- Xcode 9.0 or later
 
 #### Backwards compatibility
 

--- a/SDWebImage/SDImageCoderHelper.m
+++ b/SDWebImage/SDImageCoderHelper.m
@@ -203,20 +203,15 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     static CGColorSpaceRef colorSpace;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-        BOOL shouldUseSRGB = NO;
 #if SD_UIKIT
-        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
-        shouldUseSRGB = processInfo.operatingSystemVersion.majorVersion >= 9;
-#endif
-        if (shouldUseSRGB) {
-            // This is what iOS/tvOS device used colorspace, combined with right bitmapInfo, even without decode, can still avoid extra CA::Render::copy_image(which marked `Color Copied Images` from Instruments)
+        if (@available(iOS 9.0, tvOS 9.0, *)) {
             colorSpace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
         } else {
             colorSpace = CGColorSpaceCreateDeviceRGB();
         }
-#pragma clang diagnostic pop
+#else
+        colorSpace = CGColorSpaceCreateDeviceRGB();
+#endif
     });
     return colorSpace;
 }

--- a/SDWebImage/SDImageIOCoder.m
+++ b/SDWebImage/SDImageIOCoder.m
@@ -240,28 +240,15 @@
     static BOOL canDecode = NO;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
 #if TARGET_OS_SIMULATOR || SD_WATCH
         canDecode = NO;
-#elif SD_MAC
-        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
-        if ([processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
-            // macOS 10.13+
-            canDecode = processInfo.operatingSystemVersion.minorVersion >= 13;
-        } else {
-            canDecode = NO;
-        }
-#elif SD_UIKIT
-        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
-        if ([processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
-            // iOS 11+ && tvOS 11+
-            canDecode = processInfo.operatingSystemVersion.majorVersion >= 11;
+#else
+        if (@available(iOS 11.0, tvOS 11.0, macOS 10.13, *)) {
+            canDecode = YES;
         } else {
             canDecode = NO;
         }
 #endif
-#pragma clang diagnostic pop
     });
     return canDecode;
 }

--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -63,10 +63,6 @@
         #define UIColor NSColor
     #endif
 #else
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED != 20000 && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_5_0
-        #error SDWebImage doesn't support Deployment Target version < 5.0
-    #endif
-
     #if SD_UIKIT
         #import <UIKit/UIKit.h>
     #endif

--- a/SDWebImage/SDWebImageTransition.h
+++ b/SDWebImage/SDWebImageTransition.h
@@ -41,7 +41,7 @@ typedef void (^SDWebImageTransitionCompletionBlock)(BOOL finished);
 /**
  The timing function used for all animations within this transition animation (macOS).
  */
-@property (nonatomic, strong, nullable) CAMediaTimingFunction *timingFunction NS_AVAILABLE_MAC(10_7);
+@property (nonatomic, strong, nullable) CAMediaTimingFunction *timingFunction API_UNAVAILABLE(ios, tvos, watchos);
 /**
  A mask of options indicating how you want to perform the animations.
  */


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

### Reason
In the previous #2147 , we upgrade our min Xcode version to Xcode 8, as well as the min deployment target version for iOS & macOS.

At that time, we plan SDWebImage 5.x first beta release just before the WWDC 2018. However, now we're already back of that time.

And now, according to [App Store Submit Rule](https://developer.apple.com/news/?id=05072018a/). All the new or upgrade version for Apps **MUST** link iOS 11 SDK & Xcode 9. So it's time to drop Xcode 8.0 support.

> Starting July 2018, all iOS app updates submitted to the App Store must be built with the iOS 11 SDK and must support the Super Retina display of iPhone X.

Since Xcode tool is developer toolchain, for developers, we should use the latest version of toolchain. This will not cause issue for your Apps deployment. Because we still support iOS 8.0+/macOS 10.10+. The only update is the Xcode version.


After upgrading our min Xcode version to Xcode 9.0. We can now replace some tricky code about availability check using Xcode 9's [@available notation](https://developer.apple.com/library/archive/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW899). Instead of check `NSProcess.processInfo.operatingSystemVersion.majorVersion`. This can make it more easier to maintain. And more feature like clang analysis from clang compiler can benefit from this upgrade.