### PR TITLE
Fix rename of default disk cache directory

### DIFF
--- a/SDWebImage/SDDiskCache.h
+++ b/SDWebImage/SDDiskCache.h
@@ -103,5 +103,6 @@
 @property (nonatomic, strong, readonly, nonnull) SDImageCacheConfig *config;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
+- (void)migrateCacheFromCachePath:(nonnull NSString *)srcPath toCachePath:(nonnull NSString *)dstPath;
 
 @end

--- a/SDWebImage/SDDiskCache.h
+++ b/SDWebImage/SDDiskCache.h
@@ -103,6 +103,5 @@
 @property (nonatomic, strong, readonly, nonnull) SDImageCacheConfig *config;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
-- (void)migrateCacheFromCachePath:(nonnull NSString *)srcPath toCachePath:(nonnull NSString *)dstPath;
 
 @end

--- a/SDWebImage/SDDiskCache.m
+++ b/SDWebImage/SDDiskCache.m
@@ -42,6 +42,19 @@
     }
 }
 
+- (void)migrateCacheFromCachePath:(NSString *)srcPath toCachePath:(NSString *)dstPath {
+    // DstPath is new default path, only if diskCachePath is equal to the new default path and old default path exist, we can do move operation later.
+    if (![self.diskCachePath isEqualToString:dstPath] && ![self.fileManager fileExistsAtPath:srcPath]) { return; }
+    
+    NSDirectoryEnumerator *dirEnumerator = [self.fileManager enumeratorAtPath:srcPath];
+    NSString *file;
+    while ((file = [dirEnumerator nextObject])) {
+        // Don't handle error, just try to move.
+        [self.fileManager moveItemAtPath:[srcPath stringByAppendingPathComponent:file] toPath:[dstPath stringByAppendingPathComponent:file] error:NULL];
+    }
+    [self.fileManager removeItemAtPath:srcPath error:NULL];
+}
+
 - (BOOL)containsDataForKey:(NSString *)key {
     NSParameterAssert(key);
     NSString *filePath = [self cachePathForKey:key];

--- a/SDWebImage/SDDiskCache.m
+++ b/SDWebImage/SDDiskCache.m
@@ -46,6 +46,10 @@
     // DstPath is new default path, only if diskCachePath is equal to the new default path and old default path exist, we can do move operation later.
     if (![self.diskCachePath isEqualToString:dstPath] && ![self.fileManager fileExistsAtPath:srcPath]) { return; }
     
+    if (![self.fileManager fileExistsAtPath:self.diskCachePath]) {
+        [self.fileManager createDirectoryAtPath:self.diskCachePath withIntermediateDirectories:YES attributes:nil error:NULL];
+    }
+    
     NSDirectoryEnumerator *dirEnumerator = [self.fileManager enumeratorAtPath:srcPath];
     NSString *file;
     while ((file = [dirEnumerator nextObject])) {

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -596,8 +596,11 @@
             NSString *newDefaultPath = [[self makeDiskCachePath:@"default"] stringByAppendingPathComponent:@"com.hackemist.SDImageCache.default"];
             NSString *oldDefaultPath = [[self makeDiskCachePath:@"default"] stringByAppendingPathComponent:@"com.hackemist.SDWebImageCache.default"];
             
-            if ([self.diskCache respondsToSelector:@selector(migrateCacheFromCachePath:toCachePath:)]) {
-                [self.diskCache performSelector:@selector(migrateCacheFromCachePath:toCachePath:) withObject:oldDefaultPath withObject:newDefaultPath];
+            if ([self.diskCache respondsToSelector:NSSelectorFromString(@"migrateCacheFromCachePath:toCachePath:")]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+                [self.diskCache performSelector:NSSelectorFromString(@"migrateCacheFromCachePath:toCachePath:") withObject:oldDefaultPath withObject:newDefaultPath];
+#pragma clang diagnostic pop
             }
         });
     });

--- a/SDWebImage/SDImageCacheDefine.m
+++ b/SDWebImage/SDImageCacheDefine.m
@@ -33,13 +33,13 @@ UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSS
         }
     }
     if (!image) {
-        SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
+        SDImageCoderOptions *coderOptions = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
         if (context) {
-            SDImageCoderMutableOptions *mutableOptions = [options mutableCopy];
+            SDImageCoderMutableOptions *mutableOptions = [coderOptions mutableCopy];
             [mutableOptions setValue:context forKey:SDImageCoderWebImageContext];
-            options = [mutableOptions copy];
+            coderOptions = [mutableOptions copy];
         }
-        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:options];
+        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:coderOptions];
     }
     if (image) {
         BOOL shouldDecode = (options & SDWebImageAvoidDecodeImage) == 0;

--- a/SDWebImage/SDImageLoader.m
+++ b/SDWebImage/SDImageLoader.m
@@ -47,13 +47,13 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
         }
     }
     if (!image) {
-        SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
+        SDImageCoderOptions *coderOptions = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
         if (context) {
-            SDImageCoderMutableOptions *mutableOptions = [options mutableCopy];
+            SDImageCoderMutableOptions *mutableOptions = [coderOptions mutableCopy];
             [mutableOptions setValue:context forKey:SDImageCoderWebImageContext];
-            options = [mutableOptions copy];
+            coderOptions = [mutableOptions copy];
         }
-        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:options];
+        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:coderOptions];
     }
     if (image) {
         BOOL shouldDecode = (options & SDWebImageAvoidDecodeImage) == 0;
@@ -125,13 +125,13 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
         }
     }
     if (!image) {
-        SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
+        SDImageCoderOptions *coderOptions = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
         if (context) {
-            SDImageCoderMutableOptions *mutableOptions = [options mutableCopy];
+            SDImageCoderMutableOptions *mutableOptions = [coderOptions mutableCopy];
             [mutableOptions setValue:context forKey:SDImageCoderWebImageContext];
-            options = [mutableOptions copy];
+            coderOptions = [mutableOptions copy];
         }
-        image = [progressiveCoder incrementalDecodedImageWithOptions:options];
+        image = [progressiveCoder incrementalDecodedImageWithOptions:coderOptions];
     }
     if (image) {
         BOOL shouldDecode = (options & SDWebImageAvoidDecodeImage) == 0;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

1. Maybe from `5.x`? We changed the default disk cache name of directory, we can't just simply do the rename operation, because the older version's directory is still exist (ps. if user upgrade from older to `5.x`), and may contains many images, if we do not handle these images, they would always exists, cannot access, delete or anything.
2. Remove the compiler warnings of `options`.
