### PR TITLE
Add option to enable or disable weak memory cache for SDImageCache

### DIFF
--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -30,8 +30,12 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 // Private
 @interface SDMemoryCache <KeyType, ObjectType> ()
 
+@property (nonatomic, strong, nonnull) SDImageCacheConfig *config;
 @property (nonatomic, strong, nonnull) NSMapTable<KeyType, ObjectType> *weakCache; // strong-weak cache
 @property (nonatomic, strong, nonnull) dispatch_semaphore_t weakCacheLock; // a lock to keep the access to `weakCache` thread-safe
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithConfig:(nonnull SDImageCacheConfig *)config;
 
 @end
 
@@ -45,7 +49,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
 }
 
-- (instancetype)init {
+- (instancetype)initWithConfig:(SDImageCacheConfig *)config {
     self = [super init];
     if (self) {
         // Use a strong-weak maptable storing the secondary cache. Follow the doc that NSCache does not copy keys
@@ -53,6 +57,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         // At this case, we can sync weak cache back and do not need to load from disk cache
         self.weakCache = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsStrongMemory valueOptions:NSPointerFunctionsWeakMemory capacity:0];
         self.weakCacheLock = dispatch_semaphore_create(1);
+        self.config = config;
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(didReceiveMemoryWarning:)
                                                      name:UIApplicationDidReceiveMemoryWarningNotification
@@ -69,6 +74,9 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 // `setObject:forKey:` just call this with 0 cost. Override this is enough
 - (void)setObject:(id)obj forKey:(id)key cost:(NSUInteger)g {
     [super setObject:obj forKey:key cost:g];
+    if (!self.config.shouldUseWeakMemoryCache) {
+        return;
+    }
     if (key && obj) {
         // Store weak cache
         LOCK(self.weakCacheLock);
@@ -79,6 +87,9 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (id)objectForKey:(id)key {
     id obj = [super objectForKey:key];
+    if (!self.config.shouldUseWeakMemoryCache) {
+        return obj;
+    }
     if (key && !obj) {
         // Check weak cache
         LOCK(self.weakCacheLock);
@@ -98,6 +109,9 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (void)removeObjectForKey:(id)key {
     [super removeObjectForKey:key];
+    if (!self.config.shouldUseWeakMemoryCache) {
+        return;
+    }
     if (key) {
         // Remove weak cache
         LOCK(self.weakCacheLock);
@@ -108,10 +122,20 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 
 - (void)removeAllObjects {
     [super removeAllObjects];
+    if (!self.config.shouldUseWeakMemoryCache) {
+        return;
+    }
     // Manually remove should also remove weak cache
     LOCK(self.weakCacheLock);
     [self.weakCache removeAllObjects];
     UNLOCK(self.weakCacheLock);
+}
+
+#else
+
+- (instancetype)initWithConfig:(SDImageCacheConfig *)config {
+    self = [super init];
+    return self;
 }
 
 #endif
@@ -163,7 +187,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
         _config = [[SDImageCacheConfig alloc] init];
         
         // Init the memory cache
-        _memCache = [[SDMemoryCache alloc] init];
+        _memCache = [[SDMemoryCache alloc] initWithConfig:_config];
         _memCache.name = fullNamespace;
 
         // Init the disk cache

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -29,14 +29,24 @@ typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {
 @property (assign, nonatomic) BOOL shouldDecompressImages;
 
 /**
- * disable iCloud backup [defaults to YES]
+ * Whether or not to disable iCloud backup
+ * Defaults to YES.
  */
 @property (assign, nonatomic) BOOL shouldDisableiCloud;
 
 /**
- * use memory cache [defaults to YES]
+ * Whether or not to use memory cache
+ * @note When the memory cache is disabled, the weak memory cache will also be disabled.
+ * Defaults to YES.
  */
 @property (assign, nonatomic) BOOL shouldCacheImagesInMemory;
+
+/**
+ * The option to control weak memory cache for images. When enable, `SDImageCache`'s memory cache will use a weak maptable to store the image at the same time when it stored to memory, and get removed at the same time.
+ * However when memory warning triggered, since this weak maptable does not hold a strong reference to image instacnce, even when the memory cache itself is purged, some images which are held strongly by UIImageView or other instance can be recoveried again, to avoid re-query from disk cache or network. This may be helpful for case when app enter background and memory purched, cause cell flashing after re-enter foreground.
+ * Defautls to YES. You can change this option dynamically.
+ */
+@property (assign, nonatomic) BOOL shouldUseWeakMemoryCache;
 
 /**
  * The reading options while reading cache from disk.

--- a/SDWebImage/SDImageCacheConfig.m
+++ b/SDWebImage/SDImageCacheConfig.m
@@ -17,6 +17,7 @@ static const NSInteger kDefaultCacheMaxCacheAge = 60 * 60 * 24 * 7; // 1 week
         _shouldDecompressImages = YES;
         _shouldDisableiCloud = YES;
         _shouldCacheImagesInMemory = YES;
+        _shouldUseWeakMemoryCache = YES;
         _diskCacheReadingOptions = 0;
         _diskCacheWritingOptions = NSDataWritingAtomic;
         _maxCacheAge = kDefaultCacheMaxCacheAge;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2377 

### Pull Request Description

### Reason

In the previous #2228 , we introduce a secondary weak memory cache for `SDImageCache`. Which may solve #791 case that a `UIImage` instance is hold by other alive instance by strong reference, however, when we purge the memory cache, we can not investigate this and cause re-query disk cahce or re-download from network. 

I think that feature's aim is correct and it actually solve this problem. However, this behavior should be controlled by user but not hidden in the implementation detail. Because a weak maptable which may delay intance dealloc time at race time (See [this blog](http://cocoamine.net/blog/2013/12/13/nsmaptable-and-zeroing-weak-references/)). And a extra lock to keep thread-safe which may a little impact the performance. So it's greate that user can decide to enable/disable this feature.

The default options is ON, since most of cases this works does not cause any problem.
