### PR TITLE
Fix that `FLAnimatedImageView` will dispatch the completion block into next runloop even for non-GIF image, which may cause some rendering issue.

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -32,8 +32,8 @@
 @end
 
 typedef NS_ENUM(NSUInteger, FLAnimatedImageViewSetImagePolicy) {
-    FLAnimatedImageViewSetImagePolicyStandard, // The setImageBlock & completionBlock is always run on the same runloop. When the image or image data can determinate as a GIF image, create `FLAnimatedImage` instance on the main queue and then set it to `animatedImage` property. This may block main queue for large GIF.
-    FLAnimatedImageViewSetImagePolicyFast // The completionBlock may run on the next runloop after setImageBlock. When the image or image data can determinate as a GIF image, firstlly use static poster image to let it render, then create `FLAnimatedImage` instance on the global queue, and finally set it to `animatedImage` property on the main queue. This may be helpful for large GIF.
+    FLAnimatedImageViewSetImagePolicyStandard, // The setImageBlock & completionBlock is always run on the same runloop. When the `FLAnimatedImage` not available, but image data can determinate as a GIF image, create `FLAnimatedImage` instance on the main queue and then set it to `animatedImage` property. When image data not available, query disk cache on the main queue and continue as above. This may block main queue for large GIF.
+    FLAnimatedImageViewSetImagePolicyFast // The completionBlock may run on the next runloop after setImageBlock. When the `FLAnimatedImage` not available, but image data can determinate as a GIF image, firstlly use static poster image to let it render, then create `FLAnimatedImage` instance on the global queue, and finally set it to `animatedImage` property on the main queue. When image data not available, query disk cache on the main queue and continue as above. This not block main queue and may be helpful for large GIF.
 };
 
 

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -32,8 +32,8 @@
 @end
 
 typedef NS_ENUM(NSUInteger, FLAnimatedImageViewSetImagePolicy) {
-    FLAnimatedImageViewSetImagePolicyStandard, // The setImageBlock & completionBlock is always run on the same runloop. When the `FLAnimatedImage` not available, but image data can determinate as a GIF image, create `FLAnimatedImage` instance on the main queue and then set it to `animatedImage` property. When image data not available, query disk cache on the main queue and continue as above. This may block main queue for large GIF.
-    FLAnimatedImageViewSetImagePolicyFast // The completionBlock may run on the next runloop after setImageBlock. When the `FLAnimatedImage` not available, but image data can determinate as a GIF image, firstlly use static poster image to let it render, then create `FLAnimatedImage` instance on the global queue, and finally set it to `animatedImage` property on the main queue. When image data not available, query disk cache on the main queue and continue as above. This not block main queue and may be helpful for large GIF.
+    FLAnimatedImageViewSetImagePolicyStandard, // The setImageBlock & completionBlock is always run on the same runloop. When the `FLAnimatedImage` not available, but image data can determinate as a GIF image, create `FLAnimatedImage` instance on the main queue and then set it to `animatedImage` property. When image data not available, query disk cache on the main queue and continue as above. This may block main queue for large GIF, but can keep consistent with other format.
+    FLAnimatedImageViewSetImagePolicyPerformance // The completionBlock may run on the next runloop after setImageBlock. When the `FLAnimatedImage` not available, but image data can determinate as a GIF image, firstly use static poster image to let it render, then create `FLAnimatedImage` instance on the global queue, and finally set it to `animatedImage` property on the main queue. When image data not available, query disk cache on the global queue and continue as above. This will not block main queue which is helpful for large GIF, but it may cause issue on rare case which depends on runloop (like manual view transition code in completionBlock, you should use `SDWebImageTransition` instead).
 };
 
 
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSUInteger, FLAnimatedImageViewSetImagePolicy) {
 
 /**
  * The advanced control for setImage process and rendering for FLAnimatedImageView after image loading. This may be useful for GIF render performance.
- * See `FLAnimatedImageViewSetImagePolicy` description above for different behavior and choose the most proper one for your use case.
+ * See `FLAnimatedImageViewSetImagePolicy` description above for different policy's behavior and choose the most proper one for your use case.
  * Defaults to `FLAnimatedImageViewSetImagePolicyStandard`.
  */
 @property (nonatomic, assign) FLAnimatedImageViewSetImagePolicy sd_setImagePolicy;

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -31,6 +31,11 @@
 
 @end
 
+typedef NS_ENUM(NSUInteger, FLAnimatedImageViewSetImagePolicy) {
+    FLAnimatedImageViewSetImagePolicyStandard, // The setImageBlock & completionBlock is always run on the same runloop. When the image or image data can determinate as a GIF image, create `FLAnimatedImage` instance on the main queue and then set it to `animatedImage` property. This may block main queue for large GIF.
+    FLAnimatedImageViewSetImagePolicyFast // The completionBlock may run on the next runloop after setImageBlock. When the image or image data can determinate as a GIF image, firstlly use static poster image to let it render, then create `FLAnimatedImage` instance on the global queue, and finally set it to `animatedImage` property on the main queue. This may be helpful for large GIF.
+};
+
 
 /**
  *  A category for the FLAnimatedImage imageView class that hooks it to the SDWebImage system.
@@ -51,6 +56,13 @@
  * Defaults to YES.
  */
 @property (nonatomic, assign) BOOL sd_predrawingEnabled;
+
+/**
+ * The advanced control for setImage process and rendering for FLAnimatedImageView after image loading. This may be useful for GIF render performance.
+ * See `FLAnimatedImageViewSetImagePolicy` description above for different behavior and choose the most proper one for your use case.
+ * Defaults to `FLAnimatedImageViewSetImagePolicyStandard`.
+ */
+@property (nonatomic, assign) FLAnimatedImageViewSetImagePolicy sd_setImagePolicy;
 
 /**
  * Load the image at the given url (either from cache or download) and load it in this imageView. It works with both static and dynamic images

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -56,6 +56,19 @@
     objc_setAssociatedObject(self, @selector(sd_predrawingEnabled), @(sd_predrawingEnabled), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+- (FLAnimatedImageViewSetImagePolicy)sd_setImagePolicy {
+    FLAnimatedImageViewSetImagePolicy setImagePolicy = FLAnimatedImageViewSetImagePolicyStandard;
+    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_setImagePolicy));
+    if ([value isKindOfClass:[NSNumber class]]) {
+        setImagePolicy = value.unsignedIntegerValue;
+    }
+    return setImagePolicy;
+}
+
+- (void)setSd_setImagePolicy:(FLAnimatedImageViewSetImagePolicy)sd_setImagePolicy {
+    objc_setAssociatedObject(self, @selector(sd_setImagePolicy), @(sd_setImagePolicy), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 - (void)sd_setImageWithURL:(nullable NSURL *)url {
     [self sd_setImageWithURL:url placeholderImage:nil options:0 progress:nil completed:nil];
 }
@@ -85,51 +98,93 @@
                    options:(SDWebImageOptions)options
                   progress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                  completed:(nullable SDExternalCompletionBlock)completedBlock {
+    NSDictionary *context;
     dispatch_group_t group = dispatch_group_create();
+    SDSetImageGroupConditionBlock groupConditionBlock = ^BOOL(UIImage *image, NSData *imageData) {
+        FLAnimatedImage *associatedAnimatedImage = image.sd_FLAnimatedImage;
+        if (associatedAnimatedImage) {
+            return YES;
+        }
+        if ([NSData sd_imageFormatForImageData:imageData] == SDImageFormatGIF) {
+            return YES;
+        }
+        return NO;
+    };
+    if (group) {
+        NSMutableDictionary *mutableContext = [NSMutableDictionary dictionaryWithCapacity:2];
+        [mutableContext setValue:group forKey:SDWebImageInternalSetImageGroupKey];
+        [mutableContext setValue:groupConditionBlock forKey:SDWebImageInternalSetImageGroupConditionBlockKey];
+        context = [mutableContext copy];
+    }
+    
     __weak typeof(self)weakSelf = self;
     [self sd_internalSetImageWithURL:url
                     placeholderImage:placeholder
                              options:options
                         operationKey:nil
                        setImageBlock:^(UIImage *image, NSData *imageData) {
+                           __strong typeof(weakSelf)strongSelf = weakSelf;
+                           if (!strongSelf) {
+                               if (group) {
+                                   dispatch_group_leave(group);
+                               }
+                               return;
+                           }
                            // We could not directlly create the animated image on bacakground queue because it's time consuming, by the time we set it back, the current runloop has passed and the placeholder has been rendered and then replaced with animated image, this cause a flashing.
                            // Previously we use a trick to firstly set the static poster image, then set animated image back to avoid flashing, but this trick fail when using with custom UIView transition. Core Animation will use the current layer state to do rendering, so even we later set it back, the transition will not update. (it's recommended to use `SDWebImageTransition` instead)
                            // So we have no choice to force store the FLAnimatedImage into memory cache using a associated object binding to UIImage instance. This consumed memory is adoptable and much smaller than `_UIAnimatedImage` for big GIF
                            FLAnimatedImage *associatedAnimatedImage = image.sd_FLAnimatedImage;
                            if (associatedAnimatedImage) {
                                // Asscociated animated image exist
-                               weakSelf.animatedImage = associatedAnimatedImage;
-                               weakSelf.image = nil;
+                               strongSelf.animatedImage = associatedAnimatedImage;
+                               strongSelf.image = nil;
                                if (group) {
                                    dispatch_group_leave(group);
                                }
                            } else if ([NSData sd_imageFormatForImageData:imageData] == SDImageFormatGIF) {
-                               // Firstly set the static poster image to avoid flashing
-                               UIImage *posterImage = image.images ? image.images.firstObject : image;
-                               weakSelf.image = posterImage;
-                               weakSelf.animatedImage = nil;
-                               // Secondly create FLAnimatedImage in global queue because it's time consuming, then set it back
-                               dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+                               // Directly create FLAnimatedImage on main queue
+                               if (strongSelf.sd_setImagePolicy == FLAnimatedImageViewSetImagePolicyStandard) {
                                    FLAnimatedImage *animatedImage;
                                    // Compatibility in 4.x for lower version FLAnimatedImage.
                                    if ([FLAnimatedImage respondsToSelector:@selector(initWithAnimatedGIFData:optimalFrameCacheSize:predrawingEnabled:)]) {
-                                       animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:self.sd_optimalFrameCacheSize predrawingEnabled:self.sd_predrawingEnabled];
+                                       animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:strongSelf.sd_optimalFrameCacheSize predrawingEnabled:strongSelf.sd_predrawingEnabled];
                                    } else {
                                        animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData];
                                    }
-                                   dispatch_async(dispatch_get_main_queue(), ^{
-                                       image.sd_FLAnimatedImage = animatedImage;
-                                       weakSelf.animatedImage = animatedImage;
-                                       weakSelf.image = nil;
-                                       if (group) {
-                                           dispatch_group_leave(group);
+                                   image.sd_FLAnimatedImage = animatedImage;
+                                   strongSelf.animatedImage = animatedImage;
+                                   strongSelf.image = nil;
+                                   if (group) {
+                                       dispatch_group_leave(group);
+                                   }
+                               } else {
+                                   // Firstly set the static poster image to avoid flashing
+                                   UIImage *posterImage = image.images ? image.images.firstObject : image;
+                                   strongSelf.image = posterImage;
+                                   strongSelf.animatedImage = nil;
+                                   // Secondly create FLAnimatedImage in global queue because it's time consuming, then set it back
+                                   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+                                       FLAnimatedImage *animatedImage;
+                                       // Compatibility in 4.x for lower version FLAnimatedImage.
+                                       if ([FLAnimatedImage respondsToSelector:@selector(initWithAnimatedGIFData:optimalFrameCacheSize:predrawingEnabled:)]) {
+                                           animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:strongSelf.sd_optimalFrameCacheSize predrawingEnabled:strongSelf.sd_predrawingEnabled];
+                                       } else {
+                                           animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData];
                                        }
+                                       dispatch_async(dispatch_get_main_queue(), ^{
+                                           image.sd_FLAnimatedImage = animatedImage;
+                                           strongSelf.animatedImage = animatedImage;
+                                           strongSelf.image = nil;
+                                           if (group) {
+                                               dispatch_group_leave(group);
+                                           }
+                                       });
                                    });
-                               });
+                               }
                            } else {
                                // Not animated image
-                               weakSelf.image = image;
-                               weakSelf.animatedImage = nil;
+                               strongSelf.image = image;
+                               strongSelf.animatedImage = nil;
                                if (group) {
                                    dispatch_group_leave(group);
                                }
@@ -137,7 +192,7 @@
                        }
                             progress:progressBlock
                            completed:completedBlock
-                             context:group ? @{SDWebImageInternalSetImageGroupKey : group} : nil];
+                             context:context];
 }
 
 @end

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -14,6 +14,18 @@
 #import "UIView+WebCache.h"
 #import "NSData+ImageContentType.h"
 #import "UIImageView+WebCache.h"
+#import "UIImage+MultiFormat.h"
+
+static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageView *imageView, NSData *imageData) {
+    FLAnimatedImage *animatedImage;
+    // Compatibility in 4.x for lower version FLAnimatedImage.
+    if ([FLAnimatedImage respondsToSelector:@selector(initWithAnimatedGIFData:optimalFrameCacheSize:predrawingEnabled:)]) {
+        animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:imageView.sd_optimalFrameCacheSize predrawingEnabled:imageView.sd_predrawingEnabled];
+    } else {
+        animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData];
+    }
+    return animatedImage;
+}
 
 @implementation UIImage (FLAnimatedImage)
 
@@ -133,6 +145,8 @@
                            // We could not directlly create the animated image on bacakground queue because it's time consuming, by the time we set it back, the current runloop has passed and the placeholder has been rendered and then replaced with animated image, this cause a flashing.
                            // Previously we use a trick to firstly set the static poster image, then set animated image back to avoid flashing, but this trick fail when using with custom UIView transition. Core Animation will use the current layer state to do rendering, so even we later set it back, the transition will not update. (it's recommended to use `SDWebImageTransition` instead)
                            // So we have no choice to force store the FLAnimatedImage into memory cache using a associated object binding to UIImage instance. This consumed memory is adoptable and much smaller than `_UIAnimatedImage` for big GIF
+                           
+                           // Step 1. Check memory cache (associate object)
                            FLAnimatedImage *associatedAnimatedImage = image.sd_FLAnimatedImage;
                            if (associatedAnimatedImage) {
                                // Asscociated animated image exist
@@ -141,50 +155,64 @@
                                if (group) {
                                    dispatch_group_leave(group);
                                }
-                           } else if ([NSData sd_imageFormatForImageData:imageData] == SDImageFormatGIF) {
-                               // Directly create FLAnimatedImage on main queue
-                               if (strongSelf.sd_setImagePolicy == FLAnimatedImageViewSetImagePolicyStandard) {
-                                   FLAnimatedImage *animatedImage;
-                                   // Compatibility in 4.x for lower version FLAnimatedImage.
-                                   if ([FLAnimatedImage respondsToSelector:@selector(initWithAnimatedGIFData:optimalFrameCacheSize:predrawingEnabled:)]) {
-                                       animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:strongSelf.sd_optimalFrameCacheSize predrawingEnabled:strongSelf.sd_predrawingEnabled];
-                                   } else {
-                                       animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData];
+                               return;
+                           }
+                           // Step 2. Check if "GIF" (including animated image as well to avoid force decode case, which lose the image format)
+                           BOOL isGIF = (image.sd_imageFormat == SDImageFormatGIF || [NSData sd_imageFormatForImageData:imageData] == SDImageFormatGIF || image.images.count > 0);
+                           if (!isGIF) {
+                               strongSelf.image = image;
+                               strongSelf.animatedImage = nil;
+                               if (group) {
+                                   dispatch_group_leave(group);
+                               }
+                               return;
+                           }
+                           // Step 3. Check if data exist and query disk cache
+                           BOOL isAsync = self.sd_setImagePolicy == FLAnimatedImageViewSetImagePolicyFast;
+                           NSString *key = [[SDWebImageManager sharedManager] cacheKeyForURL:url];
+                           __block NSData *gifData = imageData;
+                           if (isAsync) {
+                               // Firstly set the static poster image to avoid flashing
+                               UIImage *posterImage = image.images ? image.images.firstObject : image;
+                               strongSelf.image = posterImage;
+                               strongSelf.animatedImage = nil;
+                               // Secondly create FLAnimatedImage in global queue because it's time consuming, then set it back
+                               dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+                                   if (!gifData) {
+                                       // Step 4. Create FLAnimatedImage
+                                       gifData = [[SDImageCache sharedImageCache] diskImageDataForKey:key];
                                    }
-                                   image.sd_FLAnimatedImage = animatedImage;
-                                   strongSelf.animatedImage = animatedImage;
-                                   strongSelf.image = nil;
-                                   if (group) {
-                                       dispatch_group_leave(group);
-                                   }
-                               } else {
-                                   // Firstly set the static poster image to avoid flashing
-                                   UIImage *posterImage = image.images ? image.images.firstObject : image;
-                                   strongSelf.image = posterImage;
-                                   strongSelf.animatedImage = nil;
-                                   // Secondly create FLAnimatedImage in global queue because it's time consuming, then set it back
-                                   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-                                       FLAnimatedImage *animatedImage;
-                                       // Compatibility in 4.x for lower version FLAnimatedImage.
-                                       if ([FLAnimatedImage respondsToSelector:@selector(initWithAnimatedGIFData:optimalFrameCacheSize:predrawingEnabled:)]) {
-                                           animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:strongSelf.sd_optimalFrameCacheSize predrawingEnabled:strongSelf.sd_predrawingEnabled];
-                                       } else {
-                                           animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData];
-                                       }
-                                       dispatch_async(dispatch_get_main_queue(), ^{
+                                   FLAnimatedImage *animatedImage = SDWebImageCreateFLAnimatedImage(self, gifData);
+                                   dispatch_async(dispatch_get_main_queue(), ^{
+                                       // Step 5. Set animatedImage
+                                       if (animatedImage) {
                                            image.sd_FLAnimatedImage = animatedImage;
                                            strongSelf.animatedImage = animatedImage;
                                            strongSelf.image = nil;
-                                           if (group) {
-                                               dispatch_group_leave(group);
-                                           }
-                                       });
+                                       } else {
+                                           strongSelf.animatedImage = nil;
+                                           strongSelf.image = image;
+                                       }
+                                       if (group) {
+                                           dispatch_group_leave(group);
+                                       }
                                    });
-                               }
+                               });
                            } else {
-                               // Not animated image
-                               strongSelf.image = image;
-                               strongSelf.animatedImage = nil;
+                               if (!gifData) {
+                                   // Step 4. Create FLAnimatedImage
+                                   gifData = [[SDImageCache sharedImageCache] diskImageDataForKey:key];
+                               }
+                               FLAnimatedImage *animatedImage = SDWebImageCreateFLAnimatedImage(self, gifData);
+                               // Step 5. Set animatedImage
+                               if (animatedImage) {
+                                   image.sd_FLAnimatedImage = animatedImage;
+                                   strongSelf.animatedImage = animatedImage;
+                                   strongSelf.image = nil;
+                               } else {
+                                   strongSelf.animatedImage = nil;
+                                   strongSelf.image = image;
+                               }
                                if (group) {
                                    dispatch_group_leave(group);
                                }

--- a/SDWebImage/NSData+ImageContentType.h
+++ b/SDWebImage/NSData+ImageContentType.h
@@ -39,4 +39,12 @@ typedef NS_ENUM(NSInteger, SDImageFormat) {
  */
 + (nonnull CFStringRef)sd_UTTypeFromSDImageFormat:(SDImageFormat)format;
 
+/**
+ Convert UTTyppe to SDImageFormat
+
+ @param uttype The UTType as CFStringRef
+ @return The Format as SDImageFormat
+ */
++ (SDImageFormat)sd_imageFormatFromUTType:(nonnull CFStringRef)uttype;
+
 @end

--- a/SDWebImage/NSData+ImageContentType.m
+++ b/SDWebImage/NSData+ImageContentType.m
@@ -95,4 +95,27 @@
     return UTType;
 }
 
++ (SDImageFormat)sd_imageFormatFromUTType:(CFStringRef)uttype {
+    if (!uttype) {
+        return SDImageFormatUndefined;
+    }
+    SDImageFormat imageFormat;
+    if (CFStringCompare(uttype, kUTTypeJPEG, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatJPEG;
+    } else if (CFStringCompare(uttype, kUTTypePNG, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatPNG;
+    } else if (CFStringCompare(uttype, kUTTypeGIF, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatGIF;
+    } else if (CFStringCompare(uttype, kUTTypeTIFF, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatTIFF;
+    } else if (CFStringCompare(uttype, kSDUTTypeWebP, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatWebP;
+    } else if (CFStringCompare(uttype, kSDUTTypeHEIC, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatHEIC;
+    } else {
+        imageFormat = SDImageFormatUndefined;
+    }
+    return imageFormat;
+}
+
 @end

--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -172,11 +172,19 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 - (void)diskImageExistsWithKey:(nullable NSString *)key completion:(nullable SDWebImageCheckCacheCompletionBlock)completionBlock;
 
 /**
- *  Sync check if image data exists in disk cache already (does not load the image)
+ *  Check if image data exists in disk cache already (does not load the image) synchronously.
  *
  *  @param key             the key describing the url
  */
 - (BOOL)diskImageDataExistsWithKey:(nullable NSString *)key;
+
+/**
+ *  Query the image data for the given key synchronously.
+ *
+ *  @param key The unique key used to store the wanted image
+ *  @return The image data for the given key, or nil if not found.
+ */
+- (nullable NSData *)diskImageDataForKey:(nullable NSString *)key;
 
 /**
  * Operation that queries the cache asynchronously and call the completion when done.
@@ -203,6 +211,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  * Query the memory cache synchronously.
  *
  * @param key The unique key used to store the image
+ * @return The image for the given key, or nil if not found.
  */
 - (nullable UIImage *)imageFromMemoryCacheForKey:(nullable NSString *)key;
 
@@ -210,6 +219,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  * Query the disk cache synchronously.
  *
  * @param key The unique key used to store the image
+ * @return The image for the given key, or nil if not found.
  */
 - (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key;
 
@@ -217,6 +227,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  * Query the cache (memory and or disk) synchronously after checking the memory cache.
  *
  * @param key The unique key used to store the image
+ * @return The image for the given key, or nil if not found.
  */
 - (nullable UIImage *)imageFromCacheForKey:(nullable NSString *)key;
 

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -375,6 +375,18 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     return exists;
 }
 
+- (nullable NSData *)diskImageDataForKey:(nullable NSString *)key {
+    if (!key) {
+        return nil;
+    }
+    __block NSData *imageData = nil;
+    dispatch_sync(self.ioQueue, ^{
+        imageData = [self diskImageDataBySearchingAllPathsForKey:key];
+    });
+    
+    return imageData;
+}
+
 - (nullable UIImage *)imageFromMemoryCacheForKey:(nullable NSString *)key {
     return [self.memCache objectForKey:key];
 }
@@ -435,7 +447,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 }
 
 - (nullable UIImage *)diskImageForKey:(nullable NSString *)key {
-    NSData *data = [self diskImageDataBySearchingAllPathsForKey:key];
+    NSData *data = [self diskImageDataForKey:key];
     return [self diskImageForKey:key data:data];
 }
 

--- a/SDWebImage/SDWebImageCodersManager.m
+++ b/SDWebImage/SDWebImageCodersManager.m
@@ -12,6 +12,7 @@
 #ifdef SD_WEBP
 #import "SDWebImageWebPCoder.h"
 #endif
+#import "UIImage+MultiFormat.h"
 
 #define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
 #define UNLOCK(lock) dispatch_semaphore_signal(lock);
@@ -121,7 +122,9 @@
     UNLOCK(self.codersLock);
     for (id<SDWebImageCoder> coder in coders.reverseObjectEnumerator) {
         if ([coder canDecodeFromData:*data]) {
-            return [coder decompressedImageWithImage:image data:data options:optionsDict];
+            UIImage *decompressedImage = [coder decompressedImageWithImage:image data:data options:optionsDict];
+            decompressedImage.sd_imageFormat = image.sd_imageFormat;
+            return decompressedImage;
         }
     }
     return nil;

--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -35,6 +35,7 @@ inline UIImage *SDScaledImageForKey(NSString * _Nullable key, UIImage * _Nullabl
         UIImage *animatedImage = [UIImage animatedImageWithImages:scaledImages duration:image.duration];
         if (animatedImage) {
             animatedImage.sd_imageLoopCount = image.sd_imageLoopCount;
+            animatedImage.sd_imageFormat = image.sd_imageFormat;
         }
         return animatedImage;
     } else {
@@ -57,6 +58,7 @@ inline UIImage *SDScaledImageForKey(NSString * _Nullable key, UIImage * _Nullabl
             }
 
             UIImage *scaledImage = [[UIImage alloc] initWithCGImage:image.CGImage scale:scale orientation:image.imageOrientation];
+            scaledImage.sd_imageFormat = image.sd_imageFormat;
             image = scaledImage;
         }
         return image;

--- a/SDWebImage/SDWebImageGIFCoder.m
+++ b/SDWebImage/SDWebImageGIFCoder.m
@@ -84,7 +84,7 @@
     }
     
     CFRelease(source);
-    
+    animatedImage.sd_imageFormat = SDImageFormatGIF;
     return animatedImage;
 #endif
 }

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -237,6 +237,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         UIImage *imageWithoutAlpha = [[UIImage alloc] initWithCGImage:imageRefWithoutAlpha scale:image.scale orientation:image.imageOrientation];
         CGContextRelease(context);
         CGImageRelease(imageRefWithoutAlpha);
+        imageWithoutAlpha.sd_imageFormat = image.sd_imageFormat;
         
         return imageWithoutAlpha;
     }
@@ -358,6 +359,8 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         if (destImage == nil) {
             return image;
         }
+        destImage.sd_imageFormat = image.sd_imageFormat;
+        
         return destImage;
     }
 }

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -11,6 +11,7 @@
 #import "NSImage+WebCache.h"
 #import <ImageIO/ImageIO.h>
 #import "NSData+ImageContentType.h"
+#import "UIImage+MultiFormat.h"
 
 #if SD_UIKIT || SD_WATCH
 static const size_t kBytesPerPixel = 4;
@@ -97,6 +98,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     }
     
     UIImage *image = [[UIImage alloc] initWithData:data];
+    image.sd_imageFormat = [NSData sd_imageFormatForImageData:data];
     
     return image;
 }
@@ -146,6 +148,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
             image = [[UIImage alloc] initWithCGImage:partialImageRef size:NSZeroSize];
 #endif
             CGImageRelease(partialImageRef);
+            image.sd_imageFormat = [NSData sd_imageFormatForImageData:data];
         }
     }
     

--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -106,6 +106,7 @@
         }
         WebPDemuxDelete(demuxer);
         CGContextRelease(canvas);
+        staticImage.sd_imageFormat = SDImageFormatWebP;
         return staticImage;
     }
     
@@ -145,6 +146,7 @@
     
     UIImage *animatedImage = [SDWebImageCoderHelper animatedImageWithFrames:frames];
     animatedImage.sd_imageLoopCount = loopCount;
+    animatedImage.sd_imageFormat = SDImageFormatWebP;
     
     return animatedImage;
 }
@@ -215,6 +217,7 @@
 #else
         image = [[UIImage alloc] initWithCGImage:newImageRef size:NSZeroSize];
 #endif
+        image.sd_imageFormat = SDImageFormatWebP;
         CGImageRelease(newImageRef);
         CGContextRelease(canvas);
     }

--- a/SDWebImage/UIImage+MultiFormat.h
+++ b/SDWebImage/UIImage+MultiFormat.h
@@ -15,7 +15,7 @@
  * UIKit:
  * For static image format, this value is always 0.
  * For animated image format, 0 means infinite looping.
- * Note that because of the limitations of categories this property can get out of sync if you create another instance with CGImage or other methods.
+ * @note Note that because of the limitations of categories this property can get out of sync if you create another instance with CGImage or other methods.
  * AppKit:
  * NSImage currently only support animated via GIF imageRep unlike UIImage.
  * The getter of this property will get the loop count from GIF imageRep
@@ -25,6 +25,8 @@
 
 /**
  * The image format represent the original compressed image data format.
+ * If you don't manually specify a format, this information is retrieve from CGImage using `CGImageGetUTType`, which may return nil for non-CG based image. At this time it will return `SDImageFormatUndefined` as default value.
+ * @note Note that because of the limitations of categories this property can get out of sync if you create another instance with CGImage or other methods.
  */
 @property (nonatomic, assign) SDImageFormat sd_imageFormat;
 

--- a/SDWebImage/UIImage+MultiFormat.h
+++ b/SDWebImage/UIImage+MultiFormat.h
@@ -23,6 +23,11 @@
  */
 @property (nonatomic, assign) NSUInteger sd_imageLoopCount;
 
+/**
+ * The image format represent the original compressed image data format.
+ */
+@property (nonatomic, assign) SDImageFormat sd_imageFormat;
+
 + (nullable UIImage *)sd_imageWithData:(nullable NSData *)data;
 - (nullable NSData *)sd_imageData;
 - (nullable NSData *)sd_imageDataAsFormat:(SDImageFormat)imageFormat;

--- a/SDWebImage/UIImage+MultiFormat.m
+++ b/SDWebImage/UIImage+MultiFormat.m
@@ -7,9 +7,9 @@
  */
 
 #import "UIImage+MultiFormat.h"
-
-#import "objc/runtime.h"
+#import "NSImage+WebCache.h"
 #import "SDWebImageCodersManager.h"
+#import "objc/runtime.h"
 
 @implementation UIImage (MultiFormat)
 
@@ -60,7 +60,7 @@
         imageFormat = value.integerValue;
         return imageFormat;
     }
-    // Check CGImage's UTType
+    // Check CGImage's UTType, may return nil for non-Image/IO based image
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
     if (&CGImageGetUTType != NULL) {

--- a/SDWebImage/UIImage+MultiFormat.m
+++ b/SDWebImage/UIImage+MultiFormat.m
@@ -53,6 +53,28 @@
 }
 #endif
 
+- (SDImageFormat)sd_imageFormat {
+    SDImageFormat imageFormat = SDImageFormatUndefined;
+    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_imageFormat));
+    if ([value isKindOfClass:[NSNumber class]]) {
+        imageFormat = value.integerValue;
+        return imageFormat;
+    }
+    // Check CGImage's UTType
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+    if (&CGImageGetUTType != NULL) {
+        CFStringRef uttype = CGImageGetUTType(self.CGImage);
+        imageFormat = [NSData sd_imageFormatFromUTType:uttype];
+    }
+#pragma clang diagnostic pop
+    return imageFormat;
+}
+
+- (void)setSd_imageFormat:(SDImageFormat)sd_imageFormat {
+    objc_setAssociatedObject(self, @selector(sd_imageFormat), @(sd_imageFormat), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 + (nullable UIImage *)sd_imageWithData:(nullable NSData *)data {
     return [[SDWebImageCodersManager sharedInstance] decodedImageWithData:data];
 }

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -11,9 +11,20 @@
 #import "SDWebImageTransition.h"
 
 /**
- A Dispatch group to maintain setImageBlock and completionBlock. This key should be used only internally and may be changed in the future. (dispatch_group_t)
+ A Dispatch group to maintain setImageBlock and completionBlock runloop order. This key should be used only internally and may be changed in the future. (dispatch_group_t)
+ You can also provide `SDWebImageInternalSetImageGroupConditionBlockKey` to dynamic control the runloop order.
+ Used by internal usage for FLAnimatedImageView currently.
  */
 FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupKey;
+
+/**
+ A SDSetImageGroupConditionBlock block object to maintain setImageBlock and completionBlock behavior. This block is called to determine whether we should use `SDWebImageInternalSetImageGroupKey` CGD group to maintain setImageBlock and completionBlock order.
+ Return YES to indicate that we should check `SDWebImageInternalSetImageGroupKey` and the completion block should be submitted to the main queue and get executed on next runloop. Return NO to indicate that the completion block should be executed immeditally. (SDSetImageGroupConditionBlock)
+ If you don't specify this value when using `SDWebImageInternalSetImageGroupKey`, always assume YES for this condition.
+ Used by internal usage for FLAnimatedImageView currently.
+ */
+FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupConditionBlockKey;
+
 /**
  A SDWebImageManager instance to control the image download and cache process using in UIImageView+WebCache category and likes. If not provided, use the shared manager (SDWebImageManager)
  */
@@ -24,6 +35,7 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageExternalCustomManagerKey;
 FOUNDATION_EXPORT const int64_t SDWebImageProgressUnitCountUnknown; /* 1LL */
 
 typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable imageData);
+typedef BOOL(^SDSetImageGroupConditionBlock)(UIImage * _Nullable image, NSData * _Nullable imageData);
 
 @interface UIView (WebCache)
 

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -18,7 +18,7 @@
 FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageInternalSetImageGroupKey;
 
 /**
- A SDSetImageGroupConditionBlock block object to maintain setImageBlock and completionBlock behavior. This block is called to determine whether we should use `SDWebImageInternalSetImageGroupKey` CGD group to maintain setImageBlock and completionBlock order.
+ A SDSetImageGroupConditionBlock block object to maintain setImageBlock and completionBlock behavior. This block is called to determine whether we should use `SDWebImageInternalSetImageGroupKey` group to maintain setImageBlock and completionBlock order.
  Return YES to indicate that we should check `SDWebImageInternalSetImageGroupKey` and the completion block should be submitted to the main queue and get executed on next runloop. Return NO to indicate that the completion block should be executed immeditally. (SDSetImageGroupConditionBlock)
  If you don't specify this value when using `SDWebImageInternalSetImageGroupKey`, always assume YES for this condition.
  Used by internal usage for FLAnimatedImageView currently.

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -11,6 +11,7 @@
 #import "UIView+WebCacheOperation.h"
 
 NSString * const SDWebImageInternalSetImageGroupKey = @"internalSetImageGroup";
+NSString * const SDWebImageInternalSetImageGroupConditionBlockKey = @"internalSetImageGroupConditionBlock";
 NSString * const SDWebImageExternalCustomManagerKey = @"externalCustomManager";
 
 const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
@@ -152,30 +153,30 @@ static char TAG_ACTIVITY_SHOW;
                 transition = sself.sd_imageTransition;
             }
 #endif
-            if ([context valueForKey:SDWebImageInternalSetImageGroupKey]) {
-                dispatch_group_t group = [context valueForKey:SDWebImageInternalSetImageGroupKey];
+            // check whether we should use GCD group to maintain setImageBlock & completionBlock order (For FLAnimatedImage compatibility)
+            dispatch_group_t group = [context valueForKey:SDWebImageInternalSetImageGroupKey];
+            BOOL groupCondition = YES;
+            if (group) {
+                // check whether we should use group notify to submit the completionBlock (or execute immediately)
+                SDSetImageGroupConditionBlock groupConditionBlock = [context valueForKey:SDWebImageInternalSetImageGroupConditionBlockKey];
+                if (groupConditionBlock) {
+                    groupCondition = groupConditionBlock(targetImage, targetData);
+                }
                 dispatch_group_enter(group);
-                dispatch_main_async_safe(^{
-#if SD_UIKIT || SD_MAC
-                    [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock transition:transition cacheType:cacheType imageURL:imageURL];
-#else
-                    [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
-#endif
-                });
-                // ensure completion block is called after custom setImage process finish
-                dispatch_group_notify(group, dispatch_get_main_queue(), ^{
-                    callCompletedBlockClojure();
-                });
-            } else {
-                dispatch_main_async_safe(^{
-#if SD_UIKIT || SD_MAC
-                    [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock transition:transition cacheType:cacheType imageURL:imageURL];
-#else
-                    [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
-#endif
-                    callCompletedBlockClojure();
-                });
             }
+            dispatch_main_async_safe(^{
+#if SD_UIKIT || SD_MAC
+                [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock transition:transition cacheType:cacheType imageURL:imageURL];
+#else
+                [sself sd_setImage:targetImage imageData:targetData basedOnClassOrViaCustomSetImageBlock:setImageBlock];
+#endif
+                if (group && groupCondition) {
+                    // submit the completion block to main queue, it may be executed on next runloop
+                    dispatch_group_notify(group, dispatch_get_main_queue(), callCompletedBlockClojure);
+                } else {
+                    callCompletedBlockClojure();
+                }
+            });
         }];
         [self sd_setImageLoadOperation:operation forKey:validOperationKey];
     } else {


### PR DESCRIPTION
Add `FLAnimatedImageViewSetImagePolicy` to control detailed behavior for GIF rendering, this may help for some user who don't need that temp poster image and global queue decoding.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

### Reason

Some user who use `FLAnimatedImageView+WebCache` for displaying GIF image face the issue that the behavior for non-GIF image is different from `UIImageView+WebCache`.

This because of that `FLAnimatedImageView` use a GCD group and `dispatch_group_notify` to manage the completion block after image loading. This API will submit the completion block to the notification queue(main queue) into next runloop. However, `UIImageView` will always call the completion block synchronously at current runloop.

This difference will cause sometime `FLAnimatedImageView+WebCache` loading a non-GIF image will flash during cell reusing.

So this PR fix that, by firstlly check whether this image is `GIF`, then use GCD group to dispatch. Or it will fallback as normal `UIImageView` process and call completion block synchronously at current runloop.

### Other change

And also, this PR introduct a new config, to let user to disable a "trick" way of displaying `FLAnimatedImage` GIF for performance issue. See #2047 . Which may cause some problem for rare case, and user should have control to disable this and just create `FLAnimatedImage` in the current queue. However, that way can still be helpful for some big GIF images. (Which the decoding process may block the main queue and cause frame drop). So we can keep both of these and let the user to choose one. 
