### PR TITLE
Fix that downloader options about image decoding is not correctly set

### DIFF
--- a/SDWebImage/SDImageCacheDefine.m
+++ b/SDWebImage/SDImageCacheDefine.m
@@ -33,13 +33,13 @@ UIImage * _Nullable SDImageCacheDecodeImageData(NSData * _Nonnull imageData, NSS
         }
     }
     if (!image) {
-        SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
+        SDImageCoderOptions *coderOptions = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
         if (context) {
-            SDImageCoderMutableOptions *mutableOptions = [options mutableCopy];
-            [mutableOptions setValue:context forKey:SDImageCoderWebImageContext];
-            options = [mutableOptions copy];
+            SDImageCoderMutableOptions *mutableCoderOptions = [coderOptions mutableCopy];
+            [mutableCoderOptions setValue:context forKey:SDImageCoderWebImageContext];
+            coderOptions = [mutableCoderOptions copy];
         }
-        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:options];
+        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:coderOptions];
     }
     if (image) {
         BOOL shouldDecode = (options & SDWebImageAvoidDecodeImage) == 0;

--- a/SDWebImage/SDImageLoader.m
+++ b/SDWebImage/SDImageLoader.m
@@ -47,13 +47,13 @@ UIImage * _Nullable SDImageLoaderDecodeImageData(NSData * _Nonnull imageData, NS
         }
     }
     if (!image) {
-        SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
+        SDImageCoderOptions *coderOptions = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
         if (context) {
-            SDImageCoderMutableOptions *mutableOptions = [options mutableCopy];
-            [mutableOptions setValue:context forKey:SDImageCoderWebImageContext];
-            options = [mutableOptions copy];
+            SDImageCoderMutableOptions *mutableCoderOptions = [coderOptions mutableCopy];
+            [mutableCoderOptions setValue:context forKey:SDImageCoderWebImageContext];
+            coderOptions = [mutableCoderOptions copy];
         }
-        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:options];
+        image = [[SDImageCodersManager sharedManager] decodedImageWithData:imageData options:coderOptions];
     }
     if (image) {
         BOOL shouldDecode = (options & SDWebImageAvoidDecodeImage) == 0;
@@ -125,13 +125,13 @@ UIImage * _Nullable SDImageLoaderDecodeProgressiveImageData(NSData * _Nonnull im
         }
     }
     if (!image) {
-        SDImageCoderOptions *options = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
+        SDImageCoderOptions *coderOptions = @{SDImageCoderDecodeFirstFrameOnly : @(decodeFirstFrame), SDImageCoderDecodeScaleFactor : @(scale)};
         if (context) {
-            SDImageCoderMutableOptions *mutableOptions = [options mutableCopy];
-            [mutableOptions setValue:context forKey:SDImageCoderWebImageContext];
-            options = [mutableOptions copy];
+            SDImageCoderMutableOptions *mutableCoderOptions = [coderOptions mutableCopy];
+            [mutableCoderOptions setValue:context forKey:SDImageCoderWebImageContext];
+            coderOptions = [mutableCoderOptions copy];
         }
-        image = [progressiveCoder incrementalDecodedImageWithOptions:options];
+        image = [progressiveCoder incrementalDecodedImageWithOptions:coderOptions];
     }
     if (image) {
         BOOL shouldDecode = (options & SDWebImageAvoidDecodeImage) == 0;

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -488,6 +488,9 @@ didReceiveResponse:(NSURLResponse *)response
     if (options & SDWebImageAllowInvalidSSLCertificates) downloaderOptions |= SDWebImageDownloaderAllowInvalidSSLCertificates;
     if (options & SDWebImageHighPriority) downloaderOptions |= SDWebImageDownloaderHighPriority;
     if (options & SDWebImageScaleDownLargeImages) downloaderOptions |= SDWebImageDownloaderScaleDownLargeImages;
+    if (options & SDWebImageAvoidDecodeImage) downloaderOptions |= SDWebImageDownloaderAvoidDecodeImage;
+    if (options & SDWebImageDecodeFirstFrameOnly) downloaderOptions |= SDWebImageDownloaderDecodeFirstFrameOnly;
+    if (options & SDWebImagePreloadAllFrames) downloaderOptions |= SDWebImageDownloaderPreloadAllFrames;
     
     if (cachedImage && options & SDWebImageRefreshCached) {
         // force progressive off if image already cached but forced refreshing


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

There is a mistake that the 3 options in `SDWebImageDownloader` does not correctly been set.

+ `SDWebImageAvoidDecodeImage`
+ `SDWebImageDecodeFirstFrameOnly`
+ `SDWebImagePreloadAllFrames`

This PR also fix the warning which shadow the local variable of `options`
