### PR TITLE
Fix the bug when FLAnimatedImageView firstly show one EXIF rotation JPEG `UIImage`, later animated GIF `FLAnimatedImage` will also be rotated

### DIFF
--- a/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
+++ b/SDWebImage/FLAnimatedImage/FLAnimatedImageView+WebCache.m
@@ -127,8 +127,9 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                            FLAnimatedImage *associatedAnimatedImage = image.sd_FLAnimatedImage;
                            if (associatedAnimatedImage) {
                                // Asscociated animated image exist
+                               // FLAnimatedImage framework contains a bug that cause GIF been rotated if previous rendered image orientation is not Up. We have to call `setImage:` with non-nil image to reset the state. See `https://github.com/rs/SDWebImage/issues/2402`
+                               strongSelf.image = associatedAnimatedImage.posterImage;
                                strongSelf.animatedImage = associatedAnimatedImage;
-                               strongSelf.image = nil;
                                return;
                            }
                            // Step 2. Check if original compressed image data is "GIF"
@@ -150,11 +151,11 @@ static inline FLAnimatedImage * SDWebImageCreateFLAnimatedImage(FLAnimatedImageV
                                if (strongSelf.sd_cacheFLAnimatedImage) {
                                    image.sd_FLAnimatedImage = animatedImage;
                                }
+                               strongSelf.image = animatedImage.posterImage;
                                strongSelf.animatedImage = animatedImage;
-                               strongSelf.image = nil;
                            } else {
-                               strongSelf.animatedImage = nil;
                                strongSelf.image = image;
+                               strongSelf.animatedImage = nil;
                            }
                        }
                             progress:progressBlock


### PR DESCRIPTION
We help FLAnimatedImage framework to fix their issue :)

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x]  I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2402 #1317

### Pull Request Description

This PR, fix a long-history issue, cause not by SDWebImage framework itself, but the third-party library FLAnimatedImage.

The upstream bugfix PR is https://github.com/Flipboard/FLAnimatedImage/pull/215. However, maybe this PR will take long time to be merged in, and some user may still face this issue, we have to fix (actually, `hack`) this issue by our own hand :)

See #2402 for the issue, demo and solution here. I just don't duplicate things twice 😴 
