### PR TITLE
Using ImageIO UTIs API to check image sources or destinations

### DIFF
--- a/SDWebImage/SDWebImageImageIOCoder.m
+++ b/SDWebImage/SDWebImageImageIOCoder.m
@@ -451,9 +451,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     dispatch_once(&onceToken, ^{
         CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatHEIC];
         NSArray *imageUTTypes = (__bridge_transfer NSArray *)CGImageSourceCopyTypeIdentifiers();
-        if ([imageUTTypes containsObject:(__bridge NSString *)(imageUTType)]) {
-            canDecode = YES;
-        }
+        canDecode = [imageUTTypes containsObject:(__bridge NSString *)(imageUTType)];
     });
     return canDecode;
 }
@@ -464,9 +462,7 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     dispatch_once(&onceToken, ^{
         CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatHEIF];
         NSArray *imageUTTypes = (__bridge_transfer NSArray *)CGImageSourceCopyTypeIdentifiers();
-        if ([imageUTTypes containsObject:(__bridge NSString *)(imageUTType)]) {
-            canDecode = YES;
-        }
+        canDecode = [imageUTTypes containsObject:(__bridge NSString *)(imageUTType)];
     });
     return canDecode;
 }
@@ -475,19 +471,9 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     static BOOL canEncode = NO;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSMutableData *imageData = [NSMutableData data];
         CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatHEIC];
-        
-        // Create an image destination.
-        CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, 1, NULL);
-        if (!imageDestination) {
-            // Can't encode to HEIC
-            canEncode = NO;
-        } else {
-            // Can encode to HEIC
-            CFRelease(imageDestination);
-            canEncode = YES;
-        }
+        NSArray *imageDestinationTypes = (__bridge_transfer NSArray *)CGImageDestinationCopyTypeIdentifiers();
+        canEncode = [imageDestinationTypes containsObject:(__bridge NSString *)imageUTType];
     });
     return canEncode;
 }
@@ -496,19 +482,9 @@ static const CGFloat kDestSeemOverlap = 2.0f;   // the numbers of pixels to over
     static BOOL canEncode = NO;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSMutableData *imageData = [NSMutableData data];
         CFStringRef imageUTType = [NSData sd_UTTypeFromSDImageFormat:SDImageFormatHEIF];
-        
-        // Create an image destination.
-        CGImageDestinationRef imageDestination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef)imageData, imageUTType, 1, NULL);
-        if (!imageDestination) {
-            // Can't encode to HEIF
-            canEncode = NO;
-        } else {
-            // Can encode to HEIF
-            CFRelease(imageDestination);
-            canEncode = YES;
-        }
+        NSArray *imageDestinationTypes = (__bridge_transfer NSArray *)CGImageDestinationCopyTypeIdentifiers();
+        canEncode = [imageDestinationTypes containsObject:(__bridge NSString *)imageUTType];
     });
     return canEncode;
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: 

### Pull Request Description

Unify the check method of image sources and destinations, using `CGImageSourceCopyTypeIdentifiers` or `CGImageDestinationCopyTypeIdentifiers `.

