### PR TITLE
Change SDImageFormat to use `NS_TYPED_EXTENSIBLE_ENUM` instead of fixed enum, to allow custom coder plugin extern the define

### DIFF
--- a/SDWebImage/NSData+ImageContentType.h
+++ b/SDWebImage/NSData+ImageContentType.h
@@ -10,15 +10,18 @@
 #import <Foundation/Foundation.h>
 #import "SDWebImageCompat.h"
 
-typedef NS_ENUM(NSInteger, SDImageFormat) {
-    SDImageFormatUndefined = -1,
-    SDImageFormatJPEG = 0,
-    SDImageFormatPNG,
-    SDImageFormatGIF,
-    SDImageFormatTIFF,
-    SDImageFormatWebP,
-    SDImageFormatHEIC
-};
+/**
+ You can use switch case like normal enum. It's also recommended to add a default case.
+ For custom coder plugin, it may also extern the enum for supported format.
+ */
+typedef NSInteger SDImageFormat NS_TYPED_EXTENSIBLE_ENUM;
+static const SDImageFormat SDImageFormatUndefined = -1;
+static const SDImageFormat SDImageFormatJPEG = 0;
+static const SDImageFormat SDImageFormatPNG = 1;
+static const SDImageFormat SDImageFormatGIF = 2;
+static const SDImageFormat SDImageFormatTIFF = 3;
+static const SDImageFormat SDImageFormatWebP = 4;
+static const SDImageFormat SDImageFormatHEIC = 5;
 
 @interface NSData (ImageContentType)
 

--- a/SDWebImage/NSData+ImageContentType.h
+++ b/SDWebImage/NSData+ImageContentType.h
@@ -11,17 +11,17 @@
 #import "SDWebImageCompat.h"
 
 /**
- You can use switch case like normal enum. It's also recommended to add a default case.
- For custom coder plugin, it may also extern the enum for supported format.
+ You can use switch case like normal enum. It's also recommended to add a default case. You should not assume anything about the raw value.
+ For custom coder plugin, it can also extern the enum for supported format. See `SDImageCoder` for more detailed information.
  */
 typedef NSInteger SDImageFormat NS_TYPED_EXTENSIBLE_ENUM;
 static const SDImageFormat SDImageFormatUndefined = -1;
-static const SDImageFormat SDImageFormatJPEG = 0;
-static const SDImageFormat SDImageFormatPNG = 1;
-static const SDImageFormat SDImageFormatGIF = 2;
-static const SDImageFormat SDImageFormatTIFF = 3;
-static const SDImageFormat SDImageFormatWebP = 4;
-static const SDImageFormat SDImageFormatHEIC = 5;
+static const SDImageFormat SDImageFormatJPEG      = 0;
+static const SDImageFormat SDImageFormatPNG       = 1;
+static const SDImageFormat SDImageFormatGIF       = 2;
+static const SDImageFormat SDImageFormatTIFF      = 3;
+static const SDImageFormat SDImageFormatWebP      = 4;
+static const SDImageFormat SDImageFormatHEIC      = 5;
 
 @interface NSData (ImageContentType)
 

--- a/SDWebImage/SDImageCoder.h
+++ b/SDWebImage/SDImageCoder.h
@@ -72,6 +72,10 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeCompressio
 
 /**
  Returns YES if this coder can encode some image. Otherwise, it should be passed to another coder.
+ For custom coder which introduce new image format, you'd better define a new `SDImageFormat` using like this. If you're creating public coder plugin for new image format, also update `https://github.com/rs/SDWebImage/wiki/Coder-Plugin-List` to avoid same value been defined twice.
+ * @code
+ static const SDImageFormat SDImageFormatHEIF = 10;
+ * @endcode
  
  @param format The image format
  @return YES if this coder can encode the image, NO otherwise


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

### Reason
Since SDWebImge 4.2, we have custom coder, which can refactor our architecture to allow new image format support by using [coder plugins](https://github.com/rs/SDWebImage/wiki/Advanced-Usage#custom-coder-420). This can make SDWebImage core lib more clear, without maintain the dependency of specify image format.

From the design part, since the coder plugin handle the image decoding / encoding format, SDWebImage core lib should not assume or dependent how much of plugins are registered and the detailed implementation of plugin. However, for current coder plugin protocol define, seems we have one type that still bind to SDWebImage repo itself, but not allow custom coder plugin to extern. This is the type `SDImaegFormat`.

```objective-c
// NSData+ImageContentType.h, in the SDWebImage core repo
typedef NS_ENUM(NSInteger, SDImageFormat) {
    SDImageFormatUndefined = -1,
    SDImageFormatJPEG = 0,
    SDImageFormatPNG,
    SDImageFormatGIF,
    SDImageFormatTIFF,
    SDImageFormatWebP,
    SDImageFormatHEIC
};

// Protocol that custom coder implements
@protocol SDImageCoder <NSObject> 

- (BOOL)canEncodeToFormat:(SDImageFormat)format;

- (nullable NSData *)encodedDataWithImage:(nullable UIImage *)image
                                   format:(SDImageFormat)format
                                  options:(nullable SDImageCoderOptions *)options;
```

We can see `SDImageFormat` here. Some coder plugin developer may want to extern the supported format with a new case, however, that `NS_ENUM` defination does not allow this. And user who need to use encoding feature, may also face the issue because they can not specify target format to encode.

## First Solution
The first naive solution, is that you define new format as global constant. It may work for Objective-C users, because the enum is actually `NSInteger` value from Objective-C side. However, for Swift user, this break the easy usage of Swift's `implicit member expression` feature. You have to use raw value and if statement to check that.

+ Objective-C

```objectivec
typedef NS_ENUM(NSInteger, SDImageFormat) {}; // Current define
static const SDImageFormat SDImageFormatHEIF = 10;
```

Generated Swift Header

```swift
public enum SDImageFormat : Int {
    case undefined
    case JPEG
    case PNG
    case GIF
    case TIFF
    case webP
    case HEIC
}

public let SDImageFormatHEIF: SDImageFormat
```

Usage

```swift
let format = SDImageFormat.PNG
switch format {
case .HEIF: // -> This trigger compile error
    print("heif")
case SDImageFormatHEIF: // -> This will not work as well, because Swift's enum check is strict, you will also get `Case will never be executed` warning
    print("heif")
default:
    print("default")
}
// You have to write like this, really bad
if (format == SDImageFormatHEIF) {
  // Something
} else {
  // Something
}
```

So this solution can not solve this problem. However, we have upgraded to Xcode 9, the `NS_TYPED_EXTENSIBLE_ENUM` is a good solution. It will convert the Objective-C define to Swift's struct enum, which is also suitable for switch case.

### Second Solution

+ Objective-C

```objectivec
typedef NSInteger SDImageFormat NS_TYPED_EXTENSIBLE_ENUM;
static const SDImageFormat SDImageFormatHEIF= 10;
```

Generated Swift Header

```swift
public struct SDImageFormat : Hashable, Equatable, RawRepresentable {
    public init(_ rawValue: Int)
    public init(rawValue: Int)
}
public static let undefined: SDImageFormat
public static let JPEG: SDImageFormat
public static let PNG: SDImageFormat
public static let GIF: SDImageFormat
public static let TIFF: SDImageFormat
public static let webP: SDImageFormat
public static let HEIC: SDImageFormat

public static let HEIF: SDImageFormat
```

Usage

```swift
let format = SDImageFormat.PNG
switch format {
case .HEIF:
    print("heif") // -> Work now
default:
    print("default")
}
```

### Define code conflict

The second solution can solve the usage of both Objective-C side and Swift side. However, there are still one problem to consideration.  Since the format define is just a `NSInteger` representation, different people who write coder plugin may accidentally define the same value twice, so that this will cause conflict from user side. (Because the switch case check will success for both of two defines) 

I don't find the best solution, but simply, we can provide a full list of format code define, in this [Coder-Plugin-List Wiki page](https://github.com/rs/SDWebImage/wiki/Coder-Plugin-List) . If other developers who want to publish a new image format plugin, they can update the list and to avoid exist code to be defined twice. 😅 

Any consideration is welcomed. 
