### PR TITLE
Fix download progress callback when download finished

### DIFF
--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -82,7 +82,7 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
  * @note This value may enhance the performance if you don't want progress callback too frequently.
  * Defaults to 0, which means each time we receive the new data from URLSession, we callback the progressBlock immediately.
  */
-@property (assign, nonatomic) NSTimeInterval minimumProgressInterval;
+@property (assign, nonatomic) double minimumProgressInterval;
 
 /**
  * The options for the receiver.

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -337,7 +337,9 @@ didReceiveResponse:(NSURLResponse *)response
     self.receivedSize = self.imageData.length;
     if (self.expectedSize == 0) {
         // Unknown expectedSize, immediately call progressBlock and return
-        [self callProgressBlocks];
+        for (SDWebImageDownloaderProgressBlock progressBlock in [self callbacksForKey:kProgressCallbackKey]) {
+            progressBlock(self.receivedSize, self.expectedSize, self.request.URL);
+        }
         return;
     }
     
@@ -348,7 +350,9 @@ didReceiveResponse:(NSURLResponse *)response
     double previousProgress = self.previousProgress;
     // Check if we need callback progress
     if ((currentProgress - previousProgress) < self.minimumProgressInterval || finished) {
-        [self callProgressBlocks];
+        for (SDWebImageDownloaderProgressBlock progressBlock in [self callbacksForKey:kProgressCallbackKey]) {
+            progressBlock(self.receivedSize, self.expectedSize, self.request.URL);
+        }
         return;
     }
     self.previousProgress = currentProgress;
@@ -368,7 +372,9 @@ didReceiveResponse:(NSURLResponse *)response
         });
     }
     
-    [self callProgressBlocks];
+    for (SDWebImageDownloaderProgressBlock progressBlock in [self callbacksForKey:kProgressCallbackKey]) {
+        progressBlock(self.receivedSize, self.expectedSize, self.request.URL);
+    }
 }
 
 - (void)URLSession:(NSURLSession *)session
@@ -503,12 +509,6 @@ didReceiveResponse:(NSURLResponse *)response
             completedBlock(image, imageData, error, finished);
         }
     });
-}
-
-- (void)callProgressBlocks {
-    for (SDWebImageDownloaderProgressBlock progressBlock in [self callbacksForKey:kProgressCallbackKey]) {
-        progressBlock(self.receivedSize, self.expectedSize, self.request.URL);
-    }
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: 

### Pull Request Description
We need to call progress block when `finished` but progress interval less than `minimumProgressInterval`.

