### PR TITLE
Fix the test case testFLAnimatedImageViewSetImageWithURL because of remote resource is not available

### DIFF
--- a/Tests/Tests/SDCategoriesTests.m
+++ b/Tests/Tests/SDCategoriesTests.m
@@ -126,7 +126,7 @@ static void * SDCategoriesTestsContext = &SDCategoriesTestsContext;
     XCTestExpectation *expectation = [self expectationWithDescription:@"FLAnimatedImageView setImageWithURL"];
     
     FLAnimatedImageView *imageView = [[FLAnimatedImageView alloc] init];
-    NSURL *originalImageURL = [NSURL URLWithString:@"https://www.interntheory.com/img/loading-small.gif"];
+    NSURL *originalImageURL = [NSURL URLWithString:kTestGIFURL];
     
     [imageView sd_setImageWithURL:originalImageURL
                         completed:^(UIImage * _Nullable image, NSError * _Nullable error, SDImageCacheType cacheType, NSURL * _Nullable imageURL) {

--- a/Tests/Tests/SDTestCase.h
+++ b/Tests/Tests/SDTestCase.h
@@ -17,6 +17,8 @@ FOUNDATION_EXPORT const int64_t kAsyncTestTimeout;
 FOUNDATION_EXPORT const int64_t kMinDelayNanosecond;
 FOUNDATION_EXPORT NSString * _Nonnull const kTestJpegURL;
 FOUNDATION_EXPORT NSString * _Nonnull const kTestPNGURL;
+FOUNDATION_EXPORT NSString * _Nonnull const kTestGIFURL;
+FOUNDATION_EXPORT NSString * _Nonnull const kTestWebPURL;
 
 @interface SDTestCase : XCTestCase
 

--- a/Tests/Tests/SDTestCase.m
+++ b/Tests/Tests/SDTestCase.m
@@ -13,6 +13,8 @@ const int64_t kAsyncTestTimeout = 5;
 const int64_t kMinDelayNanosecond = NSEC_PER_MSEC * 100; // 0.1s
 NSString *const kTestJpegURL = @"http://via.placeholder.com/50x50.jpg";
 NSString *const kTestPNGURL = @"http://via.placeholder.com/50x50.png";
+NSString *const kTestGIFURL = @"https://media.giphy.com/media/UEsrLdv7ugRTq/giphy.gif";
+NSString *const kTestWebPURL = @"http://littlesvr.ca/apng/images/SteamEngine.webp";
 
 @implementation SDTestCase
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

The original remote GIF image for `testFLAnimatedImageViewSetImageWithURL` is down. So now the all new Travis-CI test failed. We'd update a new resource to let it pass (it's from 5.x).
