### PR TITLE
Fix that using `NS_TYPED_ENUM` on `SDImageFormat` cause the existing Swift API naming changed

### DIFF
--- a/SDWebImage/NSData+ImageContentType.h
+++ b/SDWebImage/NSData+ImageContentType.h
@@ -40,7 +40,7 @@ static const SDImageFormat SDImageFormatHEIC      = 5;
  *  @param format Format as SDImageFormat
  *  @return The UTType as CFStringRef
  */
-+ (nonnull CFStringRef)sd_UTTypeFromImageFormat:(SDImageFormat)format CF_RETURNS_NOT_RETAINED;
++ (nonnull CFStringRef)sd_UTTypeFromImageFormat:(SDImageFormat)format CF_RETURNS_NOT_RETAINED NS_SWIFT_NAME(sd_UTType(from:));
 
 /**
  *  Convert UTTyppe to SDImageFormat

--- a/SDWebImage/SDImageCoder.h
+++ b/SDWebImage/SDImageCoder.h
@@ -89,7 +89,7 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext;
  @param format The image format
  @return YES if this coder can encode the image, NO otherwise
  */
-- (BOOL)canEncodeToFormat:(SDImageFormat)format;
+- (BOOL)canEncodeToFormat:(SDImageFormat)format NS_SWIFT_NAME(canEncode(to:));
 
 /**
  Encode the image to image data.


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2400 

### Pull Request Description

It seems that after #2400 change the `enum` with `NS_TYPED_ENUM`, the Swift API that use `SDImageFomat` as a arg that may also been changed, which is not as expected. 😕 

I check the [SE-0005 Better Translation of Objective-C APIs Into Swift](https://github.com/apple/swift-evolution/blob/master/proposals/0005-objective-c-name-translation.md). Swift 3 will ommit when the **method name** && **type name** contains same word. For example, **-(BOOL) canEncodeTo`Format`:(SDImage`Format`)format** this API. Since both **method name** and **type name** contains `format` word, the generated API may looks `canEncode(to:)`. 

Using enum will actually make it recognized as `SDImageFormat` **type name**. But however, It seems that a `typedef` does not cause `SDImageFormat` to be recognized as a **type name**, but leave it as `NSInteger`. So after we change this, the generated Swift API that take `SDImageFormat` as a arg may be changed from previous release.

I check and these API changed:

+ NSData+ImageFormat: `sd_UTType(from format: SDImageFormat) -> CFString` => `sd_UTType(fromImageFormat format: SDImageFormat) -> CFString`
+ SDImageCoder: `canEncode(to format: SDImageFormat) -> Bool` => `canEncode(toFormat format: SDImageFormat) -> Bool`

Thesse changes are not expected. So we have to use `NS_SWIFT_NAME` to correct the generated API, to avoid introduce unnecessary API change.

To be honest, since `NS_TYPED_ENUM` are a hint to generate Swift API, I guess they should be treated as a actual **type name** just like enum, and generate Swify API. But however, seems current Swift compiler does not assume this case. I also fire a jira for Swift team and waiting for response to see whether it's a indeed behavior.