### PR TITLE
Feature minimum progress interval

### DIFF
--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -200,10 +200,18 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
         }
         NSOperation<SDWebImageDownloaderOperation> *operation = [[operationClass alloc] initWithRequest:request inSession:sself.session options:options context:context];
         
-        if (sself.config.urlCredential) {
-            operation.credential = sself.config.urlCredential;
-        } else if (sself.config.username && sself.config.password) {
-            operation.credential = [NSURLCredential credentialWithUser:sself.config.username password:sself.config.password persistence:NSURLCredentialPersistenceForSession];
+        if ([operation respondsToSelector:@selector(setCredential:)]) {
+            if (sself.config.urlCredential) {
+                operation.credential = sself.config.urlCredential;
+            } else if (sself.config.username && sself.config.password) {
+                operation.credential = [NSURLCredential credentialWithUser:sself.config.username password:sself.config.password persistence:NSURLCredentialPersistenceForSession];
+            }
+        }
+        
+        if ([operation respondsToSelector:@selector(setMinimumProgressInterval:)]) {
+            NSTimeInterval minimumProgressInterval = sself.config.minimumProgressInterval;
+            minimumProgressInterval = MIN(MAX(minimumProgressInterval, 0), 1);
+            operation.minimumProgressInterval = minimumProgressInterval;
         }
         
         if (options & SDWebImageDownloaderHighPriority) {

--- a/SDWebImage/SDWebImageDownloaderConfig.h
+++ b/SDWebImage/SDWebImageDownloaderConfig.h
@@ -42,6 +42,15 @@ typedef NS_ENUM(NSInteger, SDWebImageDownloaderExecutionOrder) {
 @property (nonatomic, assign) NSTimeInterval downloadTimeout;
 
 /**
+ * The minimum interval about progress percent during network downloading. Which means the next progress callback and current progress callback's progress percent difference should be larger or equal to this value.
+ * The value should be 0.0-1.0.
+ * @note If you're using progressive decoding feature, this will also effect the image refresh rate.
+ * @note This value may enhance the performance if you don't want progress callback too frequently.
+ * Defaults to 0, which means each time we receive the new data from URLSession, we callback the progressBlock immediately.
+ */
+@property (nonatomic, assign) NSTimeInterval minimumProgressInterval;
+
+/**
  * The custom session configuration in use by NSURLSession. If you don't provide one, we will use `defaultSessionConfiguration` instead.
  * Defatuls to nil.
  * @note This property does not support dynamic changes, means it's immutable after the downloader instance initialized.

--- a/SDWebImage/SDWebImageDownloaderConfig.m
+++ b/SDWebImage/SDWebImageDownloaderConfig.m
@@ -34,6 +34,7 @@ static SDWebImageDownloaderConfig * _defaultDownloaderConfig;
     SDWebImageDownloaderConfig *config = [[[self class] allocWithZone:zone] init];
     config.maxConcurrentDownloads = self.maxConcurrentDownloads;
     config.downloadTimeout = self.downloadTimeout;
+    config.minimumProgressInterval = self.minimumProgressInterval;
     config.sessionConfiguration = [self.sessionConfiguration copyWithZone:zone];
     config.operationClass = self.operationClass;
     config.executionOrder = self.executionOrder;

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -36,9 +36,6 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 - (nullable id)addHandlersForProgress:(nullable SDWebImageDownloaderProgressBlock)progressBlock
                             completed:(nullable SDWebImageDownloaderCompletedBlock)completedBlock;
 
-- (nullable NSURLCredential *)credential;
-- (void)setCredential:(nullable NSURLCredential *)value;
-
 - (BOOL)cancel:(nullable id)token;
 
 - (nullable NSURLRequest *)request;
@@ -46,6 +43,10 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 
 @optional
 - (nullable NSURLSessionTask *)dataTask;
+- (nullable NSURLCredential *)credential;
+- (void)setCredential:(nullable NSURLCredential *)credential;
+- (NSTimeInterval)minimumProgressInterval;
+- (void)setMinimumProgressInterval:(NSTimeInterval)minimumProgressInterval;
 
 @end
 
@@ -73,6 +74,15 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
  * This will be overridden by any shared credentials that exist for the username or password of the request URL, if present.
  */
 @property (nonatomic, strong, nullable) NSURLCredential *credential;
+
+/**
+ * The minimum interval about progress percent during network downloading. Which means the next progress callback and current progress callback's progress percent difference should be larger or equal to this value.
+ * The value should be 0.0-1.0.
+ * @note If you're using progressive decoding feature, this will also effect the image refresh rate.
+ * @note This value may enhance the performance if you don't want progress callback too frequently.
+ * Defaults to 0, which means each time we receive the new data from URLSession, we callback the progressBlock immediately.
+ */
+@property (assign, nonatomic) NSTimeInterval minimumProgressInterval;
 
 /**
  * The options for the receiver.

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -37,9 +37,11 @@ typedef NSMutableDictionary<NSString *, id> SDCallbacksDictionary;
 @property (assign, nonatomic, getter = isFinished) BOOL finished;
 @property (strong, nonatomic, nullable) NSMutableData *imageData;
 @property (copy, nonatomic, nullable) NSData *cachedData; // for `SDWebImageDownloaderIgnoreCachedResponse`
-@property (assign, nonatomic, readwrite) NSUInteger expectedSize;
+@property (assign, nonatomic) NSUInteger expectedSize; // may be 0
+@property (assign, nonatomic) NSUInteger receivedSize;
 @property (strong, nonatomic, nullable, readwrite) NSURLResponse *response;
 @property (strong, nonatomic, nullable) NSError *responseError;
+@property (assign, nonatomic) double previousProgress; // previous progress percent
 
 // This is weak because it is injected by whoever manages this session. If this gets nil-ed out, we won't be able to run
 // the task associated with this operation
@@ -331,17 +333,37 @@ didReceiveResponse:(NSURLResponse *)response
         self.imageData = [[NSMutableData alloc] initWithCapacity:self.expectedSize];
     }
     [self.imageData appendData:data];
+    
+    self.receivedSize = self.imageData.length;
+    if (self.expectedSize == 0) {
+        // Unknown expectedSize, immediately call progressBlock and return
+        for (SDWebImageDownloaderProgressBlock progressBlock in [self callbacksForKey:kProgressCallbackKey]) {
+            progressBlock(self.receivedSize, self.expectedSize, self.request.URL);
+        }
+        return;
+    }
+    
+    // Get the finish status
+    BOOL finished = (self.receivedSize >= self.expectedSize);
+    // Get the current progress
+    double currentProgress = (double)self.receivedSize / (double)self.expectedSize;
+    double previousProgress = self.previousProgress;
+    // Check if we need callback progress
+    if (currentProgress - previousProgress < self.minimumProgressInterval) {
+        return;
+    }
+    self.previousProgress = currentProgress;
 
-    if ((self.options & SDWebImageDownloaderProgressiveLoad) && self.expectedSize > 0) {
+    if (self.options & SDWebImageDownloaderProgressiveLoad) {
         // Get the image data
         NSData *imageData = [self.imageData copy];
-        // Get the total bytes downloaded
-        const NSUInteger totalSize = imageData.length;
-        // Get the finish status
-        BOOL finished = (totalSize >= self.expectedSize);
         
         // progressive decode the image in coder queue
         dispatch_async(self.coderQueue, ^{
+            // If all the data has already been downloaded, earily return to avoid further decoding
+            if (self.receivedSize >= self.expectedSize) {
+                return;
+            }
             UIImage *image = SDImageLoaderDecodeProgressiveImageData(imageData, self.request.URL, finished, self, [[self class] imageOptionsFromDownloaderOptions:self.options], self.context);
             if (image) {
                 // We do not keep the progressive decoding image even when `finished`=YES. Because they are for view rendering but not take full function from downloader options. And some coders implementation may not keep consistent between progressive decoding and normal decoding.
@@ -350,9 +372,9 @@ didReceiveResponse:(NSURLResponse *)response
             }
         });
     }
-
+    
     for (SDWebImageDownloaderProgressBlock progressBlock in [self callbacksForKey:kProgressCallbackKey]) {
-        progressBlock(self.imageData.length, self.expectedSize, self.request.URL);
+        progressBlock(self.receivedSize, self.expectedSize, self.request.URL);
     }
 }
 

--- a/Tests/Tests/SDWebImageTestDownloadOperation.h
+++ b/Tests/Tests/SDWebImageTestDownloadOperation.h
@@ -15,7 +15,6 @@
  */
 @interface SDWebImageTestDownloadOperation : NSOperation <SDWebImageDownloaderOperation>
 
-@property (nonatomic, strong, nullable) NSURLCredential *credential;
 @property (nonatomic, strong, nullable) NSURLRequest *request;
 @property (nonatomic, strong, nullable) NSURLResponse *response;
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding // Added one `test17ThatMinimumProgressIntervalWorks`
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2199

### Pull Request Description

### Reason

See my last comment on #2199.

Our current downloader, will callback your progressBlock whenever it receive the `URLSession:dataTask:didReceiveData:` delegate method. And then do a progressive image decoding. This rate is not controllable, and after #2199 been merged, this speed become more frequent because of the progressive decoding now does not block delegate queue (so that URLSession can delivery more delegate call in session queue)

But however, when the network speed is lower, this will cause we submit progressBlock and the progressive decoding task  too frequently. And if our decoding code is not performent enough, this will consume much more CPU. So it wil cause we waste too much of time on the progressBlock business code or the progressive decoding code.

So I suggest to provide a minimum interval about progress percent, to limit the callback ratio. For example, if you specify `minimumProgressInterval` to 0.2 (20%), you will receive at most 5 callbacks from progress block. This can reduce the performance cost.

By default this value is 0, means no limit at all and just like previous behavior. (Each time receive `URLSession:dataTask:didReceiveData:`, we callback progress block)

