### PR TITLE
Feature set image block extra args

### DIFF
--- a/SDWebImage/MapKit/MKAnnotationView+WebCache.m
+++ b/SDWebImage/MapKit/MKAnnotationView+WebCache.m
@@ -59,7 +59,7 @@
                     placeholderImage:placeholder
                              options:options
                              context:context
-                       setImageBlock:^(UIImage *image, NSData *imageData) {
+                       setImageBlock:^(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
                            weakSelf.image = image;
                        }
                             progress:progressBlock

--- a/SDWebImage/NSButton+WebCache.m
+++ b/SDWebImage/NSButton+WebCache.m
@@ -126,7 +126,7 @@ static NSString * const SDAlternateImageOperationKey = @"NSButtonAlternateImageO
                     placeholderImage:placeholder
                              options:options
                              context:mutableContext
-                       setImageBlock:^(NSImage * _Nullable image, NSData * _Nullable imageData) {
+                       setImageBlock:^(NSImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
                            weakSelf.alternateImage = image;
                        }
                             progress:progressBlock

--- a/SDWebImage/UIButton+WebCache.m
+++ b/SDWebImage/UIButton+WebCache.m
@@ -109,7 +109,7 @@ static inline NSString * backgroundImageOperationKeyForState(UIControlState stat
                     placeholderImage:placeholder
                              options:options
                              context:mutableContext
-                       setImageBlock:^(UIImage *image, NSData *imageData) {
+                       setImageBlock:^(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
                            [weakSelf setImage:image forState:state];
                        }
                             progress:progressBlock
@@ -193,7 +193,7 @@ static inline NSString * backgroundImageOperationKeyForState(UIControlState stat
                     placeholderImage:placeholder
                              options:options
                              context:mutableContext
-                       setImageBlock:^(UIImage *image, NSData *imageData) {
+                       setImageBlock:^(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
                            [weakSelf setBackgroundImage:image forState:state];
                        }
                             progress:progressBlock

--- a/SDWebImage/UIImageView+HighlightedWebCache.m
+++ b/SDWebImage/UIImageView+HighlightedWebCache.m
@@ -58,7 +58,7 @@ static NSString * const SDHighlightedImageOperationKey = @"UIImageViewImageOpera
                     placeholderImage:nil
                              options:options
                              context:mutableContext
-                       setImageBlock:^(UIImage *image, NSData *imageData) {
+                       setImageBlock:^(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
                            weakSelf.highlightedImage = image;
                        }
                             progress:progressBlock

--- a/SDWebImage/UIView+WebCache.h
+++ b/SDWebImage/UIView+WebCache.h
@@ -17,7 +17,7 @@
  */
 FOUNDATION_EXPORT const int64_t SDWebImageProgressUnitCountUnknown; /* 1LL */
 
-typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable imageData);
+typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL);
 
 @interface UIView (WebCache)
 

--- a/Tests/Tests/SDWebCacheCategoriesTests.m
+++ b/Tests/Tests/SDWebCacheCategoriesTests.m
@@ -119,6 +119,40 @@
 }
 #endif
 
+- (void)testUIViewInternalSetImageWithURL {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"UIView internalSetImageWithURL"];
+    
+    UIView *view = [[UIView alloc] init];
+#if SD_MAC
+    view.wantsLayer = YES;
+#endif
+    NSURL *originalImageURL = [NSURL URLWithString:kTestJpegURL];
+    UIImage *placeholder = [[UIImage alloc] initWithContentsOfFile:[self testJPEGPath]];
+    [view sd_internalSetImageWithURL:originalImageURL
+                    placeholderImage:placeholder
+                             options:0
+                             context:nil
+                       setImageBlock:^(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {
+                           if (!imageData && cacheType == SDImageCacheTypeNone) {
+                               // placeholder
+                               expect(image).to.equal(placeholder);
+                           } else {
+                               // cache or download
+                               expect(image).toNot.beNil();
+                           }
+                           view.layer.contents = (__bridge id _Nullable)(image.CGImage);
+                       }
+                            progress:nil
+                           completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+                               expect(image).toNot.beNil();
+                               expect(error).to.beNil();
+                               expect(originalImageURL).to.equal(imageURL);
+                               expect((__bridge CGImageRef)view.layer.contents == image.CGImage).to.beTruthy();
+                               [expectation fulfill];
+                           }];
+    [self waitForExpectationsWithCommonTimeout];
+}
+
 - (void)testUIViewImageProgressKVOWork {
     XCTestExpectation *expectation = [self expectationWithDescription:@"UIView imageProgressKVO failed"];
     UIView *view = [[UIView alloc] init];
@@ -141,6 +175,12 @@
         }];
     }];
     [self waitForExpectationsWithCommonTimeout];
+}
+
+- (NSString *)testJPEGPath {
+    NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
+    NSString *testPath = [testBundle pathForResource:@"TestImage" ofType:@"jpg"];
+    return testPath;
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding // Added  one `testUIViewInternalSetImageWithURL`
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This PR, enhance our `SDSetImagBlock`, to provide more args for advacend usage.

### Reason

Currentlly, there are 4 blocks about image, in our View Category.
+ `SDExternalCompletionBlock`: image, error, cacheType, imageURL
+ `SDInternalCompletionBlock`: image, imageData, error, cacheType, finished, imageURL
+ `SDWebImageTransitionPreparesBlock`: view, image, imageData, cacheType, imageURL
+ `SDSetImageBlock`: image, imageData

It seems that some user need extra context to process their business set-image logic, after image was queried or downloaded. The last one `SDSetImageBlock`, however, does not contains the `cacheType, imageURL` context, make it not so customizable for advacend usage.

For exmaple, when introduce the `cacheType`, we can even figure out that the image was from memory cache, disk cache, or loader. So it's useful for the user who really want that usage.

### Design
Just update the `SDSetImageBlock` with more args. The all args are already here, we just pass it into the block.

```objective-c
typedef void(^SDSetImageBlock)(UIImage * _Nullable image, NSData * _Nullable imageData, SDImageCacheType cacheType, NSURL * _Nullable imageURL);
```

### API Change
This is break API for 4.x->5.x, it should be marked into the migration guide.