### PR TITLE
Adopt all the protocol APIs which contains getter value to use property instead, to make the API easy to use or Swift user

### DIFF
--- a/SDWebImage/SDAnimatedImage.h
+++ b/SDWebImage/SDAnimatedImage.h
@@ -43,7 +43,7 @@
 /**
  Returns a Boolean value indicating whether all animated image frames are already pre-loaded into memory.
  */
-- (BOOL)isAllFramesLoaded;
+@property (nonatomic, assign, readonly, getter=isAllFramesLoaded) BOOL allFramesLoaded;
 
 @end
 

--- a/SDWebImage/SDDiskCache.h
+++ b/SDWebImage/SDDiskCache.h
@@ -85,7 +85,7 @@
  
  @return The total data count.
  */
-- (NSInteger)totalCount;
+- (NSUInteger)totalCount;
 
 /**
  Returns the total size (in bytes) of data in this cache.
@@ -93,7 +93,7 @@
  
  @return The total data size in bytes.
  */
-- (NSInteger)totalSize;
+- (NSUInteger)totalSize;
 
 @end
 

--- a/SDWebImage/SDDiskCache.m
+++ b/SDWebImage/SDDiskCache.m
@@ -203,7 +203,7 @@
     return [self cachePathForKey:key inPath:self.diskCachePath];
 }
 
-- (NSInteger)totalSize {
+- (NSUInteger)totalSize {
     NSUInteger size = 0;
     NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtPath:self.diskCachePath];
     for (NSString *fileName in fileEnumerator) {
@@ -214,7 +214,7 @@
     return size;
 }
 
-- (NSInteger)totalCount {
+- (NSUInteger)totalCount {
     NSUInteger count = 0;
     NSDirectoryEnumerator *fileEnumerator = [self.fileManager enumeratorAtPath:self.diskCachePath];
     count = fileEnumerator.allObjects.count;

--- a/SDWebImage/SDImageCoder.h
+++ b/SDWebImage/SDImageCoder.h
@@ -164,7 +164,7 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext;
  
  @return The animated image data
  */
-- (nullable NSData *)animatedImageData;
+@property (nonatomic, copy, readonly, nullable) NSData *animatedImageData;
 
 /**
  Total animated frame count.
@@ -172,13 +172,13 @@ FOUNDATION_EXPORT SDImageCoderOption _Nonnull const SDImageCoderWebImageContext;
  
  @return Total animated frame count.
  */
-- (NSUInteger)animatedImageFrameCount;
+@property (nonatomic, assign, readonly) NSUInteger animatedImageFrameCount;
 /**
  Animation loop count, 0 means infinite looping.
  
  @return Animation loop count
  */
-- (NSUInteger)animatedImageLoopCount;
+@property (nonatomic, assign, readonly) NSUInteger animatedImageLoopCount;
 /**
  Returns the frame image from a specified index.
  @note The index maybe randomly if one image was set to different imageViews, keep it re-entrant. (It's not recommend to store the images into array because it's memory consuming)

--- a/SDWebImage/SDImageTransformer.h
+++ b/SDWebImage/SDImageTransformer.h
@@ -32,7 +32,7 @@ FOUNDATION_EXPORT NSString * _Nullable SDTransformedKeyForKey(NSString * _Nullab
 
  @return The cache key to appended after the original cache key. Should not be nil.
  */
-- (nonnull NSString *)transformerKey;
+@property (nonatomic, copy, readonly, nonnull) NSString *transformerKey;
 
 /**
  Transform the image to another image.

--- a/SDWebImage/SDWebImageDownloaderOperation.h
+++ b/SDWebImage/SDWebImageDownloaderOperation.h
@@ -38,15 +38,13 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 
 - (BOOL)cancel:(nullable id)token;
 
-- (nullable NSURLRequest *)request;
-- (nullable NSURLResponse *)response;
+@property (strong, nonatomic, readonly, nullable) NSURLRequest *request;
+@property (strong, nonatomic, readonly, nullable) NSURLResponse *response;
 
 @optional
-- (nullable NSURLSessionTask *)dataTask;
-- (nullable NSURLCredential *)credential;
-- (void)setCredential:(nullable NSURLCredential *)credential;
-- (double)minimumProgressInterval;
-- (void)setMinimumProgressInterval:(double)minimumProgressInterval;
+@property (strong, nonatomic, readonly, nullable) NSURLSessionTask *dataTask;
+@property (strong, nonatomic, nullable) NSURLCredential *credential;
+@property (assign, nonatomic) double minimumProgressInterval;
 
 @end
 
@@ -61,7 +59,7 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
 /**
  * The response returned by the operation's task.
  */
-@property (strong, nonatomic, nullable, readonly) NSURLResponse *response;
+@property (strong, nonatomic, readonly, nullable) NSURLResponse *response;
 
 /**
  * The operation's task
@@ -73,7 +71,7 @@ FOUNDATION_EXPORT NSString * _Nonnull const SDWebImageDownloadFinishNotification
  *
  * This will be overridden by any shared credentials that exist for the username or password of the request URL, if present.
  */
-@property (nonatomic, strong, nullable) NSURLCredential *credential;
+@property (strong, nonatomic, nullable) NSURLCredential *credential;
 
 /**
  * The minimum interval about progress percent during network downloading. Which means the next progress callback and current progress callback's progress percent difference should be larger or equal to this value. However, the final finish download progress callback does not get effected.

--- a/SDWebImage/SDWebImageIndicator.h
+++ b/SDWebImage/SDWebImageIndicator.h
@@ -20,7 +20,7 @@
 
  @return The indicator view
  */
-- (nonnull UIView *)indicatorView;
+@property (nonatomic, strong, readonly, nonnull) UIView *indicatorView;
 /**
  Start the animating for indicator.
  */

--- a/Tests/Tests/SDWebImageTestCache.m
+++ b/Tests/Tests/SDWebImageTestCache.m
@@ -91,11 +91,11 @@
     [self.fileManager createFileAtPath:[self cachePathForKey:key] contents:data attributes:nil];
 }
 
-- (NSInteger)totalCount {
+- (NSUInteger)totalCount {
     return [self.fileManager contentsOfDirectoryAtPath:self.cachePath error:nil].count;
 }
 
-- (NSInteger)totalSize {
+- (NSUInteger)totalSize {
     NSUInteger size = 0;
     for (NSString *fileName in [self.fileManager enumeratorAtPath:self.cachePath]) {
         NSString *filePath = [self.cachePath stringByAppendingPathComponent:fileName];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This PR is a API refinement. We want to make our API more easier to use for both Objective-C side and Swift side. Current many of our protocol method, use the raw getter method, instead of declare a readonly property. The generated Swift API will also be declared as function.

However, according to the Apple's API adoption, for the single getter variable (Which the implementation mostlly use a actual store property instead), it's encouraged to use property instead, so that the user can use consistently wherever I treate the instance as a actual instance of some class, or instance of the protocol.

```swift
let coder: SDImageGIFCoder = SDImageGIFCoder()
let coder2: SDAnimatedImageCoder = SDImageGIFCoder()
let frameCount = coder.animatedImageFrameCount
let frameCount2 = coder2.animatedImageFrameCount() // Not consistent
```