### PR TITLE
Add protect when custom animated image class image data is nil during progressive animation check

### DIFF
--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -626,6 +626,10 @@ static NSUInteger SDDeviceFreeMemory() {
             NSData *previousData = [((UIImage<SDAnimatedImage> *)previousImage) animatedImageData];
             NSData *currentData = [((UIImage<SDAnimatedImage> *)image) animatedImageData];
             // Check whether to use progressive rendering or not
+            if (!previousData || !currentData) {
+                // Early return
+                return;
+            }
             
             // Warning: normally the `previousData` is same instance as `currentData` because our `SDAnimatedImage` class share the same `coder` instance internally. But there may be a race condition, that later retrived `currentData` is already been updated and it's not the same instance as `previousData`.
             // And for protocol extensible design, we should not assume `SDAnimatedImage` protocol implementations always share same instance. So both of two reasons, we need that `rangeOfData` check.


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

A code robustness protect. 

Normally this can not happen for built-in `SDAnimatedImageView` progressive loading, because when the image data is nil, we don't return a valid image instance. However, it may be triggered if you use some other implementations (I write a local test and found this issue).

Just add protect for this to avoid `-[NSData rangeOfData:options:range:]` throw the exception when data is nil.

