### PR TITLE
Fix that the minimumProgressInterval should always callback the final finished progress but not ignore it

### DIFF
--- a/SDWebImage/SDWebImageDownloaderConfig.h
+++ b/SDWebImage/SDWebImageDownloaderConfig.h
@@ -42,13 +42,13 @@ typedef NS_ENUM(NSInteger, SDWebImageDownloaderExecutionOrder) {
 @property (nonatomic, assign) NSTimeInterval downloadTimeout;
 
 /**
- * The minimum interval about progress percent during network downloading. Which means the next progress callback and current progress callback's progress percent difference should be larger or equal to this value.
+ * The minimum interval about progress percent during network downloading. Which means the next progress callback and current progress callback's progress percent difference should be larger or equal to this value. However, the final finish download progress callback does not get effected.
  * The value should be 0.0-1.0.
  * @note If you're using progressive decoding feature, this will also effect the image refresh rate.
  * @note This value may enhance the performance if you don't want progress callback too frequently.
  * Defaults to 0, which means each time we receive the new data from URLSession, we callback the progressBlock immediately.
  */
-@property (nonatomic, assign) NSTimeInterval minimumProgressInterval;
+@property (nonatomic, assign) double minimumProgressInterval;
 
 /**
  * The custom session configuration in use by NSURLSession. If you don't provide one, we will use `defaultSessionConfiguration` instead.

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -45,8 +45,8 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 - (nullable NSURLSessionTask *)dataTask;
 - (nullable NSURLCredential *)credential;
 - (void)setCredential:(nullable NSURLCredential *)credential;
-- (NSTimeInterval)minimumProgressInterval;
-- (void)setMinimumProgressInterval:(NSTimeInterval)minimumProgressInterval;
+- (double)minimumProgressInterval;
+- (void)setMinimumProgressInterval:(double)minimumProgressInterval;
 
 @end
 
@@ -76,13 +76,13 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 @property (nonatomic, strong, nullable) NSURLCredential *credential;
 
 /**
- * The minimum interval about progress percent during network downloading. Which means the next progress callback and current progress callback's progress percent difference should be larger or equal to this value.
+ * The minimum interval about progress percent during network downloading. Which means the next progress callback and current progress callback's progress percent difference should be larger or equal to this value. However, the final finish download progress callback does not get effected.
  * The value should be 0.0-1.0.
  * @note If you're using progressive decoding feature, this will also effect the image refresh rate.
  * @note This value may enhance the performance if you don't want progress callback too frequently.
  * Defaults to 0, which means each time we receive the new data from URLSession, we callback the progressBlock immediately.
  */
-@property (assign, nonatomic) NSTimeInterval minimumProgressInterval;
+@property (assign, nonatomic) double minimumProgressInterval;
 
 /**
  * The options for the receiver.

--- a/SDWebImage/SDWebImageDownloaderOperation.m
+++ b/SDWebImage/SDWebImageDownloaderOperation.m
@@ -348,8 +348,9 @@ didReceiveResponse:(NSURLResponse *)response
     // Get the current progress
     double currentProgress = (double)self.receivedSize / (double)self.expectedSize;
     double previousProgress = self.previousProgress;
+    double progressInterval = currentProgress - previousProgress;
     // Check if we need callback progress
-    if (currentProgress - previousProgress < self.minimumProgressInterval) {
+    if (!finished && (progressInterval < self.minimumProgressInterval)) {
         return;
     }
     self.previousProgress = currentProgress;
@@ -360,10 +361,6 @@ didReceiveResponse:(NSURLResponse *)response
         
         // progressive decode the image in coder queue
         dispatch_async(self.coderQueue, ^{
-            // If all the data has already been downloaded, earily return to avoid further decoding
-            if (self.receivedSize >= self.expectedSize) {
-                return;
-            }
             UIImage *image = SDImageLoaderDecodeProgressiveImageData(imageData, self.request.URL, finished, self, [[self class] imageOptionsFromDownloaderOptions:self.options], self.context);
             if (image) {
                 // We do not keep the progressive decoding image even when `finished`=YES. Because they are for view rendering but not take full function from downloader options. And some coders implementation may not keep consistent between progressive decoding and normal decoding.

--- a/Tests/Tests/SDWebImageDownloaderTests.m
+++ b/Tests/Tests/SDWebImageDownloaderTests.m
@@ -262,7 +262,7 @@
 - (void)test17ThatMinimumProgressIntervalWorks {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Minimum progress interval"];
     SDWebImageDownloaderConfig *config = SDWebImageDownloaderConfig.defaultDownloaderConfig;
-    config.minimumProgressInterval = 0.51; // This will make the progress only callback once
+    config.minimumProgressInterval = 0.51; // This will make the progress only callback twice (once is 51%, another is 100%)
     SDWebImageDownloader *downloader = [[SDWebImageDownloader alloc] initWithConfig:config];
     NSURL *imageURL = [NSURL URLWithString:@"http://www.ioncannon.net/wp-content/uploads/2011/06/test2.webp"];
     __block NSUInteger allProgressCount = 0; // All progress (including operation start / first HTTP response, etc)
@@ -275,7 +275,7 @@
         }
         validProgressCount++;
     } completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, BOOL finished) {
-        if (allProgressCount > 1 && validProgressCount == 1) {
+        if (allProgressCount > 2 && validProgressCount == 2) {
             [expectation fulfill];
         } else {
             XCTFail(@"Progress callback more than once");


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2430

### Pull Request Description

This bug was introduced in #2415 .

Fix the behavior that `minimumProgressInterval` property, should not ignore the final status (when download bytes >= excepted bytes and download get finished). Even we set `minimumProgressInterval` to 1.0, when download progress reached 100%, we should callback at least once. When `minimumProgressInterval` to 0.51, we should callback twice.

Also update the comments and test to ensure this behavior.