### PR TITLE
Fix the bug that `SDWebImageContextCacheKeyFilter` wrongly be used as cache serializer and cause crash

### DIFF
--- a/SDWebImage/SDWebImageManager.m
+++ b/SDWebImage/SDWebImageManager.m
@@ -283,7 +283,7 @@ static id<SDImageLoader> _defaultImageLoader;
                 id<SDWebImageCacheKeyFilter> cacheKeyFilter = context[SDWebImageContextCacheKeyFilter];
                 NSString *key = [self cacheKeyForURL:url cacheKeyFilter:cacheKeyFilter];
                 id<SDImageTransformer> transformer = context[SDWebImageContextImageTransformer];
-                id<SDWebImageCacheSerializer> cacheSerializer = context[SDWebImageContextCacheKeyFilter];
+                id<SDWebImageCacheSerializer> cacheSerializer = context[SDWebImageContextCacheSerializer];
                 if (downloadedImage && (!downloadedImage.sd_isAnimated || (options & SDWebImageTransformAnimatedImage)) && transformer) {
                     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
                         UIImage *transformedImage = [transformer transformedImageWithImage:downloadedImage forKey:key];

--- a/Tests/Tests/SDWebImageManagerTests.m
+++ b/Tests/Tests/SDWebImageManagerTests.m
@@ -113,9 +113,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Image transformer work"];
     NSURL *imageURL = [NSURL URLWithString:kTestJPEGURL];
     SDWebImageTestTransformer *transformer = [[SDWebImageTestTransformer alloc] init];
-    NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
-    NSString *testImagePath = [testBundle pathForResource:@"TestImage" ofType:@"jpg"];
-    transformer.testImage = [[UIImage alloc] initWithContentsOfFile:testImagePath];
+    
+    transformer.testImage = [[UIImage alloc] initWithContentsOfFile:[self testJPEGPath]];
     SDWebImageManager *manager = [[SDWebImageManager alloc] initWithCache:[SDImageCache sharedImageCache] loader:[SDWebImageDownloader sharedDownloader]];
     manager.transformer = transformer;
     [[SDImageCache sharedImageCache] removeImageForKey:kTestJPEGURL withCompletion:^{
@@ -126,6 +125,41 @@
     }];
     
     [self waitForExpectationsWithCommonTimeout];
+}
+
+- (void)test09ThatCacheKeyFilterWork {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Cache key filter work"];
+    NSURL *imageURL = [NSURL URLWithString:kTestJPEGURL];
+    
+    NSString *cacheKey = @"kTestJPEGURL";
+    SDWebImageCacheKeyFilter *cacheKeyFilter = [SDWebImageCacheKeyFilter cacheKeyFilterWithBlock:^NSString * _Nullable(NSURL * _Nonnull url) {
+        if ([url isEqual:imageURL]) {
+            return cacheKey;
+        } else {
+            return url.absoluteString;
+        }
+    }];
+    
+    SDWebImageManager *manager = [[SDWebImageManager alloc] initWithCache:[SDImageCache sharedImageCache] loader:[SDWebImageDownloader sharedDownloader]];
+    manager.cacheKeyFilter = cacheKeyFilter;
+    // Check download and retrieve custom cache key
+    [manager loadImageWithURL:imageURL options:0 context:@{SDWebImageContextStoreCacheType : @(SDImageCacheTypeMemory)} progress:nil completed:^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, SDImageCacheType cacheType, BOOL finished, NSURL * _Nullable imageURL) {
+        expect(cacheType).equal(SDImageCacheTypeNone);
+        
+        // Check memory cache exist
+        [manager.imageCache containsImageForKey:cacheKey cacheType:SDImageCacheTypeMemory completion:^(SDImageCacheType containsCacheType) {
+            expect(containsCacheType).equal(SDImageCacheTypeMemory);
+            
+            [expectation fulfill];
+        }];
+    }];
+    
+    [self waitForExpectationsWithCommonTimeout];
+}
+
+- (NSString *)testJPEGPath {
+    NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
+    return [testBundle pathForResource:@"TestImage" ofType:@"jpg"];
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding // Added two to ensure the correct behavior 
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Another serious bug, that previouslly not be found. The cache key filter context arg are been parsed as cache serilizer (These two are totally different...)

It really important that we should always write test case to avoid this silly mistake, again :)

