### PR TITLE
Fix the bug that progress indicator on macOS stop at 1% but not 100% when download finished

### DIFF
--- a/SDWebImage/SDWebImageIndicator.m
+++ b/SDWebImage/SDWebImageIndicator.m
@@ -192,7 +192,7 @@
     }
 #else
     self.indicatorView.indeterminate = NO;
-    self.indicatorView.doubleValue = 1;
+    self.indicatorView.doubleValue = 100;
     [self.indicatorView stopAnimation:nil];
 #endif
 }

--- a/SDWebImage/UIView+WebCache.m
+++ b/SDWebImage/UIView+WebCache.m
@@ -83,9 +83,6 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
             NSProgress *imageProgress = sself.sd_imageProgress;
             imageProgress.totalUnitCount = expectedSize;
             imageProgress.completedUnitCount = receivedSize;
-            if (progressBlock) {
-                progressBlock(receivedSize, expectedSize, targetURL);
-            }
 #if SD_UIKIT || SD_MAC
             if ([imageIndicator respondsToSelector:@selector(updateIndicatorProgress:)]) {
                 double progress = imageProgress.fractionCompleted;
@@ -94,6 +91,9 @@ const int64_t SDWebImageProgressUnitCountUnknown = 1LL;
                 });
             }
 #endif
+            if (progressBlock) {
+                progressBlock(receivedSize, expectedSize, targetURL);
+            }
         };
         id <SDWebImageOperation> operation = [manager loadImageWithURL:url options:options context:context progress:combinedProgressBlock completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             __strong __typeof (wself) sself = wself;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: 

### Pull Request Description

A silly mistake. The `NSProgressIndicator` macOS, its `doubleValue` property, is hundred percented. Which means the `doubleValue == 100` represent 100%.

However, `UIProgressView` on UIKit, its `progress` property is the raw value. Which means `progress == 1` represent 100%.

So this just fix this. Also some little performance changes for progressBlock.

