### PR TITLE
Fix SDImageLoaderManager that only load image when loader can handle url

### DIFF
--- a/SDWebImage/SDImageLoadersManager.m
+++ b/SDWebImage/SDImageLoadersManager.m
@@ -88,7 +88,7 @@
     NSArray<id<SDImageLoader>> *loaders = self.loaders;
     UNLOCK(self.loadersLock);
     for (id<SDImageLoader> loader in loaders.reverseObjectEnumerator) {
-        if ([loader respondsToSelector:@selector(loadImageWithURL:options:context:progress:completed:)]) {
+        if ([loader canLoadWithURL:url]) {
             return [loader loadImageWithURL:url options:options context:context progress:progressBlock completed:completedBlock];
         }
     }

--- a/SDWebImage/SDWebImagePrefetcher.h
+++ b/SDWebImage/SDWebImagePrefetcher.h
@@ -14,7 +14,7 @@
 @interface SDWebImagePrefetchToken : NSObject <SDWebImageOperation>
 
 /**
- * Cancel the current prefeching.
+ * Cancel the current prefetching.
  */
 - (void)cancel;
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

...

