### PR TITLE
Fix nullable key when cancel image load operation

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -105,7 +105,7 @@
                              options:options
                         operationKey:nil
                        setImageBlock:^(UIImage *image, NSData *imageData) {
-                           // We could not directlly create the animated image on bacakground queue because it's time consuming, by the time we set it back, the current runloop has passed and the placeholder has been rendered and then replaced with animated image, this cause a flashing.
+                           // We could not directlly create the animated image on background queue because it's time consuming, by the time we set it back, the current runloop has passed and the placeholder has been rendered and then replaced with animated image, this cause a flashing.
                            // Previously we use a trick to firstly set the static poster image, then set animated image back to avoid flashing, but this trick fail when using with custom UIView transition. Core Animation will use the current layer state to do rendering, so even we later set it back, the transition will not update. (it's recommended to use `SDWebImageTransition` instead)
                            // So we have no choice to force store the FLAnimatedImage into memory cache using a associated object binding to UIImage instance. This consumed memory is adoptable and much smaller than `_UIAnimatedImage` for big GIF
                            FLAnimatedImage *associatedAnimatedImage = image.sd_FLAnimatedImage;

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -27,8 +27,7 @@
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:MyIdentifier];
  
     if (cell == nil) {
-        cell = [[[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:MyIdentifier]
-                 autorelease];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:MyIdentifier];
     }
  
     // Here we use the provided sd_setImageWithURL: method to load the web image

--- a/SDWebImage/UIView+WebCacheOperation.m
+++ b/SDWebImage/UIView+WebCacheOperation.m
@@ -42,18 +42,16 @@ typedef NSMapTable<NSString *, id<SDWebImageOperation>> SDOperationsDictionary;
 }
 
 - (void)sd_cancelImageLoadOperationWithKey:(nullable NSString *)key {
-    // Cancel in progress downloader from queue
-    SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
-    id<SDWebImageOperation> operation;
-    @synchronized (self) {
-        operation = [operationDictionary objectForKey:key];
-    }
-    if (operation) {
-        if ([operation conformsToProtocol:@protocol(SDWebImageOperation)]){
-            [operation cancel];
-        }
+    if (key) {
+        // Cancel in progress downloader from queue
+        SDOperationsDictionary *operationDictionary = [self sd_operationDictionary];
+        id<SDWebImageOperation> operation;
         @synchronized (self) {
+            operation = [operationDictionary objectForKey:key];
             [operationDictionary removeObjectForKey:key];
+        }
+        if ([operation conformsToProtocol:@protocol(SDWebImageOperation)]) {
+            [operation cancel];
         }
     }
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Fix nullable key when cancel image load operation.
