### PR TITLE
Add one sync API for SDImageCache to directly get the image data from disk instead of image instance

### DIFF
--- a/SDWebImage/SDImageCache.h
+++ b/SDWebImage/SDImageCache.h
@@ -179,6 +179,14 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
 - (BOOL)diskImageDataExistsWithKey:(nullable NSString *)key;
 
 /**
+ *  Query the image data for the given key synchronously.
+ *
+ *  @param key The unique key used to store the wanted image
+ *  @return The image data for the given key, or nil if not found.
+ */
+- (nullable NSData *)diskImageDataForKey:(nullable NSString *)key;
+
+/**
  * Operation that queries the cache asynchronously and call the completion when done.
  *
  * @param key       The unique key used to store the wanted image
@@ -203,6 +211,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  * Query the memory cache synchronously.
  *
  * @param key The unique key used to store the image
+ * @return The image for the given key, or nil if not found.
  */
 - (nullable UIImage *)imageFromMemoryCacheForKey:(nullable NSString *)key;
 
@@ -210,6 +219,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  * Query the disk cache synchronously.
  *
  * @param key The unique key used to store the image
+ * @return The image for the given key, or nil if not found.
  */
 - (nullable UIImage *)imageFromDiskCacheForKey:(nullable NSString *)key;
 
@@ -217,6 +227,7 @@ typedef void(^SDWebImageCalculateSizeBlock)(NSUInteger fileCount, NSUInteger tot
  * Query the cache (memory and or disk) synchronously after checking the memory cache.
  *
  * @param key The unique key used to store the image
+ * @return The image for the given key, or nil if not found.
  */
 - (nullable UIImage *)imageFromCacheForKey:(nullable NSString *)key;
 

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -399,6 +399,18 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
     return exists;
 }
 
+- (nullable NSData *)diskImageDataForKey:(nullable NSString *)key {
+    if (!key) {
+        return nil;
+    }
+    __block NSData *imageData = nil;
+    dispatch_sync(self.ioQueue, ^{
+        imageData = [self diskImageDataBySearchingAllPathsForKey:key];
+    });
+    
+    return imageData;
+}
+
 - (nullable UIImage *)imageFromMemoryCacheForKey:(nullable NSString *)key {
     return [self.memCache objectForKey:key];
 }
@@ -459,7 +471,7 @@ FOUNDATION_STATIC_INLINE NSUInteger SDCacheCostForImage(UIImage *image) {
 }
 
 - (nullable UIImage *)diskImageForKey:(nullable NSString *)key {
-    NSData *data = [self diskImageDataBySearchingAllPathsForKey:key];
+    NSData *data = [self diskImageDataForKey:key];
     return [self diskImageForKey:key data:data];
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2374 

### Pull Request Description

This PR add one sync version API `diskImageDataForKey:` on `SDImageCache`.

Sometimes we need to directly parse the image data instead of let the decoding process happend. So we need the raw image data. Current API seems can't solve this.

This can help to solve #2374 , which need to detect the original image foramt is GIF, and try to query disk cache to get the raw image data and get `FLAnimatedImage` instance. Except this, this may also be helpful for use case when we need directly transfer the image data (for example, store data to Photos library). So I think maybe this is adoptable.

