### PR TITLE
Decrease animated decode times when cache enable

### DIFF
--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -689,8 +689,10 @@ static NSUInteger SDDeviceFreeMemory() {
     
     // Update the current frame
     UIImage *currentFrame;
+    UIImage *fetchFrame;
     LOCKBLOCK({
         currentFrame = self.frameBuffer[@(currentFrameIndex)];
+        fetchFrame = currentFrame ? self.frameBuffer[@(nextFrameIndex)] : nil;
     });
     BOOL bufferFull = NO;
     if (currentFrame) {
@@ -743,11 +745,6 @@ static NSUInteger SDDeviceFreeMemory() {
         // Or, most cases, the decode speed is faster than render speed, we fetch next frame
         fetchFrameIndex = nextFrameIndex;
     }
-    
-    UIImage *fetchFrame;
-    LOCKBLOCK({
-        fetchFrame = self.frameBuffer[@(fetchFrameIndex)];
-    });
     
     if (!fetchFrame && !bufferFull && self.fetchQueue.operationCount == 0) {
         // Prefetch next frame in background queue

--- a/SDWebImage/SDAnimatedImageView.m
+++ b/SDWebImage/SDAnimatedImageView.m
@@ -637,9 +637,9 @@ static NSUInteger SDDeviceFreeMemory() {
                 // If current data is the same data (or instance) as previous data
                 self.isProgressive = YES;
             } else if (currentData.length > previousData.length) {
-                // If current data is appended by previous data, use `NSDataSearchAnchored`
+                // If current data is appended by previous data, use `NSDataSearchAnchored`, search is limited to start of currentData
                 NSRange range = [currentData rangeOfData:previousData options:NSDataSearchAnchored range:NSMakeRange(0, previousData.length)];
-                if (range.location == 0) {
+                if (range.location != NSNotFound) {
                     // Contains hole previous data and they start with the same beginning
                     self.isProgressive = YES;
                 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Currently, we decode animated image JIT by default, we have `frameBuffer` to save `frame`, but actually, for the most time, we would decode image from `imageSource` every time we need to render each index, so let's prevent this re-decoded things when we already have cached frame.

I simply test [dogflops](http://assets.sbnation.com/assets/2512203/dogflops.gif) git from demo, it has 78 frames, after using cache, it would reduce 43 decode times when display.

