### PR TITLE
Feature disk cache migration from 4.x

### DIFF
--- a/SDWebImage/SDDiskCache.h
+++ b/SDWebImage/SDDiskCache.h
@@ -104,4 +104,15 @@
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
+/**
+ Move the cache directory from old location to new location, the old location will be removed after finish.
+ If the old location does not exist, does nothing.
+ If the new location does not exist, only do a movement of directory.
+ If the new location does exist, will move and merge the files from old location.
+
+ @param srcPath old location of cache directory
+ @param dstPath new location of cache directory
+ */
+- (void)moveCacheDirectoryFromPath:(nonnull NSString *)srcPath toPath:(nonnull NSString *)dstPath;
+
 @end

--- a/SDWebImage/SDDiskCache.m
+++ b/SDWebImage/SDDiskCache.m
@@ -228,6 +228,35 @@
     return [path stringByAppendingPathComponent:filename];
 }
 
+- (void)moveCacheDirectoryFromPath:(nonnull NSString *)srcPath toPath:(nonnull NSString *)dstPath {
+    NSParameterAssert(srcPath);
+    NSParameterAssert(dstPath);
+    BOOL isDirectory;
+    // Check if old path is directory
+    if (![self.fileManager fileExistsAtPath:srcPath isDirectory:&isDirectory] || !isDirectory) {
+        return;
+    }
+    // Check if new path is directory
+    if (![self.fileManager fileExistsAtPath:dstPath isDirectory:&isDirectory]) {
+        // New directory does not exist, rename directory
+        [self.fileManager moveItemAtPath:srcPath toPath:dstPath error:nil];
+    } else {
+        if (!isDirectory) {
+            // New path is not directory, remove directory
+            [self.fileManager removeItemAtPath:dstPath error:nil];
+        }
+        // New directory exist, merge the files
+        NSDirectoryEnumerator *dirEnumerator = [self.fileManager enumeratorAtPath:srcPath];
+        NSString *file;
+        while ((file = [dirEnumerator nextObject])) {
+            // Don't handle error, just try to move.
+            [self.fileManager moveItemAtPath:[srcPath stringByAppendingPathComponent:file] toPath:[dstPath stringByAppendingPathComponent:file] error:nil];
+        }
+    }
+    // Remove the old path
+    [self.fileManager removeItemAtPath:srcPath error:nil];
+}
+
 #pragma mark - Hash
 
 static inline NSString * _Nullable SDDiskCacheFileNameForKey(NSString * _Nullable key) {

--- a/SDWebImage/SDDiskCache.m
+++ b/SDWebImage/SDDiskCache.m
@@ -231,20 +231,24 @@
 - (void)moveCacheDirectoryFromPath:(nonnull NSString *)srcPath toPath:(nonnull NSString *)dstPath {
     NSParameterAssert(srcPath);
     NSParameterAssert(dstPath);
+    // Check if old path is equal to new path
+    if ([srcPath isEqualToString:dstPath]) {
+        return;
+    }
     BOOL isDirectory;
     // Check if old path is directory
     if (![self.fileManager fileExistsAtPath:srcPath isDirectory:&isDirectory] || !isDirectory) {
         return;
     }
     // Check if new path is directory
-    if (![self.fileManager fileExistsAtPath:dstPath isDirectory:&isDirectory]) {
+    if (![self.fileManager fileExistsAtPath:dstPath isDirectory:&isDirectory] || !isDirectory) {
+        if (!isDirectory) {
+            // New path is not directory, remove file
+            [self.fileManager removeItemAtPath:dstPath error:nil];
+        }
         // New directory does not exist, rename directory
         [self.fileManager moveItemAtPath:srcPath toPath:dstPath error:nil];
     } else {
-        if (!isDirectory) {
-            // New path is not directory, remove directory
-            [self.fileManager removeItemAtPath:dstPath error:nil];
-        }
         // New directory exist, merge the files
         NSDirectoryEnumerator *dirEnumerator = [self.fileManager enumeratorAtPath:srcPath];
         NSString *file;
@@ -252,9 +256,9 @@
             // Don't handle error, just try to move.
             [self.fileManager moveItemAtPath:[srcPath stringByAppendingPathComponent:file] toPath:[dstPath stringByAppendingPathComponent:file] error:nil];
         }
+        // Remove the old path
+        [self.fileManager removeItemAtPath:srcPath error:nil];
     }
-    // Remove the old path
-    [self.fileManager removeItemAtPath:srcPath error:nil];
 }
 
 #pragma mark - Hash

--- a/SDWebImage/SDImageCache.m
+++ b/SDWebImage/SDImageCache.m
@@ -86,6 +86,7 @@
         
         NSAssert([config.diskCacheClass conformsToProtocol:@protocol(SDDiskCache)], @"Custom disk cache class must conform to `SDDiskCache` protocol");
         _diskCache = [[config.diskCacheClass alloc] initWithCachePath:_diskCachePath config:_config];
+        [self migrateDiskCacheDirectory];
 
 #if SD_UIKIT
         // Subscribe to app events
@@ -126,6 +127,19 @@
 - (nullable NSString *)makeDiskCachePath:(nonnull NSString*)fullNamespace {
     NSArray<NSString *> *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
     return [paths[0] stringByAppendingPathComponent:fullNamespace];
+}
+
+- (void)migrateDiskCacheDirectory {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        if ([self.diskCache isKindOfClass:[SDDiskCache class]]) {
+            NSString *newDefaultPath = [[self makeDiskCachePath:@"default"] stringByAppendingPathComponent:@"com.hackemist.SDImageCache.default"];
+            NSString *oldDefaultPath = [[self makeDiskCachePath:@"default"] stringByAppendingPathComponent:@"com.hackemist.SDWebImageCache.default"];
+            dispatch_async(self.ioQueue, ^{
+                [((SDDiskCache *)self.diskCache) moveCacheDirectoryFromPath:oldDefaultPath toPath:newDefaultPath];
+            });
+        }
+    });
 }
 
 #pragma mark - Store Ops


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding // Added `test44DiskCacheMigrationFromOldVersion`
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2412 

### Pull Request Description
The original is from #2412 

This is a migration for 4.x user of SDWebImage, because we change the default cache path from `Library/Caches/default/com.hackemist.SDWebImageCache.default` to `Library/Caches/default/com.hackemist.SDImageCache.default`

This change base on the #2412, and add one test for this migration.
And I polish the new API in `SDDiskCache` class, to make it also possible for common usage.

@zhongwuzw @bpoplauschi 