### PR TITLE
Add SDImageFormatHEIF represent mif1 && msf1 brands

### DIFF
--- a/Examples/SDWebImage Demo/MasterViewController.m
+++ b/Examples/SDWebImage Demo/MasterViewController.m
@@ -68,6 +68,7 @@
                     @"http://littlesvr.ca/apng/images/SteamEngine.webp",
                     @"http://littlesvr.ca/apng/images/world-cup-2014-42.webp",
                     @"https://isparta.github.io/compare-webp/image/gif_webp/webp/2.webp",
+                    @"https://nokiatech.github.io/heif/content/images/ski_jump_1440x960.heic",
                     @"https://nr-platform.s3.amazonaws.com/uploads/platform/published_extension/branding_icon/275/AmazonS3.png",
                     @"http://via.placeholder.com/200x200.jpg",
                     nil];

--- a/SDWebImage/NSData+ImageContentType.h
+++ b/SDWebImage/NSData+ImageContentType.h
@@ -17,7 +17,8 @@ typedef NS_ENUM(NSInteger, SDImageFormat) {
     SDImageFormatGIF,
     SDImageFormatTIFF,
     SDImageFormatWebP,
-    SDImageFormatHEIC
+    SDImageFormatHEIC,
+    SDImageFormatHEIF
 };
 
 @interface NSData (ImageContentType)

--- a/SDWebImage/NSData+ImageContentType.m
+++ b/SDWebImage/NSData+ImageContentType.m
@@ -16,8 +16,9 @@
 
 // Currently Image/IO does not support WebP
 #define kSDUTTypeWebP ((__bridge CFStringRef)@"public.webp")
-// AVFileTypeHEIC is defined in AVFoundation via iOS 11, we use this without import AVFoundation
+// AVFileTypeHEIC/AVFileTypeHEIF is defined in AVFoundation via iOS 11, we use this without import AVFoundation
 #define kSDUTTypeHEIC ((__bridge CFStringRef)@"public.heic")
+#define kSDUTTypeHEIF ((__bridge CFStringRef)@"public.heif")
 
 @implementation NSData (ImageContentType)
 
@@ -59,6 +60,9 @@
                     || [testString isEqualToString:@"ftyphevx"]) {
                     return SDImageFormatHEIC;
                 }
+                if ([testString isEqualToString:@"ftypmif1"] || [testString isEqualToString:@"ftypmsf1"]) {
+                    return SDImageFormatHEIF;
+                }
             }
             break;
         }
@@ -87,6 +91,9 @@
         case SDImageFormatHEIC:
             UTType = kSDUTTypeHEIC;
             break;
+        case SDImageFormatHEIF:
+            UTType = kSDUTTypeHEIF;
+            break;
         default:
             // default is kUTTypePNG
             UTType = kUTTypePNG;
@@ -112,6 +119,8 @@
         imageFormat = SDImageFormatWebP;
     } else if (CFStringCompare(uttype, kSDUTTypeHEIC, 0) == kCFCompareEqualTo) {
         imageFormat = SDImageFormatHEIC;
+    } else if (CFStringCompare(uttype, kSDUTTypeHEIF, 0) == kCFCompareEqualTo) {
+        imageFormat = SDImageFormatHEIF;
     } else {
         imageFormat = SDImageFormatUndefined;
     }

--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -74,6 +74,9 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         case SDImageFormatHEIC:
             // Check HEIC decoding compatibility
             return [[self class] canDecodeFromHEICFormat];
+        case SDImageFormatHEIF:
+            // Check HEIF decoding compatibility
+            return [[self class] canDecodeFromHEIFFormat];
         default:
             return YES;
     }
@@ -87,6 +90,9 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         case SDImageFormatHEIC:
             // Check HEIC decoding compatibility
             return [[self class] canDecodeFromHEICFormat];
+        case SDImageFormatHEIF:
+            // Check HEIF decoding compatibility
+            return [[self class] canDecodeFromHEIFFormat];
         default:
             return YES;
     }
@@ -372,6 +378,9 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
         case SDImageFormatHEIC:
             // Check HEIC encoding compatibility
             return [[self class] canEncodeToHEICFormat];
+        case SDImageFormatHEIF:
+            // Check HEIF encoding compatibility
+            return [[self class] canEncodeToHEIFFormat];
         default:
             return YES;
     }
@@ -440,28 +449,24 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     static BOOL canDecode = NO;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-#if TARGET_OS_SIMULATOR || SD_WATCH
-        canDecode = NO;
-#elif SD_MAC
-        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
-        if ([processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
-            // macOS 10.13+
-            canDecode = processInfo.operatingSystemVersion.minorVersion >= 13;
-        } else {
-            canDecode = NO;
+        CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatHEIC];
+        NSArray *imageUTTypes = (__bridge_transfer NSArray *)CGImageSourceCopyTypeIdentifiers();
+        if ([imageUTTypes containsObject:(__bridge NSString *)(imageUTType)]) {
+            canDecode = YES;
         }
-#elif SD_UIKIT
-        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
-        if ([processInfo respondsToSelector:@selector(operatingSystemVersion)]) {
-            // iOS 11+ && tvOS 11+
-            canDecode = processInfo.operatingSystemVersion.majorVersion >= 11;
-        } else {
-            canDecode = NO;
+    });
+    return canDecode;
+}
+
++ (BOOL)canDecodeFromHEIFFormat {
+    static BOOL canDecode = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatHEIF];
+        NSArray *imageUTTypes = (__bridge_transfer NSArray *)CGImageSourceCopyTypeIdentifiers();
+        if ([imageUTTypes containsObject:(__bridge NSString *)(imageUTType)]) {
+            canDecode = YES;
         }
-#endif
-#pragma clang diagnostic pop
     });
     return canDecode;
 }
@@ -480,6 +485,27 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
             canEncode = NO;
         } else {
             // Can encode to HEIC
+            CFRelease(imageDestination);
+            canEncode = YES;
+        }
+    });
+    return canEncode;
+}
+
++ (BOOL)canEncodeToHEIFFormat {
+    static BOOL canEncode = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSMutableData *imageData = [NSMutableData data];
+        CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatHEIF];
+        
+        // Create an image destination.
+        CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, 1, NULL);
+        if (!imageDestination) {
+            // Can't encode to HEIF
+            canEncode = NO;
+        } else {
+            // Can encode to HEIF
             CFRelease(imageDestination);
             canEncode = YES;
         }


### PR DESCRIPTION
Fix the current hard-coded system version checking with Image/IO source uttypes checking

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2081

### Pull Request Description

It seems that in the last of 2017. We introduce `SDImageFormatHEIC`. At that time, the iPhone simulator does not works well on the heif image decoding. So we do some heif decoding compatibility check based on system version, platform and simulator. But now, since Xcode 9.3, iPhone Simulator can now successfully rendering HEIF images, that check seems will cause a wrong result. And I think hard-coded the result (For example, we hard-coded watchOS does not support HEIF) is not a good idea.

Another issue, HEIF actually contains 6 brands of structural format. Such as this image: https://nokiatech.github.io/heif/content/images/ski_jump_1440x960.heic

This image's brand is `msf1`, so the format check of `sd_imageFormatForImageData:` will return `SDImageFormatUndefined`. It's not a good idea for some points of usage. The reason why current user can still sucessfully display `msf1` brand HEIF image on iOS 11 device, is because of `SDWebImageImageIOCoder` will always return YES for `SDImageFormatUndefined` (See this [code](https://github.com/rs/SDWebImage/blob/master/SDWebImage/SDWebImageImageIOCoder.m#L77)).

I think the good way to do, is to define the `SDImageFormatHEIF` format as well, which represent `msf1` and `msf1` brand. Like the format in [SDWebImageHEIFCoder](https://github.com/SDWebImage/SDWebImageHEIFCoder/blob/master/SDWebImageHEIFCoder/Classes/SDWebImageHEIFCoder.m#L339). See all brands in the [HEIF Technical information](https://nokiatech.github.io/heif/technical.html).

Image/IO framework, used by Apple platform, actualy can support `msf1` or `msf1` brand, when the actual codec is HEVC(H265). The previous assumtation of that Apple only supports `heic` brand is not correct. So I think introduce this enum is better for usage.