### PR TITLE
Replace valueForKey with objectForKey when access NSDictionary

### DIFF
--- a/SDWebImage/SDImageAPNGCoder.m
+++ b/SDWebImage/SDImageAPNGCoder.m
@@ -81,8 +81,9 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         return nil;
     }
     CGFloat scale = 1;
-    if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-        scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+    NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+    if (scaleFactor != nil) {
+        scale = [scaleFactor doubleValue];
         if (scale < 1) {
             scale = 1;
         }
@@ -139,9 +140,9 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
 - (NSUInteger)sd_imageLoopCountWithSource:(CGImageSourceRef)source {
     NSUInteger loopCount = 0;
     NSDictionary *imageProperties = (__bridge_transfer NSDictionary *)CGImageSourceCopyProperties(source, nil);
-    NSDictionary *pngProperties = [imageProperties valueForKey:(__bridge NSString *)kCGImagePropertyPNGDictionary];
+    NSDictionary *pngProperties = imageProperties[(__bridge NSString *)kCGImagePropertyPNGDictionary];
     if (pngProperties) {
-        NSNumber *apngLoopCount = [pngProperties valueForKey:(__bridge NSString *)kCGImagePropertyAPNGLoopCount];
+        NSNumber *apngLoopCount = pngProperties[(__bridge NSString *)kCGImagePropertyAPNGLoopCount];
         if (apngLoopCount != nil) {
             loopCount = apngLoopCount.unsignedIntegerValue;
         }
@@ -199,8 +200,8 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
     }
     NSMutableDictionary *properties = [NSMutableDictionary dictionary];
     double compressionQuality = 1;
-    if ([options valueForKey:SDImageCoderEncodeCompressionQuality]) {
-        compressionQuality = [[options valueForKey:SDImageCoderEncodeCompressionQuality] doubleValue];
+    if (options[SDImageCoderEncodeCompressionQuality]) {
+        compressionQuality = [options[SDImageCoderEncodeCompressionQuality] doubleValue];
     }
     [properties setValue:@(compressionQuality) forKey:(__bridge NSString *)kCGImageDestinationLossyCompressionQuality];
     
@@ -246,8 +247,9 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:SDImageFormatPNG];
         _imageSource = CGImageSourceCreateIncremental((__bridge CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceTypeIdentifierHint : (__bridge NSString *)imageUTType});
         CGFloat scale = 1;
-        if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-            scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+        NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+        if (scaleFactor != nil) {
+            scale = [scaleFactor doubleValue];
             if (scale < 1) {
                 scale = 1;
             }
@@ -297,8 +299,9 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
         
         if (partialImageRef) {
             CGFloat scale = _scale;
-            if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-                scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+            NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+            if (scaleFactor != nil) {
+                scale = [scaleFactor doubleValue];
                 if (scale < 1) {
                     scale = 1;
                 }
@@ -334,8 +337,9 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
             return nil;
         }
         CGFloat scale = 1;
-        if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-            scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+        NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+        if (scaleFactor != nil) {
+            scale = [scaleFactor doubleValue];
             if (scale < 1) {
                 scale = 1;
             }

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -355,9 +355,9 @@
         return nil;
     }
     
-    if ([context valueForKey:SDWebImageContextImageTransformer]) {
+    id<SDImageTransformer> transformer = context[SDWebImageContextImageTransformer];
+    if (transformer) {
         // grab the transformed disk image if transformer provided
-        id<SDImageTransformer> transformer = [context valueForKey:SDWebImageContextImageTransformer];
         NSString *transformerKey = [transformer transformerKey];
         key = SDTransformedKeyForKey(key, transformerKey);
     }

--- a/SDWebImage/SDImageCacheDefine.m
+++ b/SDWebImage/SDImageCacheDefine.m
@@ -15,20 +15,18 @@
 UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSString * _Nonnull cacheKey, SDWebImageOptions options, SDWebImageContext * _Nullable context) {
     UIImage *image;
     BOOL decodeFirstFrame = options & SDWebImageDecodeFirstFrameOnly;
-    NSNumber *scaleValue = [context valueForKey:SDWebImageContextImageScaleFactor];
+    NSNumber *scaleValue = context[SDWebImageContextImageScaleFactor];
     CGFloat scale = scaleValue.doubleValue >= 1 ? scaleValue.doubleValue : SDImageScaleFactorForKey(cacheKey);
     if (scale < 1) {
         scale = 1;
     }
     if (!decodeFirstFrame) {
+        Class animatedImageClass = context[SDWebImageContextAnimatedImageClass];
         // check whether we should use `SDAnimatedImage`
-        if ([context valueForKey:SDWebImageContextAnimatedImageClass]) {
-            Class animatedImageClass = [context valueForKey:SDWebImageContextAnimatedImageClass];
-            if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)]) {
-                image = [[animatedImageClass alloc] initWithData:imageData scale:scale];
-                if (options & SDWebImagePreloadAllFrames && [image respondsToSelector:@selector(preloadAllFrames)]) {
-                    [((id<SDAnimatedImage>)image) preloadAllFrames];
-                }
+        if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)]) {
+            image = [[animatedImageClass alloc] initWithData:imageData scale:scale];
+            if (options & SDWebImagePreloadAllFrames && [image respondsToSelector:@selector(preloadAllFrames)]) {
+                [((id<SDAnimatedImage>)image) preloadAllFrames];
             }
         }
     }

--- a/SDWebImage/SDImageGIFCoder.m
+++ b/SDWebImage/SDImageGIFCoder.m
@@ -74,8 +74,9 @@
         return nil;
     }
     CGFloat scale = 1;
-    if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-        scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+    NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+    if (scaleFactor != nil) {
+        scale = [scaleFactor doubleValue];
         if (scale < 1) {
             scale = 1;
         }
@@ -132,9 +133,9 @@
 - (NSUInteger)sd_imageLoopCountWithSource:(CGImageSourceRef)source {
     NSUInteger loopCount = 1;
     NSDictionary *imageProperties = (__bridge_transfer NSDictionary *)CGImageSourceCopyProperties(source, nil);
-    NSDictionary *gifProperties = [imageProperties valueForKey:(__bridge NSString *)kCGImagePropertyGIFDictionary];
+    NSDictionary *gifProperties = imageProperties[(__bridge NSString *)kCGImagePropertyGIFDictionary];
     if (gifProperties) {
-        NSNumber *gifLoopCount = [gifProperties valueForKey:(__bridge NSString *)kCGImagePropertyGIFLoopCount];
+        NSNumber *gifLoopCount = gifProperties[(__bridge NSString *)kCGImagePropertyGIFLoopCount];
         if (gifLoopCount != nil) {
             loopCount = gifLoopCount.unsignedIntegerValue;
         }
@@ -186,8 +187,9 @@
         CFStringRef imageUTType = [NSData sd_UTTypeFromImageFormat:SDImageFormatGIF];
         _imageSource = CGImageSourceCreateIncremental((__bridge CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceTypeIdentifierHint : (__bridge NSString *)imageUTType});
         CGFloat scale = 1;
-        if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-            scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+        NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+        if (scaleFactor != nil) {
+            scale = [scaleFactor doubleValue];
             if (scale < 1) {
                 scale = 1;
             }
@@ -237,8 +239,9 @@
         
         if (partialImageRef) {
             CGFloat scale = _scale;
-            if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-                scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+            NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+            if (scaleFactor != nil) {
+                scale = [scaleFactor doubleValue];
                 if (scale < 1) {
                     scale = 1;
                 }
@@ -282,8 +285,8 @@
     }
     NSMutableDictionary *properties = [NSMutableDictionary dictionary];
     double compressionQuality = 1;
-    if ([options valueForKey:SDImageCoderEncodeCompressionQuality]) {
-        compressionQuality = [[options valueForKey:SDImageCoderEncodeCompressionQuality] doubleValue];
+    if (options[SDImageCoderEncodeCompressionQuality]) {
+        compressionQuality = [options[SDImageCoderEncodeCompressionQuality] doubleValue];
     }
     [properties setValue:@(compressionQuality) forKey:(__bridge NSString *)kCGImageDestinationLossyCompressionQuality];
     
@@ -335,8 +338,9 @@
             return nil;
         }
         CGFloat scale = 1;
-        if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-            scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+        NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+        if (scaleFactor != nil) {
+            scale = [scaleFactor doubleValue];
             if (scale < 1) {
                 scale = 1;
             }

--- a/SDWebImage/SDImageIOCoder.m
+++ b/SDWebImage/SDImageIOCoder.m
@@ -65,8 +65,9 @@
         return nil;
     }
     CGFloat scale = 1;
-    if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-        scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+    NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+    if (scaleFactor != nil) {
+        scale = [scaleFactor doubleValue];
         if (scale < 1) {
             scale = 1;
         }
@@ -97,8 +98,9 @@
     if (self) {
         _imageSource = CGImageSourceCreateIncremental(NULL);
         CGFloat scale = 1;
-        if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-            scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+        NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+        if (scaleFactor != nil) {
+            scale = [scaleFactor doubleValue];
             if (scale < 1) {
                 scale = 1;
             }
@@ -153,8 +155,9 @@
         
         if (partialImageRef) {
             CGFloat scale = _scale;
-            if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-                scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+            NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+            if (scaleFactor != nil) {
+                scale = [scaleFactor doubleValue];
                 if (scale < 1) {
                     scale = 1;
                 }
@@ -220,8 +223,8 @@
 #endif
     [properties setValue:@(exifOrientation) forKey:(__bridge NSString *)kCGImagePropertyOrientation];
     double compressionQuality = 1;
-    if ([options valueForKey:SDImageCoderEncodeCompressionQuality]) {
-        compressionQuality = [[options valueForKey:SDImageCoderEncodeCompressionQuality] doubleValue];
+    if (options[SDImageCoderEncodeCompressionQuality]) {
+        compressionQuality = [options[SDImageCoderEncodeCompressionQuality] doubleValue];
     }
     [properties setValue:@(compressionQuality) forKey:(__bridge NSString *)kCGImageDestinationLossyCompressionQuality];
     

--- a/SDWebImage/SDImageLoader.m
+++ b/SDWebImage/SDImageLoader.m
@@ -21,7 +21,7 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
     NSCParameterAssert(imageURL);
     
     UIImage *image;
-    id<SDWebImageCacheKeyFilter> cacheKeyFilter = [context valueForKey:SDWebImageContextCacheKeyFilter];
+    id<SDWebImageCacheKeyFilter> cacheKeyFilter = context[SDWebImageContextCacheKeyFilter];
     NSString *cacheKey;
     if (cacheKeyFilter) {
         cacheKey = [cacheKeyFilter cacheKeyForURL:imageURL];
@@ -29,20 +29,18 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
         cacheKey = imageURL.absoluteString;
     }
     BOOL decodeFirstFrame = options & SDWebImageDecodeFirstFrameOnly;
-    NSNumber *scaleValue = [context valueForKey:SDWebImageContextImageScaleFactor];
+    NSNumber *scaleValue = context[SDWebImageContextImageScaleFactor];
     CGFloat scale = scaleValue.doubleValue >= 1 ? scaleValue.doubleValue : SDImageScaleFactorForKey(cacheKey);
     if (scale < 1) {
         scale = 1;
     }
     if (!decodeFirstFrame) {
         // check whether we should use `SDAnimatedImage`
-        if ([context valueForKey:SDWebImageContextAnimatedImageClass]) {
-            Class animatedImageClass = [context valueForKey:SDWebImageContextAnimatedImageClass];
-            if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)]) {
-                image = [[animatedImageClass alloc] initWithData:imageData scale:scale];
-                if (options & SDWebImagePreloadAllFrames && [image respondsToSelector:@selector(preloadAllFrames)]) {
-                    [((id<SDAnimatedImage>)image) preloadAllFrames];
-                }
+        Class animatedImageClass = context[SDWebImageContextAnimatedImageClass];
+        if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)]) {
+            image = [[animatedImageClass alloc] initWithData:imageData scale:scale];
+            if (options & SDWebImagePreloadAllFrames && [image respondsToSelector:@selector(preloadAllFrames)]) {
+                [((id<SDAnimatedImage>)image) preloadAllFrames];
             }
         }
     }
@@ -78,7 +76,7 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
     NSCParameterAssert(operation);
     
     UIImage *image;
-    id<SDWebImageCacheKeyFilter> cacheKeyFilter = [context valueForKey:SDWebImageContextCacheKeyFilter];
+    id<SDWebImageCacheKeyFilter> cacheKeyFilter = context[SDWebImageContextCacheKeyFilter];
     NSString *cacheKey;
     if (cacheKeyFilter) {
         cacheKey = [cacheKeyFilter cacheKeyForURL:imageURL];
@@ -86,7 +84,7 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
         cacheKey = imageURL.absoluteString;
     }
     BOOL decodeFirstFrame = options & SDWebImageDecodeFirstFrameOnly;
-    NSNumber *scaleValue = [context valueForKey:SDWebImageContextImageScaleFactor];
+    NSNumber *scaleValue = context[SDWebImageContextImageScaleFactor];
     CGFloat scale = scaleValue.doubleValue >= 1 ? scaleValue.doubleValue : SDImageScaleFactorForKey(cacheKey);
     if (scale < 1) {
         scale = 1;
@@ -111,11 +109,9 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
     [progressiveCoder updateIncrementalData:imageData finished:finished];
     if (!decodeFirstFrame) {
         // check whether we should use `SDAnimatedImage`
-        if ([context valueForKey:SDWebImageContextAnimatedImageClass]) {
-            Class animatedImageClass = [context valueForKey:SDWebImageContextAnimatedImageClass];
-            if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)] && [progressiveCoder conformsToProtocol:@protocol(SDAnimatedImageCoder)]) {
-                image = [[animatedImageClass alloc] initWithAnimatedCoder:(id<SDAnimatedImageCoder>)progressiveCoder scale:scale];
-            }
+        Class animatedImageClass = context[SDWebImageContextAnimatedImageClass];
+        if ([animatedImageClass isSubclassOfClass:[UIImage class]] && [animatedImageClass conformsToProtocol:@protocol(SDAnimatedImage)] && [progressiveCoder conformsToProtocol:@protocol(SDAnimatedImageCoder)]) {
+            image = [[animatedImageClass alloc] initWithAnimatedCoder:(id<SDAnimatedImageCoder>)progressiveCoder scale:scale];
         }
     }
     if (!image) {

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -173,10 +173,8 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
         mutableRequest.HTTPShouldHandleCookies = (options & SDWebImageDownloaderHandleCookies);
         mutableRequest.HTTPShouldUsePipelining = YES;
         mutableRequest.allHTTPHeaderFields = sself.HTTPHeaders;
-        id<SDWebImageDownloaderRequestModifier> requestModifier;
-        if ([context valueForKey:SDWebImageContextDownloadRequestModifier]) {
-            requestModifier = [context valueForKey:SDWebImageContextDownloadRequestModifier];
-        } else {
+        id<SDWebImageDownloaderRequestModifier> requestModifier = context[SDWebImageContextDownloadRequestModifier];
+        if (!requestModifier) {
             requestModifier = self.requestModifier;
         }
         
@@ -475,10 +473,8 @@ didReceiveResponse:(NSURLResponse *)response
 }
 
 - (id<SDWebImageOperation>)loadImageWithURL:(NSURL *)url options:(SDWebImageOptions)options context:(SDWebImageContext *)context progress:(SDImageLoaderProgressBlock)progressBlock completed:(SDImageLoaderCompletedBlock)completedBlock {
-    UIImage *cachedImage;
-    if ([context valueForKey:SDWebImageContextLoaderCachedImage]) {
-        cachedImage = [context valueForKey:SDWebImageContextLoaderCachedImage];
-    }
+    UIImage *cachedImage = context[SDWebImageContextLoaderCachedImage];
+    
     SDWebImageDownloaderOptions downloaderOptions = 0;
     if (options & SDWebImageLowPriority) downloaderOptions |= SDWebImageDownloaderLowPriority;
     if (options & SDWebImageProgressiveLoad) downloaderOptions |= SDWebImageDownloaderProgressiveLoad;

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -103,10 +103,15 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 
 - (nullable NSArray<id> *)callbacksForKey:(NSString *)key {
     LOCK(self.callbacksLock);
-    NSMutableArray<id> *callbacks = [[self.callbackBlocks valueForKey:key] mutableCopy];
+    NSArray<SDCallbacksDictionary *> *callbackBlocks = [self.callbackBlocks copy];
     UNLOCK(self.callbacksLock);
-    // We need to remove [NSNull null] because there might not always be a progress block for each callback
-    [callbacks removeObjectIdenticalTo:[NSNull null]];
+    NSMutableArray<id> *callbacks = [NSMutableArray arrayWithCapacity:callbackBlocks.count];
+    for (SDCallbacksDictionary *callbacksDic in callbackBlocks) {
+        id callback = callbacksDic[key];
+        if (callback) {
+            [callbacks addObject:callback];
+        }
+    }
     return [callbacks copy]; // strip mutability here
 }
 

--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -189,7 +189,7 @@ static id<SDImageLoader> _defaultImageLoader;
     // Check whether we should query cache
     BOOL shouldQueryCache = (options & SDWebImageFromLoaderOnly) == 0;
     if (shouldQueryCache) {
-        id<SDWebImageCacheKeyFilter> cacheKeyFilter = [context valueForKey:SDWebImageContextCacheKeyFilter];
+        id<SDWebImageCacheKeyFilter> cacheKeyFilter = context[SDWebImageContextCacheKeyFilter];
         NSString *key = [self cacheKeyForURL:url cacheKeyFilter:cacheKeyFilter];
         __weak SDWebImageCombinedOperation *weakOperation = operation;
         operation.cacheOperation = [self.imageCache queryImageForKey:key options:options context:context completion:^(UIImage * _Nullable cachedImage, NSData * _Nullable cachedData, SDImageCacheType cacheType) {
@@ -277,13 +277,13 @@ static id<SDImageLoader> _defaultImageLoader;
                 }
                 
                 SDImageCacheType storeCacheType = SDImageCacheTypeAll;
-                if ([context valueForKey:SDWebImageContextStoreCacheType]) {
-                    storeCacheType = [[context valueForKey:SDWebImageContextStoreCacheType] unsignedIntegerValue];
+                if (context[SDWebImageContextStoreCacheType]) {
+                    storeCacheType = [context[SDWebImageContextStoreCacheType] integerValue];
                 }
-                id<SDWebImageCacheKeyFilter> cacheKeyFilter = [context valueForKey:SDWebImageContextCacheKeyFilter];
+                id<SDWebImageCacheKeyFilter> cacheKeyFilter = context[SDWebImageContextCacheKeyFilter];
                 NSString *key = [self cacheKeyForURL:url cacheKeyFilter:cacheKeyFilter];
-                id<SDImageTransformer> transformer = [context valueForKey:SDWebImageContextImageTransformer];
-                id<SDWebImageCacheSerializer> cacheSerializer = [context valueForKey:SDWebImageContextCacheKeyFilter];
+                id<SDImageTransformer> transformer = context[SDWebImageContextImageTransformer];
+                id<SDWebImageCacheSerializer> cacheSerializer = context[SDWebImageContextCacheKeyFilter];
                 if (downloadedImage && (!downloadedImage.sd_isAnimated || (options & SDWebImageTransformAnimatedImage)) && transformer) {
                     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
                         UIImage *transformedImage = [transformer transformedImageWithImage:downloadedImage forKey:key];
@@ -369,17 +369,17 @@ static id<SDImageLoader> _defaultImageLoader;
     SDWebImageMutableContext *mutableContext = [SDWebImageMutableContext dictionary];
     
     // Image Transformer from manager
-    if (![context valueForKey:SDWebImageContextImageTransformer]) {
+    if (!context[SDWebImageContextImageTransformer]) {
         id<SDImageTransformer> transformer = self.transformer;
         [mutableContext setValue:transformer forKey:SDWebImageContextImageTransformer];
     }
     // Cache key filter from manager
-    if (![context valueForKey:SDWebImageContextCacheKeyFilter]) {
+    if (!context[SDWebImageContextCacheKeyFilter]) {
         id<SDWebImageCacheKeyFilter> cacheKeyFilter = self.cacheKeyFilter;
         [mutableContext setValue:cacheKeyFilter forKey:SDWebImageContextCacheKeyFilter];
     }
     // Cache serializer from manager
-    if (![context valueForKey:SDWebImageContextCacheSerializer]) {
+    if (!context[SDWebImageContextCacheSerializer]) {
         id<SDWebImageCacheSerializer> cacheSerializer = self.cacheSerializer;
         [mutableContext setValue:cacheSerializer forKey:SDWebImageContextCacheSerializer];
     }

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -44,10 +44,8 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
                           progress:(nullable SDImageLoaderProgressBlock)progressBlock
                          completed:(nullable SDInternalCompletionBlock)completedBlock {
     context = [context copy]; // copy to avoid mutable object
-    NSString *validOperationKey = nil;
-    if ([context valueForKey:SDWebImageContextSetImageOperationKey]) {
-        validOperationKey = [context valueForKey:SDWebImageContextSetImageOperationKey];
-    } else {
+    NSString *validOperationKey = context[SDWebImageContextSetImageOperationKey];
+    if (!validOperationKey) {
         validOperationKey = NSStringFromClass([self class]);
     }
     [self sd_cancelImageLoadOperationWithKey:validOperationKey];
@@ -70,10 +68,8 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
         id<SDWebImageIndicator> imageIndicator = self.sd_imageIndicator;
 #endif
         
-        SDWebImageManager *manager;
-        if ([context valueForKey:SDWebImageContextCustomManager]) {
-            manager = (SDWebImageManager *)[context valueForKey:SDWebImageContextCustomManager];
-        } else {
+        SDWebImageManager *manager = context[SDWebImageContextCustomManager];
+        if (!manager) {
             manager = [SDWebImageManager sharedManager];
         }
         

--- a/SDWebImage/WebP/SDImageWebPCoder.m
+++ b/SDWebImage/WebP/SDImageWebPCoder.m
@@ -112,10 +112,11 @@
     
     uint32_t flags = WebPDemuxGetI(demuxer, WEBP_FF_FORMAT_FLAGS);
     BOOL hasAnimation = flags & ANIMATION_FLAG;
-    BOOL decodeFirstFrame = [[options valueForKey:SDImageCoderDecodeFirstFrameOnly] boolValue];
+    BOOL decodeFirstFrame = [options[SDImageCoderDecodeFirstFrameOnly] boolValue];
     CGFloat scale = 1;
-    if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-        scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+    NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+    if (scaleFactor != nil) {
+        scale = [scaleFactor doubleValue];
         if (scale < 1) {
             scale = 1;
         }
@@ -212,8 +213,9 @@
         // Progressive images need transparent, so always use premultiplied BGRA
         _idec = WebPINewRGB(MODE_bgrA, NULL, 0, 0);
         CGFloat scale = 1;
-        if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-            scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+        NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+        if (scaleFactor != nil) {
+            scale = [scaleFactor doubleValue];
             if (scale < 1) {
                 scale = 1;
             }
@@ -284,8 +286,9 @@
             return nil;
         }
         CGFloat scale = _scale;
-        if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-            scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+        NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+        if (scaleFactor != nil) {
+            scale = [scaleFactor doubleValue];
             if (scale < 1) {
                 scale = 1;
             }
@@ -425,8 +428,8 @@
     NSData *data;
     
     double compressionQuality = 1;
-    if ([options valueForKey:SDImageCoderEncodeCompressionQuality]) {
-        compressionQuality = [[options valueForKey:SDImageCoderEncodeCompressionQuality] doubleValue];
+    if (options[SDImageCoderEncodeCompressionQuality]) {
+        compressionQuality = [options[SDImageCoderEncodeCompressionQuality] doubleValue];
     }
     NSArray<SDImageFrame *> *frames = [SDImageCoderHelper framesFromAnimatedImage:image];
     
@@ -633,8 +636,9 @@ static void FreeImageData(void *info, const void *data, size_t size) {
             return nil;
         }
         CGFloat scale = 1;
-        if ([options valueForKey:SDImageCoderDecodeScaleFactor]) {
-            scale = [[options valueForKey:SDImageCoderDecodeScaleFactor] doubleValue];
+        NSNumber *scaleFactor = options[SDImageCoderDecodeScaleFactor];
+        if (scaleFactor != nil) {
+            scale = [scaleFactor doubleValue];
             if (scale < 1) {
                 scale = 1;
             }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

1. Replace `valueForKey` with `objectForKey` when access `NSDictionary`. Reason is:

- `valueForKey` would check the first character of the `key` wether `[key characterAtIndex] != '@'` , if not, `valueForKey`'s internal would call `objectForKey`, for our cases, we only need `objectForKey`, so let's remove these redundancy code.
- `valueForKey` has the risk of crash when access unknown key, which key has the first character of `@`. We maybe haven't this risky in our framework.

2. Remove `NSNull` check when access `callbackBlocks` of `SDWebImageDownloaderOperation`.

