### PR TITLE
Fix that `shouldUseWeakMemoryCache` code was lost during merge conflict

### DIFF
--- a/SDWebImage/SDMemoryCache.m
+++ b/SDWebImage/SDMemoryCache.m
@@ -84,6 +84,9 @@ static void * SDMemoryCacheContext = &SDMemoryCacheContext;
 // `setObject:forKey:` just call this with 0 cost. Override this is enough
 - (void)setObject:(id)obj forKey:(id)key cost:(NSUInteger)g {
     [super setObject:obj forKey:key cost:g];
+    if (!self.config.shouldUseWeakMemoryCache) {
+        return;
+    }
     if (key && obj) {
         // Store weak cache
         LOCK(self.weakCacheLock);
@@ -94,6 +97,9 @@ static void * SDMemoryCacheContext = &SDMemoryCacheContext;
 
 - (id)objectForKey:(id)key {
     id obj = [super objectForKey:key];
+    if (!self.config.shouldUseWeakMemoryCache) {
+        return obj;
+    }
     if (key && !obj) {
         // Check weak cache
         LOCK(self.weakCacheLock);
@@ -113,6 +119,9 @@ static void * SDMemoryCacheContext = &SDMemoryCacheContext;
 
 - (void)removeObjectForKey:(id)key {
     [super removeObjectForKey:key];
+    if (!self.config.shouldUseWeakMemoryCache) {
+        return;
+    }
     if (key) {
         // Remove weak cache
         LOCK(self.weakCacheLock);
@@ -123,6 +132,9 @@ static void * SDMemoryCacheContext = &SDMemoryCacheContext;
 
 - (void)removeAllObjects {
     [super removeAllObjects];
+    if (!self.config.shouldUseWeakMemoryCache) {
+        return;
+    }
     // Manually remove should also remove weak cache
     LOCK(self.weakCacheLock);
     [self.weakCache removeAllObjects];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This is a bug that during when I'm solving the merge conflict from master to 5.x branch. The `shouldUseWeakMemoryCache` property does not do anything. So this PR fix it.

