### PR TITLE
Add cache control for FLAnimatedImage, this allow user to disable memory cache for associated FLAnimatedImage instance

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -53,6 +53,13 @@
 @property (nonatomic, assign) BOOL sd_predrawingEnabled;
 
 /**
+ * Cache control for associated FLAnimatedImage object for memory cache. When enabled, we will bind created FLAnimatedImage instance to UIImage, and store it into memory cache to avoid create this instance cause decoding performance. See `UIImage+FLAnimatedImage`.
+ * When enabled, this may consume more memory, if you are facing memory issue, disable it and let FLAnimatedImage been created just in time and dealloced as it not been used. However, when disabled, this may impact performance since we need query disk cache when current GIF url is cached.
+ * Defatuls to YES;
+ */
+@property (nonatomic, assign) BOOL sd_cacheFLAnimatedImage;
+
+/**
  * Load the image at the given url (either from cache or download) and load it in this imageView. It works with both static and dynamic images
  * The download is asynchronous and cached.
  *

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.h
@@ -54,7 +54,7 @@
 
 /**
  * Cache control for associated FLAnimatedImage object for memory cache. When enabled, we will bind created FLAnimatedImage instance to UIImage, and store it into memory cache to avoid create this instance cause decoding performance. See `UIImage+FLAnimatedImage`.
- * When enabled, this may consume more memory, if you are facing memory issue, disable it and let FLAnimatedImage been created just in time and dealloced as it not been used. However, when disabled, this may impact performance since we need query disk cache when current GIF url is cached.
+ * When enabled, this may consume more memory, if you are facing memory issue, disable it and let FLAnimatedImage been created just in time and dealloced as it not been used. However, when disabled, this may impact performance since we need query disk cache, create FLAnimatedImage and decoding even when the current GIF url is cached.
  * Defatuls to YES;
  */
 @property (nonatomic, assign) BOOL sd_cacheFLAnimatedImage;

--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -56,6 +56,19 @@
     objc_setAssociatedObject(self, @selector(sd_predrawingEnabled), @(sd_predrawingEnabled), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+- (BOOL)sd_cacheFLAnimatedImage {
+    BOOL cacheFLAnimatedImage = YES;
+    NSNumber *value = objc_getAssociatedObject(self, @selector(sd_cacheFLAnimatedImage));
+    if ([value isKindOfClass:[NSNumber class]]) {
+        cacheFLAnimatedImage = value.boolValue;
+    }
+    return cacheFLAnimatedImage;
+}
+
+- (void)setSd_cacheFLAnimatedImage:(BOOL)sd_cacheFLAnimatedImage {
+    objc_setAssociatedObject(self, @selector(sd_cacheFLAnimatedImage), @(sd_cacheFLAnimatedImage), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 - (void)sd_setImageWithURL:(nullable NSURL *)url {
     [self sd_setImageWithURL:url placeholderImage:nil options:0 progress:nil completed:nil];
 }
@@ -113,12 +126,14 @@
                                    FLAnimatedImage *animatedImage;
                                    // Compatibility in 4.x for lower version FLAnimatedImage.
                                    if ([FLAnimatedImage respondsToSelector:@selector(initWithAnimatedGIFData:optimalFrameCacheSize:predrawingEnabled:)]) {
-                                       animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:self.sd_optimalFrameCacheSize predrawingEnabled:self.sd_predrawingEnabled];
+                                       animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData optimalFrameCacheSize:weakSelf.sd_optimalFrameCacheSize predrawingEnabled:weakSelf.sd_predrawingEnabled];
                                    } else {
                                        animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData];
                                    }
                                    dispatch_async(dispatch_get_main_queue(), ^{
-                                       image.sd_FLAnimatedImage = animatedImage;
+                                       if (weakSelf.sd_cacheFLAnimatedImage) {
+                                           image.sd_FLAnimatedImage = animatedImage;
+                                       }
                                        weakSelf.animatedImage = animatedImage;
                                        weakSelf.image = nil;
                                        if (group) {

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -43,7 +43,7 @@ typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {
 
 /**
  * The option to control weak memory cache for images. When enable, `SDImageCache`'s memory cache will use a weak maptable to store the image at the same time when it stored to memory, and get removed at the same time.
- * However when memory warning triggered, since this weak maptable does not hold a strong reference to image instacnce, even when the memory cache itself is purged, some images which are held strongly by UIImageView or other instance can be recoveried again, to avoid re-query from disk cache or network. This may be helpful for case when app enter background and memory purched, cause cell flashing after re-enter foreground.
+ * However when memory warning is triggered, since the weak maptable does not hold a strong reference to image instacnce, even when the memory cache itself is purged, some images which are held strongly by UIImageViews or other live instances can be recovered again, to avoid later re-query from disk cache or network. This may be helpful for the case, for example, when app enter background and memory is purged, cause cell flashing after re-enter foreground.
  * Defautls to YES. You can change this option dynamically.
  */
 @property (assign, nonatomic) BOOL shouldUseWeakMemoryCache;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2377 

### Pull Request Description

### Reason
This PR provide a control for `FLAnimatedImageView+WebCache`, which allow user to decide whether to use memory cache for associated `FLAnimatedImage` instance on UIImage object for memory cache storage. The related PR is #2181 

Since `FLAnimatedImage` is not so **Lightweight** as normal static `UIImage`, because it also hold a `internal cache`, and bind `compressed GIF data`, `poster image`, these two property, maybe also memory consuming. So it's better to provide a control for this behavior. For example, if user just use some small GIF and use a UITableView cell which only 10 FLAnimatedImageView can visible on screen at same time, they do not need to cache it at all.

