### PR TITLE
Fix resource key invalid when clean cached disk file

### DIFF
--- a/SDWebImage/SDDiskCache.m
+++ b/SDWebImage/SDDiskCache.m
@@ -177,10 +177,10 @@
         // Target half of our maximum cache size for this cleanup pass.
         const NSUInteger desiredCacheSize = maxCacheSize / 2;
         
-        // Sort the remaining cache files by their last modification time (oldest first).
+        // Sort the remaining cache files by their last modification time or last access time (oldest first).
         NSArray<NSURL *> *sortedFiles = [cacheFiles keysSortedByValueWithOptions:NSSortConcurrent
                                                                  usingComparator:^NSComparisonResult(id obj1, id obj2) {
-                                                                     return [obj1[NSURLContentModificationDateKey] compare:obj2[NSURLContentModificationDateKey]];
+                                                                     return [obj1[cacheContentDateKey] compare:obj2[cacheContentDateKey]];
                                                                  }];
         
         // Delete files until we fall below our desired cache size.


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Keep resource key the same as `cacheContentDateKey`, because if `cacheContentDateKey` is `NSURLContentAccessDateKey`, we can not get `NSURLContentModificationDateKey` value when we do secondly clean step.

```
NSArray<NSString *> *resourceKeys = @[NSURLIsDirectoryKey, cacheContentDateKey, NSURLTotalFileAllocatedSizeKey];
```
