### PR TITLE
Add SDImageCoderWebImageContext coder option, which allow custom coder plugin, to receive the context option from top-level API

### DIFF
--- a/SDWebImage/SDImageCacheDefine.m
+++ b/SDWebImage/SDImageCacheDefine.m
@@ -33,7 +33,13 @@ UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSS
         }
     }
     if (!image) {
-        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:@{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)}];
+        SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
+        if (context) {
+            SDImageCoderMutableOptions *mutableOptions = [options mutableCopy];
+            [mutableOptions setValue:context forKey:SDImageCoderWebImageContext];
+            options = [mutableOptions copy];
+        }
+        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:options];
     }
     if (image) {
         BOOL shouldDecode = (options & SDWebImageAvoidDecodeImage) == 0;

--- a/SDWebImage/SDImageCoder.h
+++ b/SDWebImage/SDImageCoder.h
@@ -12,6 +12,7 @@
 
 typedef NSString * SDImageCoderOption NS_STRING_ENUM;
 typedef NSDictionary<SDImageCoderOption, id> SDImageCoderOptions;
+typedef NSMutableDictionary<SDImageCoderOption, id> SDImageCoderMutableOptions;
 
 #pragma mark - Coder Options
 // These options are for image decoding
@@ -37,6 +38,14 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeFirstFrame
  @note works for `SDImageCoder`
  */
 FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderEncodeCompressionQuality;
+
+/**
+ A SDWebImageContext object which hold the original context options from top-level API. (SDWebImageContext)
+ This option is ignored for all built-in coders and take no effect.
+ But this may be useful for some custom coders, because some business logic may dependent on things other than image or image data inforamtion only.
+ See `SDWebImageContext` for more detailed information.
+ */
+FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext;
 
 #pragma mark - Coder
 /**

--- a/SDWebImage/SDImageCoder.m
+++ b/SDWebImage/SDImageCoder.m
@@ -13,3 +13,5 @@ SDImageCoderOption const SDImageCoderDecodeScaleFactor = @"decodeScaleFactor";
 
 SDImageCoderOption const SDImageCoderEncodeFirstFrameOnly = @"encodeFirstFrameOnly";
 SDImageCoderOption const SDImageCoderEncodeCompressionQuality = @"encodeCompressionQuality";
+
+SDImageCoderOption const SDImageCoderWebImageContext = @"webImageContext";

--- a/SDWebImage/SDImageLoader.m
+++ b/SDWebImage/SDImageLoader.m
@@ -47,7 +47,13 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
         }
     }
     if (!image) {
-        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:@{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)}];
+        SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
+        if (context) {
+            SDImageCoderMutableOptions *mutableOptions = [options mutableCopy];
+            [mutableOptions setValue:context forKey:SDImageCoderWebImageContext];
+            options = [mutableOptions copy];
+        }
+        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:options];
     }
     if (image) {
         BOOL shouldDecode = (options & SDWebImageAvoidDecodeImage) == 0;
@@ -119,7 +125,13 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
         }
     }
     if (!image) {
-        image = [progressiveCoder incrementalDecodedImageWithOptions:@{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)}];
+        SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
+        if (context) {
+            SDImageCoderMutableOptions *mutableOptions = [options mutableCopy];
+            [mutableOptions setValue:context forKey:SDImageCoderWebImageContext];
+            options = [mutableOptions copy];
+        }
+        image = [progressiveCoder incrementalDecodedImageWithOptions:options];
     }
     if (image) {
         BOOL shouldDecode = (options & SDWebImageAvoidDecodeImage) == 0;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

### Reason
This is a solution for #2404 . `SDWebImageContext` contains all the extra information through view category, cache, manager API, but it's not accessable from the custom coder plugin.

It's not surprise because in my mind, a decoder, should only consider about the image & image data, or anything related to the decoding option (Like animation or not, scale factor).

But however, if some custom coder plugin user, who want do some business logic related process, during image decoding. They have no choice to know the context. So I guess, maybe we can open this possibility.

### Related PR
Actually, this feature request, is from [SDWebImageFLPlugin's PR](https://github.com/SDWebImage/SDWebImageFLPlugin/pull/2), which will create a `SDWebImageFLCoder`, to directlly produce a FLAnimatedImage, to end up that previous hack code that do image decoding during View setImage process.

The image decoding process, should always happend in image coder, but not hack into the setImageBlock. And that PR provide a better solution. And since all the decoding method is called from global queue, this can keep better performance.