### PR TITLE
Make download receive response notification only dispatch to specific observer

### DIFF
--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -91,6 +91,8 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadStopNotification;
 typedef SDImageLoaderProgressBlock SDWebImageDownloaderProgressBlock;
 typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
 
+@protocol SDWebImageDownloaderOperation;
+
 /**
  *  A token associated with each download. Can be used to cancel a download
  */
@@ -115,6 +117,11 @@ typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
  The download's response.
  */
 @property (nonatomic, strong, nullable, readonly) NSURLResponse *response;
+
+/**
+ Init download token with downloadOperation.
+ */
+- (nonnull instancetype)initWithDownloadOperation:(nullable NSOperation<SDWebImageDownloaderOperation> *)downloadOperation;
 
 @end
 

--- a/SDWebImage/SDWebImageDownloader.h
+++ b/SDWebImage/SDWebImageDownloader.h
@@ -91,8 +91,6 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadStopNotification;
 typedef SDImageLoaderProgressBlock SDWebImageDownloaderProgressBlock;
 typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
 
-@protocol SDWebImageDownloaderOperation;
-
 /**
  *  A token associated with each download. Can be used to cancel a download
  */
@@ -117,11 +115,6 @@ typedef SDImageLoaderCompletedBlock SDWebImageDownloaderCompletedBlock;
  The download's response.
  */
 @property (nonatomic, strong, nullable, readonly) NSURLResponse *response;
-
-/**
- Init download token with downloadOperation.
- */
-- (nonnull instancetype)initWithDownloadOperation:(nullable NSOperation<SDWebImageDownloaderOperation> *)downloadOperation;
 
 @end
 

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -25,7 +25,7 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
 + (nonnull instancetype)new  NS_UNAVAILABLE;
-- (nonnull instancetype)initWithDownloadOperation:(nullable NSOperation<SDWebImageDownloaderOperation> *)downloadOperation NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithDownloadOperation:(nullable NSOperation<SDWebImageDownloaderOperation> *)downloadOperation;
 
 @end
 

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -23,6 +23,10 @@ static void * SDWebImageDownloaderContext = &SDWebImageDownloaderContext;
 @property (nonatomic, weak, nullable) SDWebImageDownloader *downloader;
 @property (nonatomic, assign, getter=isCancelled) BOOL cancelled;
 
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new  NS_UNAVAILABLE;
+- (nonnull instancetype)initWithDownloadOperation:(nullable NSOperation<SDWebImageDownloaderOperation> *)downloadOperation NS_DESIGNATED_INITIALIZER;
+
 @end
 
 @interface SDWebImageDownloader () <NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
@@ -429,10 +433,6 @@ didReceiveResponse:(NSURLResponse *)response
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:SDWebImageDownloadReceiveResponseNotification object:nil];
-}
-
-- (instancetype)init {
-    return [self initWithDownloadOperation:nil];
 }
 
 - (instancetype)initWithDownloadOperation:(NSOperation<SDWebImageDownloaderOperation> *)downloadOperation {

--- a/SDWebImage/SDWebImageDownloader.m
+++ b/SDWebImage/SDWebImageDownloader.m
@@ -429,20 +429,20 @@ didReceiveResponse:(NSURLResponse *)response
 @implementation SDWebImageDownloadToken
 
 - (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:SDWebImageDownloadReceiveResponseNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:SDWebImageDownloadReceiveResponseNotification object:_downloadOperation];
 }
 
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(downloadReceiveResponse:) name:SDWebImageDownloadReceiveResponseNotification object:nil];
+- (void)setDownloadOperation:(NSOperation<SDWebImageDownloaderOperation> *)downloadOperation {
+    if (downloadOperation != _downloadOperation) {
+        [[NSNotificationCenter defaultCenter] removeObserver:self name:SDWebImageDownloadReceiveResponseNotification object:_downloadOperation];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(downloadReceiveResponse:) name:SDWebImageDownloadReceiveResponseNotification object:downloadOperation];
+        _downloadOperation = downloadOperation;
     }
-    return self;
 }
 
 - (void)downloadReceiveResponse:(NSNotification *)notification {
     NSOperation<SDWebImageDownloaderOperation> *downloadOperation = notification.object;
-    if (downloadOperation && downloadOperation == self.downloadOperation) {
+    if (downloadOperation) {
         self.response = downloadOperation.response;
     }
 }

--- a/SDWebImage/UIView+WebCacheOperation.m
+++ b/SDWebImage/UIView+WebCacheOperation.m
@@ -11,7 +11,7 @@
 
 static char loadOperationKey;
 
-// key is copy, value is weak because operation instance is retained by SDWebImageManager's runningOperations property
+// key is strong, value is weak because operation instance is retained by SDWebImageManager's runningOperations property
 // we should use lock to keep thread-safe because these method may not be acessed from main queue
 typedef NSMapTable<NSString *, id<SDWebImageOperation>> SDOperationsDictionary;
 


### PR DESCRIPTION
Make download receive response notification only dispatch to specific observer

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Currently, we add observer when create `SDWebImageDownloadToken`, when post `SDWebImageDownloadReceiveResponseNotification`, every observer would receive notification, we use `downloadOperation == self.downloadOperation` to filter its wanted notification. It's not necessary, e.x. Let's assume we have 10 `downloadToken`, each download would be post notification once, so notification center would dispatch selector at most (1 + 2 + 3 + ..... + 10) = 55 times in main thread. After my `PR`, we only dispatch 10 times.

