### PR TITLE
Remove kCGImageSourceShouldCache option when creating image source

### DIFF
--- a/SDWebImage/SDImageAPNGCoder.m
+++ b/SDWebImage/SDImageAPNGCoder.m
@@ -326,8 +326,7 @@ const CFStringRef kCGImagePropertyAPNGUnclampedDelayTime = (__bridge CFStringRef
     }
     self = [super init];
     if (self) {
-        // use Image/IO cache because it's already keep a balance between CPU & memory
-        CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)data, (__bridge CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceShouldCache : @(YES)});
+        CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
         if (!imageSource) {
             return nil;
         }

--- a/SDWebImage/SDImageGIFCoder.m
+++ b/SDWebImage/SDImageGIFCoder.m
@@ -327,8 +327,7 @@
     }
     self = [super init];
     if (self) {
-        // use Image/IO cache because it's already keep a balance between CPU & memory
-        CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)data, (__bridge CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceShouldCache : @(YES)});
+        CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
         if (!imageSource) {
             return nil;
         }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/rs/SDWebImage/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/SDWebImage/)
* [x] I have searched for a similar pull request in the [project](https://github.com/rs/SDWebImage/pulls) and found none

* [ ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

`kCGImageSourceShouldCache` is only valid when creating an image from image source, image source would not treat this option. Only `kCGImageSourceTypeIdentifierHint` can pass to options when creating image source. Please see [Documents](https://developer.apple.com/documentation/imageio/kcgimagesourceshouldcache)