### PR TITLE
Add no expiration file support of disk cache

### DIFF
--- a/SDWebImage/SDDiskCache.m
+++ b/SDWebImage/SDDiskCache.m
@@ -135,7 +135,7 @@
                                                                   options:NSDirectoryEnumerationSkipsHiddenFiles
                                                              errorHandler:NULL];
     
-    NSDate *expirationDate = [NSDate dateWithTimeIntervalSinceNow:-self.config.maxCacheAge];
+    NSDate *expirationDate = (self.config.maxCacheAge < 0) ? nil: [NSDate dateWithTimeIntervalSinceNow:-self.config.maxCacheAge];
     NSMutableDictionary<NSURL *, NSDictionary<NSString *, id> *> *cacheFiles = [NSMutableDictionary dictionary];
     NSUInteger currentCacheSize = 0;
     
@@ -155,7 +155,7 @@
         
         // Remove files that are older than the expiration date;
         NSDate *modifiedDate = resourceValues[cacheContentDateKey];
-        if ([[modifiedDate laterDate:expirationDate] isEqualToDate:expirationDate]) {
+        if (expirationDate && [[modifiedDate laterDate:expirationDate] isEqualToDate:expirationDate]) {
             [urlsToDelete addObject:fileURL];
             continue;
         }

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -44,14 +44,14 @@ typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {
 
 /*
  * The option to control weak memory cache for images. When enable, `SDImageCache`'s memory cache will use a weak maptable to store the image at the same time when it stored to memory, and get removed at the same time.
- * However when memory warning is triggered, since the weak maptable does not hold a strong reference to image instacnce, even when the memory cache itself is purged, some images which are held strongly by UIImageViews or other live instances can be recovered again, to avoid later re-query from disk cache or network. This may be helpful for the case, for example, when app enter background and memory is purged, cause cell flashing after re-enter foreground.
+ * However when memory warning is triggered, since the weak maptable does not hold a strong reference to image instance, even when the memory cache itself is purged, some images which are held strongly by UIImageViews or other live instances can be recovered again, to avoid later re-query from disk cache or network. This may be helpful for the case, for example, when app enter background and memory is purged, cause cell flashing after re-enter foreground.
  * Defautls to YES. You can change this option dynamically.
  */
 @property (assign, nonatomic) BOOL shouldUseWeakMemoryCache;
 
 /**
  * Whether or not to remove the expired disk data when application entering the background. (Not works for macOS)
- * Defatuls to YES.
+ * Defaults to YES.
  */
 @property (assign, nonatomic) BOOL shouldRemoveExpiredDataWhenEnterBackground;
 
@@ -70,6 +70,7 @@ typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {
 /**
  * The maximum length of time to keep an image in the disk cache, in seconds.
  * Setting this to a negative value means no expiring.
+ * Setting this to zero means that all cached files would be removed when do expiration check.
  * Defaults to 1 weak.
  */
 @property (assign, nonatomic) NSTimeInterval maxCacheAge;

--- a/SDWebImage/SDImageCacheConfig.h
+++ b/SDWebImage/SDImageCacheConfig.h
@@ -68,13 +68,14 @@ typedef NS_ENUM(NSUInteger, SDImageCacheConfigExpireType) {
 @property (assign, nonatomic) NSDataWritingOptions diskCacheWritingOptions;
 
 /**
- * The maximum length of time to keep an image in the cache, in seconds.
+ * The maximum length of time to keep an image in the disk cache, in seconds.
+ * Setting this to a negative value means no expiring.
  * Defaults to 1 weak.
  */
 @property (assign, nonatomic) NSTimeInterval maxCacheAge;
 
 /**
- * The maximum size of the cache, in bytes.
+ * The maximum size of the disk cache, in bytes.
  * Defaults to 0. Which means there is no cache size limit.
  */
 @property (assign, nonatomic) NSUInteger maxCacheSize;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Add no expiration file support of disk cache, if user set a negative value of `maxCacheAge`, we would not do expiration check and remove any expiration file.
