### PR TITLE
Fix crash when assign request property of SDWebImageDownloadToken

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -109,12 +109,12 @@ typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
 /**
  The download's request.
  */
-@property (nonatomic, copy, nullable, readonly) NSURLRequest *request;
+@property (nonatomic, strong, nullable, readonly) NSURLRequest *request;
 
 /**
  The download's response.
  */
-@property (nonatomic, copy, nullable, readonly) NSURLResponse *response;
+@property (nonatomic, strong, nullable, readonly) NSURLResponse *response;
 
 @end
 

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -19,8 +19,8 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
 @interface SDWebImageDownloadToken ()
 
 @property (nonatomic, strong, nullable, readwrite) NSURL *url;
-@property (nonatomic, copy, nullable, readwrite) NSURLRequest *request;
-@property (nonatomic, copy, nullable, readwrite) NSURLResponse *response;
+@property (nonatomic, strong, nullable, readwrite) NSURLRequest *request;
+@property (nonatomic, strong, nullable, readwrite) NSURLResponse *response;
 @property (nonatomic, strong, nullable, readwrite) id downloadOperationCancelToken;
 @property (nonatomic, weak, nullable) NSOperation<SDWebImageDownloaderOperation> *downloadOperation;
 @property (nonatomic, weak, nullable) SDWebImageDownloader *downloader;


### PR DESCRIPTION
* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

Fixed #2380 .
