### PR TITLE
Rename `sd_UTTypeFromSDImageFormat` to `sd_UTTypeFromImageFormat`

### DIFF
--- a/SDWebImage/NSData+ImageContentType.h
+++ b/SDWebImage/NSData+ImageContentType.h
@@ -37,7 +37,7 @@ typedef NS_ENUM(NSInteger, SDImageFormat) {
  *  @param format Format as SDImageFormat
  *  @return The UTType as CFStringRef
  */
-+ (nonnull CFStringRef)sd_UTTypeFromSDImageFormat:(SDImageFormat)format CF_RETURNS_NOT_RETAINED;
++ (nonnull CFStringRef)sd_UTTypeFromImageFormat:(SDImageFormat)format CF_RETURNS_NOT_RETAINED;
 
 /**
  *  Convert UTTyppe to SDImageFormat

--- a/SDWebImage/NSData+ImageContentType.m
+++ b/SDWebImage/NSData+ImageContentType.m
@@ -66,7 +66,7 @@
     return SDImageFormatUndefined;
 }
 
-+ (nonnull CFStringRef)sd_UTTypeFromSDImageFormat:(SDImageFormat)format {
++ (nonnull CFStringRef)sd_UTTypeFromImageFormat:(SDImageFormat)format {
     CFStringRef UTType;
     switch (format) {
         case SDImageFormatJPEG:

--- a/SDWebImage/SDImageAPNGCoder.m
+++ b/SDWebImage/SDImageAPNGCoder.m
@@ -188,7 +188,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
     }
     
     NSMutableData *imageData = [NSMutableData data];
-    CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatPNG];
+    CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:SDImageFormatPNG];
     NSArray<SDImageFrame *> *frames = [SDImageCoderHelper framesFromAnimatedImage:image];
     
     // Create an image destination. APNG does not support EXIF image orientation
@@ -243,7 +243,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
 - (instancetype)initIncrementalWithOptions:(nullable SDImageCoderOptions *)options {
     self = [super init];
     if (self) {
-        CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatPNG];
+        CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:SDImageFormatPNG];
         _imageSource = CGImageSourceCreateIncremental((__bridge CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceTypeIdentifierHint : (__bridge NSString *)imageUTType});
         CGFloat scale = 1;
         if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {

--- a/SDWebImage/SDImageCoderHelper.m
+++ b/SDWebImage/SDImageCoderHelper.m
@@ -80,7 +80,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
 #else
     
     NSMutableData *imageData = [NSMutableData data];
-    CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatGIF];
+    CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:SDImageFormatGIF];
     // Create an image destination. GIF does not support EXIF image orientation
     CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, frameCount, NULL);
     if (!imageDestination) {

--- a/SDWebImage/SDImageGIFCoder.m
+++ b/SDWebImage/SDImageGIFCoder.m
@@ -183,7 +183,7 @@
 - (instancetype)initIncrementalWithOptions:(nullable SDImageCoderOptions *)options {
     self = [super init];
     if (self) {
-        CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatGIF];
+        CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:SDImageFormatGIF];
         _imageSource = CGImageSourceCreateIncremental((__bridge CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceTypeIdentifierHint : (__bridge NSString *)imageUTType});
         CGFloat scale = 1;
         if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
@@ -271,7 +271,7 @@
     }
     
     NSMutableData *imageData = [NSMutableData data];
-    CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatGIF];
+    CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:SDImageFormatGIF];
     NSArray<SDImageFrame *> *frames = [SDImageCoderHelper framesFromAnimatedImage:image];
     
     // Create an image destination. GIF does not support EXIF image orientation

--- a/SDWebImage/SDImageIOCoder.m
+++ b/SDWebImage/SDImageIOCoder.m
@@ -203,7 +203,7 @@
     }
     
     NSMutableData *imageData = [NSMutableData data];
-    CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:format];
+    CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:format];
     
     // Create an image destination.
     CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, 1, NULL);
@@ -261,7 +261,7 @@
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSMutableData *imageData = [NSMutableData data];
-        CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatHEIC];
+        CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:SDImageFormatHEIC];
         
         // Create an image destination.
         CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, 1, NULL);

--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -24,7 +24,7 @@
     expect(format == SDImageFormatUndefined);
     
     // Test invalid format
-    CFStringRef type = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatUndefined];
+    CFStringRef type = [NSData sd_UTTypeFromImageFormat:SDImageFormatUndefined];
     expect(CFStringCompare(kUTTypePNG, type, 0)).equal(kCFCompareEqualTo);
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Renaming Rename `sd_UTTypeFromSDImageFormat` to `sd_UTTypeFromImageFormat`. Since that `SDImageFormat` 's `SD` does not needed in the selector naming. It's just a prefix.


This renaming does not affect our Swift user, since both of these generated Swift API is `open class func sd_UTType(from format: SDImageFormat) -> CFString`.

