### PR TITLE
Keep the information about image's original compressed format, for API which only contains image but not image data to process extra logic

### DIFF
--- a/SDWebImage/NSData+ImageContentType.h
+++ b/SDWebImage/NSData+ImageContentType.h
@@ -32,11 +32,19 @@ typedef NS_ENUM(NSInteger, SDImageFormat) {
 + (SDImageFormat)sd_imageFormatForImageData:(nullable NSData *)data;
 
 /**
- Convert SDImageFormat to UTType
-
- @param format Format as SDImageFormat
- @return The UTType as CFStringRef
+ *  Convert SDImageFormat to UTType
+ *
+ *  @param format Format as SDImageFormat
+ *  @return The UTType as CFStringRef
  */
 + (nonnull CFStringRef)sd_UTTypeFromSDImageFormat:(SDImageFormat)format;
+
+/**
+ *  Convert UTTyppe to SDImageFormat
+ *
+ *  @param uttype The UTType as CFStringRef
+ *  @return The Format as SDImageFormat
+ */
++ (SDImageFormat)sd_imageFormatFromUTType:(nonnull CFStringRef)uttype;
 
 @end

--- a/SDWebImage/NSData+ImageContentType.m
+++ b/SDWebImage/NSData+ImageContentType.m
@@ -95,4 +95,27 @@
     return UTType;
 }
 
++ (SDImageFormat)sd_imageFormatFromUTType:(CFStringRef)uttype {
+    if (!uttype) {
+        return SDImageFormatUndefined;
+    }
+    SDImageFormat imageFormat;
+    if (CFStringCompare(uttype, kUTTypeJPEG, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatJPEG;
+    } else if (CFStringCompare(uttype, kUTTypePNG, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatPNG;
+    } else if (CFStringCompare(uttype, kUTTypeGIF, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatGIF;
+    } else if (CFStringCompare(uttype, kUTTypeTIFF, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatTIFF;
+    } else if (CFStringCompare(uttype, kSDUTTypeWebP, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatWebP;
+    } else if (CFStringCompare(uttype, kSDUTTypeHEIC, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatHEIC;
+    } else {
+        imageFormat = SDImageFormatUndefined;
+    }
+    return imageFormat;
+}
+
 @end

--- a/SDWebImage/SDWebImageCodersManager.m
+++ b/SDWebImage/SDWebImageCodersManager.m
@@ -12,6 +12,7 @@
 #ifdef SD_WEBP
 #import "SDWebImageWebPCoder.h"
 #endif
+#import "UIImage+MultiFormat.h"
 
 #define LOCK(lock) dispatch_semaphore_wait(lock, DISPATCH_TIME_FOREVER);
 #define UNLOCK(lock) dispatch_semaphore_signal(lock);
@@ -121,7 +122,9 @@
     UNLOCK(self.codersLock);
     for (id<SDWebImageCoder> coder in coders.reverseObjectEnumerator) {
         if ([coder canDecodeFromData:*data]) {
-            return [coder decompressedImageWithImage:image data:data options:optionsDict];
+            UIImage *decompressedImage = [coder decompressedImageWithImage:image data:data options:optionsDict];
+            decompressedImage.sd_imageFormat = image.sd_imageFormat;
+            return decompressedImage;
         }
     }
     return nil;

--- a/SDWebImage/SDWebImageCompat.m
+++ b/SDWebImage/SDWebImageCompat.m
@@ -35,6 +35,7 @@ inline UIImage *SDScaledImageForKey(NSString * _Nullable key, UIImage * _Nullabl
         UIImage *animatedImage = [UIImage animatedImageWithImages:scaledImages duration:image.duration];
         if (animatedImage) {
             animatedImage.sd_imageLoopCount = image.sd_imageLoopCount;
+            animatedImage.sd_imageFormat = image.sd_imageFormat;
         }
         return animatedImage;
     } else {
@@ -57,6 +58,7 @@ inline UIImage *SDScaledImageForKey(NSString * _Nullable key, UIImage * _Nullabl
             }
 
             UIImage *scaledImage = [[UIImage alloc] initWithCGImage:image.CGImage scale:scale orientation:image.imageOrientation];
+            scaledImage.sd_imageFormat = image.sd_imageFormat;
             image = scaledImage;
         }
         return image;

--- a/SDWebImage/SDWebImageGIFCoder.m
+++ b/SDWebImage/SDWebImageGIFCoder.m
@@ -81,6 +81,7 @@
         
         animatedImage = [SDWebImageCoderHelper animatedImageWithFrames:frames];
         animatedImage.sd_imageLoopCount = loopCount;
+        animatedImage.sd_imageFormat = SDImageFormatGIF;
     }
     
     CFRelease(source);

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -11,6 +11,7 @@
 #import "NSImage+WebCache.h"
 #import <ImageIO/ImageIO.h>
 #import "NSData+ImageContentType.h"
+#import "UIImage+MultiFormat.h"
 
 #if SD_UIKIT || SD_WATCH
 static const size_t kBytesPerPixel = 4;
@@ -97,6 +98,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     }
     
     UIImage *image = [[UIImage alloc] initWithData:data];
+    image.sd_imageFormat = [NSData sd_imageFormatForImageData:data];
     
     return image;
 }
@@ -146,6 +148,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
             image = [[UIImage alloc] initWithCGImage:partialImageRef size:NSZeroSize];
 #endif
             CGImageRelease(partialImageRef);
+            image.sd_imageFormat = [NSData sd_imageFormatForImageData:data];
         }
     }
     

--- a/SDWebImage/SDWebImageWebPCoder.m
+++ b/SDWebImage/SDWebImageWebPCoder.m
@@ -106,6 +106,7 @@
         }
         WebPDemuxDelete(demuxer);
         CGContextRelease(canvas);
+        staticImage.sd_imageFormat = SDImageFormatWebP;
         return staticImage;
     }
     
@@ -145,6 +146,7 @@
     
     UIImage *animatedImage = [SDWebImageCoderHelper animatedImageWithFrames:frames];
     animatedImage.sd_imageLoopCount = loopCount;
+    animatedImage.sd_imageFormat = SDImageFormatWebP;
     
     return animatedImage;
 }
@@ -215,6 +217,7 @@
 #else
         image = [[UIImage alloc] initWithCGImage:newImageRef size:NSZeroSize];
 #endif
+        image.sd_imageFormat = SDImageFormatWebP;
         CGImageRelease(newImageRef);
         CGContextRelease(canvas);
     }

--- a/SDWebImage/UIImage+MultiFormat.h
+++ b/SDWebImage/UIImage+MultiFormat.h
@@ -15,13 +15,20 @@
  * UIKit:
  * For static image format, this value is always 0.
  * For animated image format, 0 means infinite looping.
- * Note that because of the limitations of categories this property can get out of sync if you create another instance with CGImage or other methods.
+ * @note Note that because of the limitations of categories this property can get out of sync if you create another instance with CGImage or other methods.
  * AppKit:
  * NSImage currently only support animated via GIF imageRep unlike UIImage.
  * The getter of this property will get the loop count from GIF imageRep
  * The setter of this property will set the loop count from GIF imageRep
  */
 @property (nonatomic, assign) NSUInteger sd_imageLoopCount;
+
+/**
+ * The image format represent the original compressed image data format.
+ * If you don't manually specify a format, this information is retrieve from CGImage using `CGImageGetUTType`, which may return nil for non-CG based image. At this time it will return `SDImageFormatUndefined` as default value.
+ * @note Note that because of the limitations of categories this property can get out of sync if you create another instance with CGImage or other methods.
+ */
+@property (nonatomic, assign) SDImageFormat sd_imageFormat;
 
 + (nullable UIImage *)sd_imageWithData:(nullable NSData *)data;
 - (nullable NSData *)sd_imageData;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2374 

### Pull Request Description

This PR add a `sd_imageFormat` property to UIImage category, which store the original compressed image data format (because UIImage will lost this information after created).

This feature is useful to fix #2374 , because we need to detect that if `image.sd_imageFormat == SDImageFormatGIF` to query cache again. However, except that, this property can be really useful for many aspects. Including extra process for image transformer (base on type to do something like a `GIF` mark).. So I think introduce this API is adoptable.

Change is quite simple, each `SDWebImageCoder` decode method shuold store the image format information, and some common method which create new image based on CGImage should also keep this information not been lost.
