### PR TITLE
Refactor cache options of SDImageCache

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -14,36 +14,31 @@
 
 typedef NS_OPTIONS(NSUInteger, SDImageCacheOptions) {
     /**
-     * By default, we do not query image data when the image is already cached in memory. This mask can force to query image data at the same time. However, this query is asynchronously unless you specify `SDImageCacheQueryMemoryDataSync`
+     * By default, we do not query image disk data when the image is already cached in memory. This mask can force to query image disk data only. However, this query is asynchronously unless you specify `SDImageCacheQueryDiskDataSync`
      */
-    SDImageCacheQueryMemoryData = 1 << 0,
-    /**
-     * By default, when you only specify `SDImageCacheQueryMemoryData`, we query the memory image data asynchronously. Combined this mask as well to query the memory image data synchronously.
-     */
-    SDImageCacheQueryMemoryDataSync = 1 << 1,
+    SDImageCacheForceQueryDiskData = 1 << 0,
     /**
      * By default, when the memory cache miss, we query the disk cache asynchronously. This mask can force to query disk cache (when memory cache miss) synchronously.
-     @note These 3 query options can be combined together. For the full list about these masks combination, see wiki page.
      */
-    SDImageCacheQueryDiskDataSync = 1 << 2,
+    SDImageCacheQueryDiskDataSync = 1 << 1,
     /**
      * By default, images are decoded respecting their original size. On iOS, this flag will scale down the
      * images to a size compatible with the constrained memory of devices.
      */
-    SDImageCacheScaleDownLargeImages = 1 << 3,
+    SDImageCacheScaleDownLargeImages = 1 << 2,
     /**
      * By default, we will decode the image in the background during cache query and download from the network. This can help to improve performance because when rendering image on the screen, it need to be firstly decoded. But this happen on the main queue by Core Animation.
      * However, this process may increase the memory usage as well. If you are experiencing a issue due to excessive memory consumption, This flag can prevent decode the image.
      */
-    SDImageCacheAvoidDecodeImage = 1 << 4,
+    SDImageCacheAvoidDecodeImage = 1 << 3,
     /**
      * By default, we decode the animated image. This flag can force decode the first frame only and produece the static image.
      */
-    SDImageCacheDecodeFirstFrameOnly = 1 << 5,
+    SDImageCacheDecodeFirstFrameOnly = 1 << 4,
     /**
      * By default, for `SDAnimatedImage`, we decode the animated image frame during rendering to reduce memory usage. This flag actually trigger `preloadAllAnimatedImageFrames = YES` after image load from disk cache
      */
-    SDImageCachePreloadAllFrames = 1 << 6
+    SDImageCachePreloadAllFrames = 1 << 5
 };
 
 /**

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -27,8 +27,7 @@
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:MyIdentifier];
  
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:MyIdentifier]
-                 autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:MyIdentifier];
     }
  
     // Here we use the provided sd_setImageWithURL: method to load the web image


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Related `PR`: #2312 

Reason:
@dreampiggy I think a lot and maybe don't get the point when I saw these options like `SDImageCacheQueryMemoryData` and `SDImageCacheQueryMemoryDataSync`. Memory query is always synchronous, I don't know what's the meaning about memory sync/async TBO. Maybe I missed something.

I added an option `SDImageCacheForceQueryDiskData` that would query disk image data forcedly.

