### PR TITLE
Fix cache migration when dstPath intermediate directories not exist

### DIFF
--- a/SDWebImage/SDDiskCache.h
+++ b/SDWebImage/SDDiskCache.h
@@ -109,6 +109,7 @@
  If the old location does not exist, does nothing.
  If the new location does not exist, only do a movement of directory.
  If the new location does exist, will move and merge the files from old location.
+ If the new location does exist, but is not a directory, will remove it and do a movement of directory.
 
  @param srcPath old location of cache directory
  @param dstPath new location of cache directory

--- a/SDWebImage/SDDiskCache.m
+++ b/SDWebImage/SDDiskCache.m
@@ -246,6 +246,11 @@
             // New path is not directory, remove file
             [self.fileManager removeItemAtPath:dstPath error:nil];
         }
+        NSString *dstParentPath = [dstPath stringByDeletingLastPathComponent];
+        // Creates any non-existent parent directories as part of creating the directory in path
+        if (![self.fileManager fileExistsAtPath:dstParentPath]) {
+            [self.fileManager createDirectoryAtPath:dstParentPath withIntermediateDirectories:YES attributes:nil error:NULL];
+        }
         // New directory does not exist, rename directory
         [self.fileManager moveItemAtPath:srcPath toPath:dstPath error:nil];
     } else {
@@ -253,7 +258,6 @@
         NSDirectoryEnumerator *dirEnumerator = [self.fileManager enumeratorAtPath:srcPath];
         NSString *file;
         while ((file = [dirEnumerator nextObject])) {
-            // Don't handle error, just try to move.
             [self.fileManager moveItemAtPath:[srcPath stringByAppendingPathComponent:file] toPath:[dstPath stringByAppendingPathComponent:file] error:nil];
         }
         // Remove the old path


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Fixes #2417 
