### PR TITLE
Add `sd_setAnimationImagesWithURLs` API with progress && completedBlock, to allow easy of usage and testable

### DIFF
--- a/SDWebImage/SDWebImagePrefetcher.h
+++ b/SDWebImage/SDWebImagePrefetcher.h
@@ -49,8 +49,8 @@
 
 @end
 
-typedef void(^SDWebImagePrefetcherProgressBlock)(NSUInteger noOfFinishedUrls, NSUInteger noOfTotalUrls);
-typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger noOfFinishedUrls, NSUInteger noOfSkippedUrls);
+typedef void(^SDWebImagePrefetcherProgressBlock)(NSUInteger numberOfFinishedUrls, NSUInteger numberOfTotalUrls);
+typedef void(^SDWebImagePrefetcherCompletionBlock)(NSUInteger numberOfFinishedUrls, NSUInteger numberOfSkippedUrls);
 
 /**
  * Prefetch some URLs in the cache for future use. Images are downloaded in low priority.

--- a/SDWebImage/SDWebImagePrefetcher.m
+++ b/SDWebImage/SDWebImagePrefetcher.m
@@ -91,10 +91,7 @@
         __weak typeof(self) wself = self;
         id<SDWebImageOperation> operation = [self.manager loadImageWithURL:url options:self.options context:self.context progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
             __strong typeof(wself) sself = wself;
-            if (!sself) {
-                return;
-            }
-            if (!finished) {
+            if (!sself || !finished) {
                 return;
             }
             atomic_fetch_add_explicit(&(token->_finishedCount), 1, memory_order_relaxed);

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -193,12 +193,31 @@
 
 #pragma mark - Animation of multiple images
 
+typedef void(^SDImageBatchProgressBlock)(NSUInteger noOfFinishedUrls, NSUInteger noOfTotalUrls);
+typedef void(^SDImageBatchCompletionBlock)(NSUInteger noOfFinishedUrls, NSUInteger noOfSkippedUrls);
+
 /**
  * Download an array of images and starts them in an animation loop
  *
  * @param arrayOfURLs An array of NSURL
  */
 - (void)sd_setAnimationImagesWithURLs:(nonnull NSArray<NSURL *> *)arrayOfURLs;
+
+/**
+ * Download an array of images and starts them in an animation loop
+ *
+ * @param arrayOfURLs An array of NSURL
+ * @param progressBlock   block to be called when progress updates;
+ *                        first parameter is the number of completed (successful or not) requests,
+ *                        second parameter is the total number of images originally requested to be fetched
+ * @param completedBlock  block to be called when the current fetching is completed
+ *                        first param is the number of completed (successful or not) requests,
+ *                        second parameter is the number of skipped requests
+ */
+- (void)sd_setAnimationImagesWithURLs:(nonnull NSArray<NSURL *> *)arrayOfURLs
+                             progress:(nullable SDImageBatchProgressBlock)progressBlock
+                            completed:(nullable SDImageBatchCompletionBlock)completedBlock;
+
 
 /**
  * Cancel the current animation images load

--- a/SDWebImage/UIImageView+WebCache.h
+++ b/SDWebImage/UIImageView+WebCache.h
@@ -193,8 +193,8 @@
 
 #pragma mark - Animation of multiple images
 
-typedef void(^SDImageBatchProgressBlock)(NSUInteger noOfFinishedUrls, NSUInteger noOfTotalUrls);
-typedef void(^SDImageBatchCompletionBlock)(NSUInteger noOfFinishedUrls, NSUInteger noOfSkippedUrls);
+typedef void(^SDImageBatchProgressBlock)(NSUInteger numberOfFinishedUrls, NSUInteger numberOfTotalUrls);
+typedef void(^SDImageBatchCompletionBlock)(NSUInteger numberOfFinishedUrls, NSUInteger numberOfSkippedUrls);
 
 /**
  * Download an array of images and starts them in an animation loop

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -86,14 +86,11 @@
     
     __block NSUInteger finishedCount = 0;
     __block NSUInteger skippedCount = 0;
+    __weak __typeof(self) wself = self;
     [arrayOfURLs enumerateObjectsUsingBlock:^(NSURL *logoImageURL, NSUInteger idx, BOOL * _Nonnull stop) {
-        __weak __typeof(self) wself = self;
         id <SDWebImageOperation> operation = [[SDWebImageManager sharedManager] loadImageWithURL:logoImageURL options:0 progress:nil completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             __strong typeof(wself) sself = wself;
-            if (!sself) {
-                return;
-            }
-            if (!finished) {
+            if (!sself || !finished) {
                 return;
             }
             dispatch_main_async_safe(^{

--- a/SDWebImage/UIImageView+WebCache.m
+++ b/SDWebImage/UIImageView+WebCache.m
@@ -69,17 +69,37 @@
 #pragma mark - Animation of multiple images
 
 - (void)sd_setAnimationImagesWithURLs:(nonnull NSArray<NSURL *> *)arrayOfURLs {
+    return [self sd_setAnimationImagesWithURLs:arrayOfURLs progress:nil completed:nil];
+}
+
+- (void)sd_setAnimationImagesWithURLs:(nonnull NSArray<NSURL *> *)arrayOfURLs progress:(nullable SDImageBatchProgressBlock)progressBlock completed:(nullable SDImageBatchCompletionBlock)completedBlock {
     [self sd_cancelCurrentAnimationImagesLoad];
     NSPointerArray *operationsArray = [self sd_animationOperationArray];
     
+    NSUInteger totalCount = arrayOfURLs.count;
+    if (totalCount == 0) {
+        if (completedBlock) {
+            completedBlock(0, 0);
+        }
+        return;
+    }
+    
+    __block NSUInteger finishedCount = 0;
+    __block NSUInteger skippedCount = 0;
     [arrayOfURLs enumerateObjectsUsingBlock:^(NSURL *logoImageURL, NSUInteger idx, BOOL * _Nonnull stop) {
         __weak __typeof(self) wself = self;
         id <SDWebImageOperation> operation = [[SDWebImageManager sharedManager] loadImageWithURL:logoImageURL options:0 progress:nil completed:^(UIImage *image, NSData *data, NSError *error, SDImageCacheType cacheType, BOOL finished, NSURL *imageURL) {
             __strong typeof(wself) sself = wself;
-            if (!sself) return;
+            if (!sself) {
+                return;
+            }
+            if (!finished) {
+                return;
+            }
             dispatch_main_async_safe(^{
-                [sself stopAnimating];
-                if (sself && image) {
+                finishedCount++;
+                if (image) {
+                    [sself stopAnimating];
                     NSMutableArray<UIImage *> *currentImages = [[sself animationImages] mutableCopy];
                     if (!currentImages) {
                         currentImages = [[NSMutableArray alloc] init];
@@ -97,8 +117,21 @@
 
                     sself.animationImages = currentImages;
                     [sself setNeedsLayout];
+                    [sself startAnimating];
+                } else {
+                    skippedCount++;
                 }
-                [sself startAnimating];
+                // Current operation finished
+                if (progressBlock) {
+                    progressBlock(finishedCount, totalCount);
+                }
+                
+                // All finished
+                if (finishedCount == totalCount) {
+                    if (completedBlock) {
+                        completedBlock(finishedCount, skippedCount);
+                    }
+                }
             });
         }];
         @synchronized (self) {

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -64,13 +64,13 @@
     
     __block NSUInteger counter = 0;
     UIImageView *imageView = [[UIImageView alloc] init];
-    [imageView sd_setAnimationImagesWithURLs:[urls copy] progress:^(NSUInteger noOfFinishedUrls, NSUInteger noOfTotalUrls) {
+    [imageView sd_setAnimationImagesWithURLs:[urls copy] progress:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfTotalUrls) {
         counter++;
-        expect(counter).equal(noOfFinishedUrls);
-        expect(noOfTotalUrls).equal(urlCount);
-    } completed:^(NSUInteger noOfFinishedUrls, NSUInteger noOfSkippedUrls) {
-        expect(noOfSkippedUrls).equal(0);
-        expect(noOfFinishedUrls).equal(urlCount);
+        expect(counter).equal(numberOfFinishedUrls);
+        expect(numberOfTotalUrls).equal(urlCount);
+    } completed:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfSkippedUrls) {
+        expect(numberOfSkippedUrls).equal(0);
+        expect(numberOfFinishedUrls).equal(urlCount);
         [expectation fulfill];
     }];
     

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -50,6 +50,33 @@
                                    }];
     [self waitForExpectationsWithCommonTimeout];
 }
+
+- (void)testUIImageViewSetAnimationImagesWithURLs {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"MKAnnotationView setImageWithURL"];
+    
+    const NSUInteger urlCount = 30;
+    NSString *urlformat = @"https://raw.githubusercontent.com/mikeswanson/JBWatchActivityIndicator/master/Common%%20Images/Normal%%20Size%%20(1.0x)/30/Activity%d%%402x.png";
+    NSMutableArray<NSURL *> *urls = [NSMutableArray arrayWithCapacity:urlCount];
+    for (int i = 1; i <= urlCount; i++) {
+        NSString *url = [NSString stringWithFormat:urlformat, i];
+        [urls addObject:[NSURL URLWithString:url]];
+    }
+    
+    __block NSUInteger counter = 0;
+    UIImageView *imageView = [[UIImageView alloc] init];
+    [imageView sd_setAnimationImagesWithURLs:[urls copy] progress:^(NSUInteger noOfFinishedUrls, NSUInteger noOfTotalUrls) {
+        counter++;
+        expect(counter).equal(noOfFinishedUrls);
+        expect(noOfTotalUrls).equal(urlCount);
+    } completed:^(NSUInteger noOfFinishedUrls, NSUInteger noOfSkippedUrls) {
+        expect(noOfSkippedUrls).equal(0);
+        expect(noOfFinishedUrls).equal(urlCount);
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:kAsyncTestTimeout * 5 handler:nil];
+}
+
 #endif
 
 - (void)testMKAnnotationViewSetImageWithURL {

--- a/Tests/Tests/SDWebImagePrefetcherTests.m
+++ b/Tests/Tests/SDWebImagePrefetcherTests.m
@@ -35,15 +35,15 @@
     __block NSUInteger numberOfPrefetched = 0;
     
     [[SDImageCache sharedImageCache] clearDiskOnCompletion:^{
-        [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:imageURLs progress:^(NSUInteger noOfFinishedUrls, NSUInteger noOfTotalUrls) {
+        [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:imageURLs progress:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfTotalUrls) {
             numberOfPrefetched += 1;
-            expect(numberOfPrefetched).to.equal(noOfFinishedUrls);
-            expect(noOfFinishedUrls).to.beLessThanOrEqualTo(noOfTotalUrls);
-            expect(noOfTotalUrls).to.equal(imageURLs.count);
-        } completed:^(NSUInteger noOfFinishedUrls, NSUInteger noOfSkippedUrls) {
-            expect(numberOfPrefetched).to.equal(noOfFinishedUrls);
-            expect(noOfFinishedUrls).to.equal(imageURLs.count);
-            expect(noOfSkippedUrls).to.equal(0);
+            expect(numberOfPrefetched).to.equal(numberOfFinishedUrls);
+            expect(numberOfFinishedUrls).to.beLessThanOrEqualTo(numberOfTotalUrls);
+            expect(numberOfTotalUrls).to.equal(imageURLs.count);
+        } completed:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfSkippedUrls) {
+            expect(numberOfPrefetched).to.equal(numberOfFinishedUrls);
+            expect(numberOfFinishedUrls).to.equal(imageURLs.count);
+            expect(numberOfSkippedUrls).to.equal(0);
             [expectation fulfill];
         }];
     }];
@@ -54,9 +54,9 @@
 - (void)test03PrefetchWithEmptyArrayWillCallTheCompletionWithAllZeros {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Prefetch with empty array"];
     
-    [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:@[] progress:nil completed:^(NSUInteger noOfFinishedUrls, NSUInteger noOfSkippedUrls) {
-        expect(noOfFinishedUrls).to.equal(0);
-        expect(noOfSkippedUrls).to.equal(0);
+    [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:@[] progress:nil completed:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfSkippedUrls) {
+        expect(numberOfFinishedUrls).to.equal(0);
+        expect(numberOfSkippedUrls).to.equal(0);
         [expectation fulfill];
     }];
     
@@ -80,10 +80,10 @@
     // Clear the disk cache to make it more realistic for multi-thread environment
     [[SDImageCache sharedImageCache] clearDiskOnCompletion:^{
         dispatch_async(queue1, ^{
-            [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:imageURLs1 progress:^(NSUInteger noOfFinishedUrls, NSUInteger noOfTotalUrls) {
+            [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:imageURLs1 progress:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfTotalUrls) {
                 numberOfPrefetched1 += 1;
-            } completed:^(NSUInteger noOfFinishedUrls, NSUInteger noOfSkippedUrls) {
-                expect(numberOfPrefetched1).to.equal(noOfFinishedUrls);
+            } completed:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfSkippedUrls) {
+                expect(numberOfPrefetched1).to.equal(numberOfFinishedUrls);
                 prefetchFinished1 = YES;
                 // both completion called
                 if (prefetchFinished1 && prefetchFinished2) {
@@ -92,10 +92,10 @@
             }];
         });
         dispatch_async(queue2, ^{
-            [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:imageURLs2 progress:^(NSUInteger noOfFinishedUrls, NSUInteger noOfTotalUrls) {
+            [[SDWebImagePrefetcher sharedImagePrefetcher] prefetchURLs:imageURLs2 progress:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfTotalUrls) {
                 numberOfPrefetched2 += 1;
-            } completed:^(NSUInteger noOfFinishedUrls, NSUInteger noOfSkippedUrls) {
-                expect(numberOfPrefetched2).to.equal(noOfFinishedUrls);
+            } completed:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfSkippedUrls) {
+                expect(numberOfPrefetched2).to.equal(numberOfFinishedUrls);
                 prefetchFinished2 = YES;
                 // both completion called
                 if (prefetchFinished1 && prefetchFinished2) {
@@ -121,12 +121,12 @@
     self.prefetcher.delegate = self;
     // Current implementation, the delegate method called before the progressBlock and completionBlock
     [[SDImageCache sharedImageCache] clearDiskOnCompletion:^{
-        [self.prefetcher prefetchURLs:[imageURLs copy] progress:^(NSUInteger noOfFinishedUrls, NSUInteger noOfTotalUrls) {
-            expect(self.finishedCount).to.equal(noOfFinishedUrls);
-            expect(self.totalCount).to.equal(noOfTotalUrls);
-        } completed:^(NSUInteger noOfFinishedUrls, NSUInteger noOfSkippedUrls) {
-            expect(self.finishedCount).to.equal(noOfFinishedUrls);
-            expect(self.skippedCount).to.equal(noOfSkippedUrls);
+        [self.prefetcher prefetchURLs:[imageURLs copy] progress:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfTotalUrls) {
+            expect(self.finishedCount).to.equal(numberOfFinishedUrls);
+            expect(self.totalCount).to.equal(numberOfTotalUrls);
+        } completed:^(NSUInteger numberOfFinishedUrls, NSUInteger numberOfSkippedUrls) {
+            expect(self.finishedCount).to.equal(numberOfFinishedUrls);
+            expect(self.skippedCount).to.equal(numberOfSkippedUrls);
             [expectation fulfill];
         }];
     }];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #2007 

### Pull Request Description

During today's test case wrting, I found one strange method (Which I never use once...) in the View Category. It's the `[UIImageView sd_setAnimationImagesWithURLs:]`.

When I want to write something to test it, I find that it's hard because there are no any callbacks or notification, even the KVO seems not really convenient. Even if I use KVO on `animationImages` property, I still can not get when the download finished, because url array may fail, I pass 30 urls but does not means only when the `animationImages` contains 30 elements, the image loading finished. (If one failed, the final `animationImages` contains 29 elements)

I'm curious about the use case this method. Should we make it more useful or just leave it there ? Or even we can totally remove it in 5.x because of unspecified usage ? Because current API is...so wired. 😅 I read the comments and find it's looks same as the `SDWebImagePrefecher`, so I create a basic implementation to make it more useful with `progressBlock` and `completionBlock`. So that I can easily write test for this.

This PR don't need to merge now, until I can get the idea of this...